### PR TITLE
make macOS builder happy

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -9,6 +9,10 @@ class AppDelegate: FlutterAppDelegate {
         return true
     }
     
+    override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+        return true
+    }
+    
     var playerView: AVPlayerView!
     var player: AVPlayer?
     var videoUrl: URL?


### PR DESCRIPTION
根据 macOS 编译器提示做的修改
```
macos/Runner/AppDelegate.swift has been modified and cannot be automatically migrated.
We recommend developers override applicationSupportsSecureRestorableState in AppDelegate.swift as follows:
override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
  return true
}
```