### PR TITLE
fix(ios): volume controll

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -638,8 +638,11 @@ class _PlayerItemState extends State<PlayerItem>
 
   Future<void> setVolume(double value) async {
     try {
-      FlutterVolumeController.updateShowSystemUI(false);
+      await FlutterVolumeController.updateShowSystemUI(false);
       await FlutterVolumeController.setVolume(value);
+      if (Platform.isIOS && !volumeSeeking) {
+        await FlutterVolumeController.updateShowSystemUI(true);
+      }
     } catch (_) {}
   }
 


### PR DESCRIPTION
#390 

`iOS: needs to update MPVolumeView visibility, otherwise pressing physical buttons won't display volume slider after [showSystemUI] is reset to true.`