### PR TITLE
fix:  #297 清除缓存功能失效

### DIFF
--- a/lib/pages/about/about_page.dart
+++ b/lib/pages/about/about_page.dart
@@ -45,9 +45,13 @@ class _AboutPageState extends State<AboutPage> {
     navigationBarState.showNavigate();
   }
 
-  Future<void> _getCacheSize() async {
+  Future<Directory> _getCacheDir() async {
     Directory tempDir = await getTemporaryDirectory();
-    Directory cacheDir = Directory('${tempDir.path}/libCachedImageData');
+    return Directory('${tempDir.path}/libCachedImageData');
+  }
+
+  Future<void> _getCacheSize() async {
+    Directory cacheDir = await _getCacheDir();
 
     if (await cacheDir.exists()) {
       int totalSizeBytes = await _getTotalSizeOfFilesInDir(cacheDir);
@@ -85,8 +89,8 @@ class _AboutPageState extends State<AboutPage> {
   }
 
   Future<void> _clearCache() async {
-    final cacheManager = DefaultCacheManager();
-    await cacheManager.emptyCache();
+    final Directory libCacheDir = await _getCacheDir();
+    await libCacheDir.delete(recursive: true);
     _getCacheSize();
   }
 


### PR DESCRIPTION
fix #297

通过删除缓存目录的方式实现清除缓存的方式

CachedNetworkImage version 2.3 版本之后原本的 `emptyCache` 失效

只能通过 CachedNetworkImage 自带的 `.evictFromCache(url)` 去实现，不过当前项目要是需要记录所有的 url 改动有点大，折中方案的话，可以直接删除整个缓存目录