### PR TITLE
New features: DLNA video cast & External video player support

### DIFF
--- a/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
@@ -1,5 +1,38 @@
 package com.example.kazumi
 
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.annotation.NonNull
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity()
+class MainActivity: FlutterActivity() {
+    private val CHANNEL = "com.predidit.kazumi/intent"
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "openWithMime") {
+                val url = call.argument<String>("url")
+                val mimeType = call.argument<String>("mimeType")
+                if (url != null && mimeType != null) {
+                    openWithMime(url, mimeType)
+                    result.success(null)
+                } else {
+                    result.error("INVALID_ARGUMENT", "URL and MIME type required", null)
+                }
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+
+    private fun openWithMime(url: String, mimeType: String) {
+        val intent = Intent()
+        intent.action = Intent.ACTION_VIEW
+        intent.setDataAndType(Uri.parse(url), mimeType)
+        startActivity(intent)
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,11 +3,40 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        // let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+        // let channel = FlutterMethodChannel(name: "com.predidit.kazumi/intent",
+        //                                    binaryMessenger: controller.binaryMessenger)
+        // channel.setMethodCallHandler({
+        //     (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+        //     if call.method == "openVideoWithMime" {
+        //         guard let args = call.arguments else { return }
+        //         if let myArgs = args as? [String: Any],
+        //            let url = myArgs["url"] as? String,
+        //            let mimeType = myArgs["mimeType"] as? String {
+        //             self.openVideoWithMime(url: url, mimeType: mimeType)
+        //         }
+        //         result(nil)
+        //     } else {
+        //         result(FlutterMethodNotImplemented)
+        //     }
+        // })
+        GeneratedPluginRegistrant.register(with: self)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    // private func openVideoWithMime(url: String, mimeType: String) {
+    //     if let videoUrl = URL(string: url) {
+    //         let player = AVPlayer(url: videoUrl)
+    //         let playerViewController = AVPlayerViewController()
+    //         playerViewController.player = player
+    //
+    //         UIApplication.shared.keyWindow?.rootViewController?.present(playerViewController, animated: true, completion: {
+    //             playerViewController.player!.play()
+    //         })
+    //     }
+    // }
 }

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -1,4 +1,3 @@
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:video_player/video_player.dart';
 import 'package:kazumi/modules/danmaku/danmaku_module.dart';
 import 'package:flutter/material.dart' show debugPrint;
@@ -61,7 +60,6 @@ abstract class _PlayerController with Store {
   late bool hAenable;
 
   Future init({int offset = 0}) async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
     playing = false;
     loading = true;
     isBuffering = true;
@@ -86,7 +84,6 @@ abstract class _PlayerController with Store {
       await mediaPlayer.play();
     }
     debugPrint('VideoURL初始化完成');
-    prefs.setString('video', videoUrl);
     // 加载弹幕
     getDanDanmaku(
         videoPageController.title, videoPageController.currentEspisode);

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -1,3 +1,4 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:video_player/video_player.dart';
 import 'package:kazumi/modules/danmaku/danmaku_module.dart';
 import 'package:flutter/material.dart' show debugPrint;
@@ -60,6 +61,7 @@ abstract class _PlayerController with Store {
   late bool hAenable;
 
   Future init({int offset = 0}) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     playing = false;
     loading = true;
     isBuffering = true;
@@ -84,6 +86,7 @@ abstract class _PlayerController with Store {
       await mediaPlayer.play();
     }
     debugPrint('VideoURL初始化完成');
+    prefs.setString('video', videoUrl);
     // 加载弹幕
     getDanDanmaku(
         videoPageController.title, videoPageController.currentEspisode);

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:kazumi/utils/remote.dart';
 import 'package:kazumi/utils/utils.dart';
 import 'package:kazumi/utils/webdav.dart';
 import 'package:provider/provider.dart';
@@ -781,8 +782,7 @@ class _PlayerItemState extends State<PlayerItem>
                                                 ),
                                                 child: const Row(
                                                   children: <Widget>[
-                                                    Icon(
-                                                        Icons.fast_forward,
+                                                    Icon(Icons.fast_forward,
                                                         color: Colors.white),
                                                     Text(
                                                       ' 倍速播放',
@@ -916,6 +916,13 @@ class _PlayerItemState extends State<PlayerItem>
                                             const Expanded(
                                               child: dtb.DragToMoveArea(
                                                   child: SizedBox(height: 40)),
+                                            ),
+                                            IconButton(
+                                              color: Colors.white,
+                                              icon: const Icon(Icons.cast),
+                                              onPressed: () {
+                                                RemotePlay().castVideo(context);
+                                              },
                                             ),
                                             TextButton(
                                               style: ButtonStyle(

--- a/lib/pages/webview_desktop/webview_desktop_controller.dart
+++ b/lib/pages/webview_desktop/webview_desktop_controller.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:kazumi/utils/utils.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 import 'package:kazumi/pages/player/player_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_windows/webview_windows.dart';
 
 class WebviewDesktopItemController {
@@ -70,6 +70,7 @@ class WebviewDesktopItemController {
   }
 
   initJSBridge() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     webviewController.webMessage.listen((event) async {
       if (event.toString().contains('iframeMessage:')) {
         String messageItem =
@@ -114,6 +115,7 @@ class WebviewDesktopItemController {
         count++;
         if (messageItem.contains('http') && !isVideoSourceLoaded) {
           debugPrint('Loading video source ${Uri.decodeFull(messageItem)}');
+          prefs.setString('video', Uri.decodeFull(messageItem));
           videoPageController.logLines
               .add('Loading video source ${Uri.decodeFull(messageItem)}');
           isIframeLoaded = true;

--- a/lib/pages/webview_desktop/webview_desktop_controller.dart
+++ b/lib/pages/webview_desktop/webview_desktop_controller.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 import 'package:kazumi/pages/player/player_controller.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_windows/webview_windows.dart';
 
 class WebviewDesktopItemController {
@@ -70,7 +69,6 @@ class WebviewDesktopItemController {
   }
 
   initJSBridge() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
     webviewController.webMessage.listen((event) async {
       if (event.toString().contains('iframeMessage:')) {
         String messageItem =
@@ -115,7 +113,6 @@ class WebviewDesktopItemController {
         count++;
         if (messageItem.contains('http') && !isVideoSourceLoaded) {
           debugPrint('Loading video source ${Uri.decodeFull(messageItem)}');
-          prefs.setString('video', Uri.decodeFull(messageItem));
           videoPageController.logLines
               .add('Loading video source ${Uri.decodeFull(messageItem)}');
           isIframeLoaded = true;

--- a/lib/utils/remote.dart
+++ b/lib/utils/remote.dart
@@ -4,9 +4,11 @@ import 'dart:io';
 import 'package:dlna_dart/dlna.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+
+import '../pages/player/player_controller.dart';
 
 class RemotePlay {
 
@@ -22,8 +24,7 @@ class RemotePlay {
   castVideo(BuildContext context) async {
     final searcher = DLNAManager();
     final dlna = await searcher.start();
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    final String? video = prefs.getString('video');
+    final String video = Modular.get<PlayerController>().videoUrl;
     List<Widget> dlnaDevice = [];
     SmartDialog.show(builder: (context) {
       return StatefulBuilder(builder: (context, setState) {
@@ -39,7 +40,7 @@ class RemotePlay {
               onPressed: () async {
                 searcher.stop();
                 if (Platform.isAndroid) {
-                  if (await _launchURLWithMIME(video!, 'video/mp4')) {
+                  if (await _launchURLWithMIME(video, 'video/mp4')) {
                     SmartDialog.dismiss();
                     SmartDialog.showToast(
                         '尝试唤起外部播放器',displayType: SmartToastType.onlyRefresh);
@@ -52,7 +53,7 @@ class RemotePlay {
                 }
                 else if (Platform.isWindows) {
                   SmartDialog.dismiss();
-                  if (await canLaunchUrlString(video!) == true) {
+                  if (await canLaunchUrlString(video) == true) {
                     launchUrlString(video);
                     SmartDialog.showToast(
                         '尝试唤起外部播放器',displayType: SmartToastType.onlyRefresh);
@@ -106,7 +107,7 @@ class RemotePlay {
                                   SmartDialog.showToast(
                                       '尝试投屏至 ${value.info.friendlyName}',
                                       displayType: SmartToastType.onlyRefresh);
-                                  DLNADevice(value.info).setUrl(video!);
+                                  DLNADevice(value.info).setUrl(video);
                                   DLNADevice(value.info).play();
                                 }
                                 catch (e) {

--- a/lib/utils/remote.dart
+++ b/lib/utils/remote.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dlna_dart/dlna.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+class RemotePlay {
+
+  // 注意：仍需开发非 Android 设备的远程播放功能。
+  // 外部播放使用 MethodChannel 方法实现，而这只在 Android 设备中有效。
+  // 对于 Windows 设备，使用了 url_launcher 以支持浏览器的播放。
+  // 在 Windows 设备上，使用 scheme 的方案没有效果。VLC / PotPlayer 等主流播放器更倾向于使用 CLI 命令。
+  // 而对于 iOS / Mac 设备，由于没有设备，无法进行开发与验证。
+  // 可行的 iOS / Mac 处理代码，请参见 ios/Runner/AppDelegate.swift 的注释部分。
+
+  static const platform = MethodChannel('com.predidit.kazumi/intent');
+
+  castVideo(BuildContext context) async {
+    final searcher = DLNAManager();
+    final dlna = await searcher.start();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? video = prefs.getString('video');
+    List<Widget> dlnaDevice = [];
+    SmartDialog.show(builder: (context) {
+      return StatefulBuilder(builder: (context, setState) {
+        return AlertDialog(
+          title: const Text('远程播放'),
+          content: SingleChildScrollView(
+            child: Column(
+              children: dlnaDevice,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                searcher.stop();
+                if (Platform.isAndroid) {
+                  if (await _launchURLWithMIME(video!, 'video/mp4')) {
+                    SmartDialog.dismiss();
+                    SmartDialog.showToast(
+                        '尝试唤起外部播放器',displayType: SmartToastType.onlyRefresh);
+                  }
+                  else
+                  {
+                    SmartDialog.showToast(
+                        '无法使用外部播放器',displayType: SmartToastType.onlyRefresh);
+                  }
+                }
+                else if (Platform.isWindows) {
+                  SmartDialog.dismiss();
+                  if (await canLaunchUrlString(video!) == true) {
+                    launchUrlString(video);
+                    SmartDialog.showToast(
+                        '尝试唤起外部播放器',displayType: SmartToastType.onlyRefresh);
+                  }
+                  else {
+                    SmartDialog.showToast(
+                        '无法使用外部播放器',displayType: SmartToastType.onlyRefresh);
+                  }
+                }
+                else {
+                  SmartDialog.showToast(
+                      '暂不支持该设备',
+                      displayType: SmartToastType.onlyRefresh
+                  );
+                }
+              },
+              child: const Text('外部播放'),
+            ),
+            const SizedBox(width: 20),
+            TextButton(
+              onPressed: () {
+                searcher.stop();
+                SmartDialog.dismiss();
+              },
+              child: Text(
+                '退出',
+                style: TextStyle(color: Theme.of(context).colorScheme.outline),
+              ),
+            ),
+            TextButton(
+                onPressed: () {
+                    setState(() {});
+                    SmartDialog.showToast(
+                      '开始搜索',
+                      displayType: SmartToastType.onlyRefresh
+                    );
+                    dlna.devices.stream.listen((deviceList) {
+                      dlnaDevice = [];
+                      deviceList.forEach((key, value) async {
+                        debugPrint('Key: $key');
+                        debugPrint(
+                            'Value: ${value.info.friendlyName} ${value.info.deviceType} ${value.info.URLBase}');
+                        setState(() {
+                          dlnaDevice.add(ListTile(
+                              leading: _deviceUPnPIcon(
+                                  value.info.deviceType.split(':')[3]),
+                              title: Text(value.info.friendlyName),
+                              subtitle: Text(value.info.deviceType.split(':')[3]),
+                              onTap: () {
+                                try {
+                                  SmartDialog.showToast(
+                                      '尝试投屏至 ${value.info.friendlyName}',
+                                      displayType: SmartToastType.onlyRefresh);
+                                  DLNADevice(value.info).setUrl(video!);
+                                  DLNADevice(value.info).play();
+                                }
+                                catch (e) {
+                                  debugPrint('DLNA Error: $e');
+                                  SmartDialog.showNotify(msg: 'DLNA 异常: $e \n尝试重新进入 DLNA 投屏或切换设备', notifyType: NotifyType.alert);
+                                }
+                              }));
+                        });
+                      });
+                    });
+                    Timer(const Duration(seconds: 30), () {
+                      SmartDialog.showToast(
+                        '已搜索30s，若未发现设备请尝试重新进入 DLNA 投屏',
+                        displayType: SmartToastType.onlyRefresh,
+                      );
+                    });
+                },
+                child: Text(
+                  '搜索',
+                  style:
+                      TextStyle(color: Theme.of(context).colorScheme.outline),
+                )),
+          ],
+        );
+      });
+    });
+  }
+
+  Icon _deviceUPnPIcon(String deviceType) {
+    switch (deviceType) {
+      case 'MediaRenderer':
+        return const Icon(Icons.cast_connected);
+      case 'MediaServer':
+        return const Icon(Icons.cast_connected);
+      case 'InternetGatewayDevice':
+        return const Icon(Icons.router);
+      case 'BasicDevice':
+        return const Icon(Icons.device_hub);
+      case 'DimmableLight':
+        return const Icon(Icons.lightbulb);
+      case 'WLANAccessPoint':
+        return const Icon(Icons.lan);
+      case 'WLANConnectionDevice':
+        return const Icon(Icons.wifi_tethering);
+      case 'Printer':
+        return const Icon(Icons.print);
+      case 'Scanner':
+        return const Icon(Icons.scanner);
+      case 'DigitalSecurityCamera':
+        return const Icon(Icons.camera_enhance_outlined);
+      default:
+        return const Icon(Icons.question_mark);
+    }
+  }
+
+  Future<bool> _launchURLWithMIME(String url, String mimeType) async {
+    try {
+      await platform.invokeMethod('openWithMime', <String, String>{
+        'url': url,
+        'mimeType': mimeType
+      });
+      return true;
+    } on PlatformException catch (e) {
+      debugPrint("Failed to open with mime: '${e.message}'.");
+      return false;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
+  dlna_dart:
+    dependency: "direct main"
+    description:
+      name: dlna_dart
+      sha256: ae07c1c53077bbf58756fa589f936968719b0085441981d33e74f82f89d1d281
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.8"
   expressions:
     dependency: transitive
     description:
@@ -950,7 +958,7 @@ packages:
     source: hosted
     version: "0.1.9"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,7 +958,7 @@ packages:
     source: hosted
     version: "0.1.9"
   shared_preferences:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: shared_preferences
       sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,7 +76,6 @@ dependencies:
   webdav_client: ^1.2.2
   tray_manager: ^0.2.3
   dlna_dart: ^0.0.8
-  shared_preferences: ^2.2.3
   webview_windows:
     git:
       url: https://github.com/Predidit/flutter-webview-windows.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,8 @@ dependencies:
   animated_search_bar: ^2.7.1
   webdav_client: ^1.2.2
   tray_manager: ^0.2.3
+  dlna_dart: ^0.0.8
+  shared_preferences: ^2.2.3
   webview_windows:
     git:
       url: https://github.com/Predidit/flutter-webview-windows.git


### PR DESCRIPTION
相关issue #74 #23 

#74 说明

- 投屏通过 UPnP(DLNA) 技术实现，在不支持此技术的设备上，投屏功能不会生效
- 建议说明 UPnP(DLNA) 投屏要求为在同一网络下
- 建议说明 Windows 10 及更早的版本中，Windows Media Player 对 m3u8 的播放支持不完整，这不是投屏功能的 Bug
- 尚不明确是否需要制作额外的 DLNA 投屏控制页面。经测试，投屏到 Android 电视上的内容可以通过遥控器直接操作，故暂不实现

#23 说明

- 在 Android / iOS 设备上，外部播放的实现方式为打开指定 MIME 类型为 `video/mp4` 的链接
- iOS 设备需要进行测试（手头没设备），我已将 iOS 相关代码注释，**详见 PR 文件中 `ios/Runner/AppDelegate.swift` 和 `lib/utils/remote.dart` 中的注释部分**
- Windows 平台目前仅支持浏览器打开，**原因详见 PR 文件中 `lib/utils/remote.dart` 中的注释部分**。需要更好的实现办法