### PR TITLE
fix: A RenderFlex overflowed by 10.0 pixels on the right

### DIFF
--- a/lib/bean/appbar/sys_app_bar.dart
+++ b/lib/bean/appbar/sys_app_bar.dart
@@ -20,6 +20,8 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   final Widget? leading;
 
+  final double? leadingWidth;
+
   final PreferredSizeWidget? bottom;
 
   const SysAppBar(
@@ -31,6 +33,7 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
       this.shape,
       this.actions,
       this.leading,
+      this.leadingWidth,
       this.bottom});
 
   void _handleCloseEvent() {
@@ -76,6 +79,7 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
           title: title,
           actions: acs,
           leading: leading,
+          leadingWidth: leadingWidth,
           backgroundColor: backgroundColor,
           elevation: elevation,
           shape: shape,

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -117,6 +117,7 @@ class _PopularPageState extends State<PopularPage>
           },
           child: Scaffold(
               appBar: SysAppBar(
+                leadingWidth: 66, // default 56 + 10
                 leading: (Utils.isCompact())
                     ? Row(
                         children: [


### PR DESCRIPTION
fix #325 
<p float='left'>
<img src="https://github.com/user-attachments/assets/081476d6-dda9-4afd-9905-ab37b6de80f2" width="128">
<img src="https://github.com/user-attachments/assets/777d1bb9-0792-4dc9-9519-f4d3b0ca952b" width="128">
</p>

找个一个解决办法了，现在由于 ` const SizedBox(width: 10,)` 导致 **A RenderFlex overflowed by 10.0 pixels on the right**，新增一个 leadingWidth 的属性，然后让默认的 leadingWidth 宽度增加 10 就好了，默认是 56，所以这里的宽度设置为 66 ，就可以解决问题了