### PR TITLE
correct owner and group can be useful for rootless builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,7 +164,7 @@
               cp ../assets/images/logo/logo_linux.png usr/share/icons/hicolor/512x512/apps/io.github.predidit.kazumi.png
 
               cd ..
-              dpkg-deb --build Kazumi_linux_canary_amd64
+              dpkg-deb --build --root-owner-group Kazumi_linux_canary_amd64
             shell: bash
 
           - name: Upload linux outputs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,7 +159,7 @@
               cp ../assets/images/logo/logo_linux.png usr/share/icons/hicolor/512x512/apps/io.github.predidit.kazumi.png
 
               cd ..
-              dpkg-deb --build Kazumi_linux_${{ env.tag }}_amd64
+              dpkg-deb --build --root-owner-group Kazumi_linux_${{ env.tag }}_amd64
             shell: bash
 
           - name: Upload linux outputs


### PR DESCRIPTION
如果有另外的发行版需要用容器化重打包这对他们很有用