### PR TITLE
update function Utils.getScreenInfo()

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -10,9 +10,29 @@ import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:kazumi/request/api.dart';
+import 'package:screen_pixel/screen_pixel.dart';
 
 class Utils {
   static final Random random = Random();
+
+  static Future<Map<String, double>?> getScreenInfo(BuildContext context) async {
+    final screenPixelPlugin = ScreenPixel();
+    Map<String, double>? screenResolution;
+    final screenRatio = MediaQuery.of(context).devicePixelRatio;
+    Map<String, double>? screenInfo = {};
+
+    try {
+      screenResolution = await screenPixelPlugin.getResolution();
+      screenInfo = {
+        'width': screenResolution['width']!,
+        'height': screenResolution['height']!,
+        'ratio': screenRatio
+      };
+    } on PlatformException {
+      screenInfo = null;
+    }
+    return screenInfo;
+  }
 
   static Future<String> getCookiePath() async {
     final Directory tempDir = await getApplicationSupportDirectory();

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import fvp
 import package_info_plus
 import path_provider_foundation
 import screen_brightness_macos
+import screen_pixel
 import screen_retriever
 import shared_preferences_foundation
 import sqflite
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
+  ScreenPixelPlugin.register(with: registry.registrar(forPlugin: "ScreenPixelPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -949,6 +949,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.3"
+  screen_pixel:
+    dependency: "direct main"
+    description:
+      name: screen_pixel
+      sha256: b7310d81d98289ba1d6fb381ec95094b30b43ee1e901fefb65a3cf4de7d77e6b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   screen_retriever:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dependencies:
   webdav_client: ^1.2.2
   tray_manager: ^0.2.3
   dlna_dart: ^0.0.8
+  screen_pixel: ^0.0.3
   webview_windows:
     git:
       url: https://github.com/Predidit/flutter-webview-windows.git

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_volume_controller/flutter_volume_controller_plugin_c_api.h>
 #include <fvp/fvp_plugin_c_api.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
+#include <screen_pixel/screen_pixel_plugin_c_api.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -25,6 +26,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FvpPluginCApi"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
+  ScreenPixelPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenPixelPluginCApi"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   TrayManagerPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_volume_controller
   fvp
   screen_brightness_windows
+  screen_pixel
   screen_retriever
   tray_manager
   url_launcher_windows


### PR DESCRIPTION
相关 issue #32 

当 `Utils.getScreenInfo()` 获取到系统屏幕信息时，返回一个类型为 `Future<Map<String, double>>` 的值；
该值包含屏幕宽度 `width` 、屏幕高度 `height` 和缩放比例 `ratio` 。

当获取失败时，返回 `null` 。

剩下的就是适配了（没做）