### PR TITLE
Add macOS external player selector

### DIFF
--- a/lib/bean/card/bangumi_card.dart
+++ b/lib/bean/card/bangumi_card.dart
@@ -97,7 +97,7 @@ class BangumiContent extends StatelessWidget {
     return Expanded(
       child: Padding(
         // 多列
-        padding: const EdgeInsets.fromLTRB(4, 5, 0, 3),
+        padding: const EdgeInsets.fromLTRB(5, 3, 5, 0),
         // 单列
         // padding: const EdgeInsets.fromLTRB(14, 10, 4, 8),
         child: Column(
@@ -113,7 +113,7 @@ class BangumiContent extends StatelessWidget {
                     fontWeight: FontWeight.w500,
                     letterSpacing: 0.3,
                   ),
-                  maxLines: 1,
+                  maxLines: Utils.isDesktop() || Utils.isTablet() ? 3 : 2,
                   overflow: TextOverflow.ellipsis,
                 )),
               ],

--- a/lib/pages/plugin_editor/plugin_view_page.dart
+++ b/lib/pages/plugin_editor/plugin_view_page.dart
@@ -159,7 +159,7 @@ class _PluginViewPageState extends State<PluginViewPage> {
                   itemCount: pluginsController.pluginList.length,
                   itemBuilder: (context, index) {
                     return Card(
-                      margin: const EdgeInsets.all(8.0),
+                      margin: const EdgeInsets.fromLTRB(8, 8, 8, 0),
                       child: ListTile(
                         title: Text(
                           pluginsController.pluginList[index].name,

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -267,9 +267,9 @@ class _PopularPageState extends State<PopularPage>
                         ),
                         SliverPadding(
                             padding: const EdgeInsets.fromLTRB(
-                                StyleString.safeSpace,
+                                StyleString.cardSpace,
                                 0,
-                                StyleString.safeSpace,
+                                StyleString.cardSpace,
                                 0),
                             sliver: Observer(builder: (context) {
                               if (popularController.bangumiList.isEmpty &&

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -210,7 +210,7 @@ class _TimelinePageState extends State<TimelinePage>
               ),
             ),
             body: Padding(
-                padding: const EdgeInsets.only(left: 5, right: 5, top: 10),
+                padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
                 child: renderBody(orientation)),
           ),
         );

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -11,6 +11,7 @@ class AppDelegate: FlutterAppDelegate {
     
     var playerView: AVPlayerView!
     var player: AVPlayer?
+    var videoUrl: URL?
     
     override func applicationDidFinishLaunching(_ notification: Notification) {
         let controller : FlutterViewController = mainFlutterWindow?.contentViewController as! FlutterViewController
@@ -32,6 +33,46 @@ class AppDelegate: FlutterAppDelegate {
     }
     
     private func openVideoWithMime(url: String, mimeType: String) {
+        videoUrl = URL(string: url)
+        
+        let selectMenu = NSMenu()
+        
+        /* AVPlayer menu item sample start */
+        let menuItem = NSMenuItem()
+        menuItem.attributedTitle = NSAttributedString(string: "AVPlayer", attributes: [.font: NSFont.systemFont(ofSize: 14)])
+        menuItem.action = #selector(openWithAVPlayer)
+        menuItem.toolTip = "macOS自带播放器，部分视频源有兼容问题"
+        
+        let icon = NSWorkspace.shared.icon(forFile: "/System/Applications/Preview.app")
+        icon.size = NSSize(width: 16, height: 16)
+        menuItem.image = icon
+        
+        selectMenu.addItem(menuItem)
+        /* AVPlayer menu item sample end */
+        
+        /* IINA menu item start */
+        if let iinaPath = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.colliderli.iina") {
+            let menuItem = NSMenuItem()
+            menuItem.attributedTitle = NSAttributedString(string: "IINA.app", attributes: [.font: NSFont.systemFont(ofSize: 14)])
+            menuItem.action = #selector(openWithSelectedApp(_:))
+            menuItem.representedObject = "/Applications/IINA.app/Contents/MacOS/IINA"
+            
+            let icon = NSWorkspace.shared.icon(forFile: "/Applications/IINA.app")
+            icon.size = NSSize(width: 16, height: 16)
+            menuItem.image = icon
+
+            selectMenu.addItem(menuItem)
+        }
+        /* IINA menu item end */
+        
+        /* Add more app to menu item here start */
+
+        /* Add more app to menu item here end */
+        
+        selectMenu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
+    }
+    
+    @objc func openWithAVPlayer () {
         let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 1280, height: 860),
                               styleMask: [.titled, .closable, .resizable],
                               backing: .buffered, defer: false)
@@ -43,10 +84,23 @@ class AppDelegate: FlutterAppDelegate {
         window.contentView?.addSubview(playerView)
         window.delegate = self
         
-        let videoUrl = URL(string: url)
         player = AVPlayer(url: videoUrl!)
         playerView.player = player
         playerView.player?.play()
+    }
+    
+    @objc func openWithSelectedApp (_ sender: NSMenuItem) {
+        if let selectedApp = sender.representedObject {
+            let process = Process()
+            process.launchPath = selectedApp as? String
+            process.arguments = [videoUrl!.absoluteString]
+
+            do {
+                try process.run()
+            } catch {
+                print("Failed to open app: \(error)")
+            }
+        }
     }
 }
 

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: FlutterAppDelegate {
         /* AVPlayer menu item sample end */
         
         /* IINA menu item start */
-        if let iinaPath = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.colliderli.iina") {
+        if (NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.colliderli.iina") != nil) {
             let menuItem = NSMenuItem()
             menuItem.attributedTitle = NSAttributedString(string: "IINA.app", attributes: [.font: NSFont.systemFont(ofSize: 14)])
             menuItem.action = #selector(openWithSelectedApp(_:))


### PR DESCRIPTION
1. 给macOS增加了外部播放的软件选择。

<img width="290" alt="image" src="https://github.com/user-attachments/assets/89b7e1e1-09b3-40c6-83b2-1b02d086a749">

至于iOS平台，我认为手机端的外部播放主要作用在于DLNA，因此不考虑为此花时间增加功能。

2. 依然是一些间距的修改，现在bangumi card可以显示2/3行标题了

<img width="163" alt="image" src="https://github.com/user-attachments/assets/0c680084-be29-4e9c-b1e4-1c3370e467e6">
<img width="155" alt="image" src="https://github.com/user-attachments/assets/a4185dbd-518a-452e-a463-5210c822d493">
