### PR TITLE
feat: 重构按键输入处理，并支持部分快捷键

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,11 @@ void main() async {
       await windowManager.show();
       await windowManager.focus();
     });
-    await hotKeyManager.register(KazumiHotKey.appMinimize,keyDownHandler: (hotKey) => windowManager.minimize());
+    await hotKeyManager.register(KazumiHotKey.appMinimize,
+        keyDownHandler: (hotKey) =>
+            Future.delayed(const Duration(milliseconds: 100), () {
+              windowManager.hide();
+            })); // prevent inapp hotkeys issue
   }
   if (Platform.isAndroid || Platform.isIOS) {
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:kazumi/app_module.dart';
 import 'package:kazumi/app_widget.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:kazumi/utils/hotkey.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -16,6 +18,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   if (Utils.isDesktop()) {
     await windowManager.ensureInitialized();
+    await hotKeyManager.unregisterAll();
     bool isLowResolution = await Utils.isLowResolution();
     WindowOptions windowOptions = WindowOptions(
       size: isLowResolution ? const Size(800, 600) : const Size(1280, 860),
@@ -29,6 +32,7 @@ void main() async {
       await windowManager.show();
       await windowManager.focus();
     });
+    await hotKeyManager.register(KazumiHotKey.appMinimize,keyDownHandler: (hotKey) => windowManager.minimize());
   }
   if (Platform.isAndroid || Platform.isIOS) {
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);

--- a/lib/utils/hotkey.dart
+++ b/lib/utils/hotkey.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/services.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
+
+class KazumiHotKey {
+  static final HotKey videoVolumeUp =
+      HotKey(key: PhysicalKeyboardKey.arrowUp, scope: HotKeyScope.inapp);
+
+  static final HotKey videoVolumeDown =
+      HotKey(key: PhysicalKeyboardKey.arrowDown, scope: HotKeyScope.inapp);
+
+  static final HotKey videoDecrease =
+      HotKey(key: PhysicalKeyboardKey.arrowLeft, scope: HotKeyScope.inapp);
+
+  static final HotKey videoIncrease =
+      HotKey(key: PhysicalKeyboardKey.arrowRight, scope: HotKeyScope.inapp);
+
+  static final HotKey videoPause =
+      HotKey(key: PhysicalKeyboardKey.space, scope: HotKeyScope.inapp);
+
+  static final HotKey videoEscape =
+      HotKey(key: PhysicalKeyboardKey.escape, scope: HotKeyScope.inapp);
+
+  static final HotKey videoFullscreen =
+      HotKey(key: PhysicalKeyboardKey.keyF, scope: HotKeyScope.inapp);
+
+  static final HotKey videoDanmaku =
+      HotKey(key: PhysicalKeyboardKey.keyD, scope: HotKeyScope.inapp);
+
+  static final HotKey appMinimize = HotKey(
+      key: PhysicalKeyboardKey.keyH,
+      modifiers: [HotKeyModifier.shift],
+      scope: HotKeyScope.inapp);
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <flutter_volume_controller/flutter_volume_controller_plugin.h>
 #include <fvp/fvp_plugin.h>
+#include <hotkey_manager_linux/hotkey_manager_linux_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
@@ -24,6 +25,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) fvp_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FvpPlugin");
   fvp_plugin_register_with_registrar(fvp_registrar);
+  g_autoptr(FlPluginRegistrar) hotkey_manager_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "HotkeyManagerLinuxPlugin");
+  hotkey_manager_linux_plugin_register_with_registrar(hotkey_manager_linux_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
   flutter_volume_controller
   fvp
+  hotkey_manager_linux
   screen_retriever
   tray_manager
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import connectivity_plus
 import device_info_plus
 import flutter_volume_controller
 import fvp
+import hotkey_manager_macos
 import package_info_plus
 import path_provider_foundation
 import screen_brightness_macos
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterVolumeControllerPlugin.register(with: registry.registrar(forPlugin: "FlutterVolumeControllerPlugin"))
   FvpPlugin.register(with: registry.registrar(forPlugin: "FvpPlugin"))
+  HotkeyManagerMacosPlugin.register(with: registry.registrar(forPlugin: "HotkeyManagerMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -539,6 +539,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  hotkey_manager:
+    dependency: "direct main"
+    description:
+      name: hotkey_manager
+      sha256: "06f0655b76c8dd322fb7101dc615afbdbf39c3d3414df9e059c33892104479cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
+  hotkey_manager_linux:
+    dependency: transitive
+    description:
+      name: hotkey_manager_linux
+      sha256: "83676bda8210a3377bc6f1977f193bc1dbdd4c46f1bdd02875f44b6eff9a8473"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_macos:
+    dependency: transitive
+    description:
+      name: hotkey_manager_macos
+      sha256: "03b5967e64357b9ac05188ea4a5df6fe4ed4205762cb80aaccf8916ee1713c96"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_platform_interface:
+    dependency: transitive
+    description:
+      name: hotkey_manager_platform_interface
+      sha256: "98ffca25b8cc9081552902747b2942e3bc37855389a4218c9d50ca316b653b13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_windows:
+    dependency: transitive
+    description:
+      name: hotkey_manager_windows
+      sha256: "0d03ced9fe563ed0b68f0a0e1b22c9ffe26eb8053cb960e401f68a4f070e0117"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   html:
     dependency: transitive
     description:
@@ -1216,6 +1256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uni_platform:
+    dependency: transitive
+    description:
+      name: uni_platform
+      sha256: e02213a7ee5352212412ca026afd41d269eb00d982faa552f419ffc2debfad84
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   universal_io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   dlna_dart: ^0.0.8
   screen_pixel: ^0.0.3
   logger: ^2.4.0
+  hotkey_manager: ^0.2.3
   webview_windows:
     git:
       url: https://github.com/Predidit/flutter-webview-windows.git

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_volume_controller/flutter_volume_controller_plugin_c_api.h>
 #include <fvp/fvp_plugin_c_api.h>
+#include <hotkey_manager_windows/hotkey_manager_windows_plugin_c_api.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
 #include <screen_pixel/screen_pixel_plugin_c_api.h>
 #include <screen_retriever/screen_retriever_plugin.h>
@@ -24,6 +25,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterVolumeControllerPluginCApi"));
   FvpPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FvpPluginCApi"));
+  HotkeyManagerWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("HotkeyManagerWindowsPluginCApi"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
   ScreenPixelPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   flutter_volume_controller
   fvp
+  hotkey_manager_windows
   screen_brightness_windows
   screen_pixel
   screen_retriever


### PR DESCRIPTION
重构应用对各种按键输入的处理，并统一由快捷键处理器管理

受影响的键位：

- 全局
  - Shift+H 最小化应用（老板键）
- 视频播放页
  - ↑ ↓ 音量控制
  - ← → 进度控制
  - Space 暂停或继续播放
  - Esc 退出全屏
  - D 弹幕控制
  - F 全屏控制

各个作用域的快捷键将在加载时进行注册

_对 #299 Q2及未来其他快捷键实现的初步准备_

Closes #264 