### PR TITLE
增加自动暂停和播放源检测；修复macOS和iOS的bug

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -794,9 +794,7 @@ class _PlayerItemState extends State<PlayerItem>
                               Utils.exitFullScreen();
                               videoPageController.androidFullscreen =
                                   !videoPageController.androidFullscreen;
-                            } else if (Platform.isMacOS) {
-                              windowManager.unmaximize();
-                            } else {
+                            } else if (!Platform.isMacOS) {
                               windowManager.hide();
                             }
                           }

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -794,6 +794,8 @@ class _PlayerItemState extends State<PlayerItem>
                               Utils.exitFullScreen();
                               videoPageController.androidFullscreen =
                                   !videoPageController.androidFullscreen;
+                            } else if (Platform.isMacOS) {
+                              windowManager.unmaximize();
                             } else {
                               windowManager.hide();
                             }
@@ -1199,7 +1201,14 @@ class _PlayerItemState extends State<PlayerItem>
                                       color: Colors.white,
                                       icon: const Icon(Icons.cast),
                                       onPressed: () {
-                                        RemotePlay().castVideo(context);
+                                        if (videoPageController.currentPlugin.referer == '') {
+                                          playerController.pause();
+                                          RemotePlay().castVideo(context);
+                                        } else {
+                                          SmartDialog.showToast('暂不支持该播放源',
+                                              displayType:
+                                                  SmartToastType.onlyRefresh);
+                                        }
                                       },
                                     ),
                                     // 追番

--- a/lib/utils/remote.dart
+++ b/lib/utils/remote.dart
@@ -27,6 +27,7 @@ class RemotePlay {
     List<Widget> dlnaDevice = [];
     SmartDialog.show(
         useAnimation: false,
+        clickMaskDismiss: false,
         builder: (context) {
           return StatefulBuilder(builder: (context, setState) {
             return AlertDialog(


### PR DESCRIPTION
1. 增加外部播放时自动暂停和播放源检测
2. 修复#303 
3. 修复macOS和iOS在触发外部播放对话框后，点击框外关闭会导致无法再次拉起对话框，现在无法通过点击框外关闭