### PR TITLE
press logo jump to history page

### DIFF
--- a/lib/bean/appbar/sys_app_bar.dart
+++ b/lib/bean/appbar/sys_app_bar.dart
@@ -79,7 +79,7 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
           toolbarHeight: preferredSize.height,
           scrolledUnderElevation: 0.0,
           title: title,
-          centerTitle: true,
+          centerTitle: Platform.isIOS ? true : false,
           actions: acs,
           leading: leading,
           leadingWidth: leadingWidth,

--- a/lib/bean/appbar/sys_app_bar.dart
+++ b/lib/bean/appbar/sys_app_bar.dart
@@ -79,6 +79,7 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
           toolbarHeight: preferredSize.height,
           scrolledUnderElevation: 0.0,
           title: title,
+          centerTitle: true,
           actions: acs,
           leading: leading,
           leadingWidth: leadingWidth,

--- a/lib/pages/menu/side_menu.dart
+++ b/lib/pages/menu/side_menu.dart
@@ -55,11 +55,16 @@ class _SideMenu extends State<SideMenu> {
                         child: Padding(
                           padding: const EdgeInsets.only(top: 8),
                           child: ClipOval(
-                            child: Image.asset(
+                            child: InkWell(
+                              customBorder: const CircleBorder(),
+                              onTap: () {
+                                Modular.to.pushNamed('/tab/my/history');
+                              },
+                              child: Image.asset(
                               'assets/images/logo/logo_android.png',
                             ),
                           ),
-                        )),
+                        ))),
                     destinations: const <NavigationRailDestination>[
                       NavigationRailDestination(
                         selectedIcon: Icon(Icons.home),

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -125,10 +125,16 @@ class _PopularPageState extends State<PopularPage>
                             width: 10,
                           ),
                           ClipOval(
-                            child: Image.asset(
-                              'assets/images/logo/logo_android.png',
+                            child: InkWell(
+                              customBorder: const CircleBorder(),
+                              onTap: () {
+                                Modular.to.pushNamed('/tab/my/history');
+                              },
+                              child: Image.asset(
+                                'assets/images/logo/logo_android.png',
+                              ),
                             ),
-                          ),
+                          )
                         ],
                       )
                     : null,


### PR DESCRIPTION
1. #362 , #341 

2. `centerTitle: true` 是因为 macOS 不这样设置有的页面标题在左边有的页面标题在中间，Windows 就只会出现在左边。macOS 总有些奇奇怪怪的 bug