### PR TITLE
increase maximum font size for non-compact devices

### DIFF
--- a/lib/pages/settings/danmaku/danmaku_settings_window.dart
+++ b/lib/pages/settings/danmaku/danmaku_settings_window.dart
@@ -2,6 +2,7 @@ import 'package:canvas_danmaku/canvas_danmaku.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:kazumi/utils/storage.dart';
+import 'package:kazumi/utils/utils.dart';
 
 class DanmakuSettingsWindow extends StatefulWidget {
   final DanmakuController danmakuController;
@@ -27,7 +28,7 @@ class _DanmakuSettingsWindowState extends State<DanmakuSettingsWindow> {
               Slider(
                 value: widget.danmakuController.option.fontSize,
                 min: 10,
-                max: 32,
+                max: Utils.isCompact() ? 32 : 48,
                 divisions: 22,
                 label: widget.danmakuController.option.fontSize.toString(),
                 onChanged: (value) {

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kazumi/request/api.dart';
+import 'package:kazumi/utils/utils.dart';
 
 class StyleString {
   static const double cardSpace = 8;
@@ -85,6 +86,24 @@ final List<double> danFontList = [
   30.0,
   31.0,
   32.0,
+  if (!Utils.isCompact()) ...[
+    33.0,
+    34.0,
+    35.0,
+    36.0,
+    37.0,
+    38.0,
+    39.0,
+    40.0,
+    41.0,
+    42.0,
+    43.0,
+    44.0,
+    45.0,
+    46.0,
+    47.0,
+    48.0,
+  ]
 ];
 
 // 可选弹幕字体字重


### PR DESCRIPTION
电脑上弹幕上限太小了， 既然默认大小是1.5倍，那么最大值也给个1.5倍吧，这里把电脑版最大值从32改成了48，
其实最好是能不使用“字号”而是“百分比”来设置弹幕大小，想B站一样， 甚至能实现切全屏时弹幕跟着放大，这样更舒服，但是实现有点麻烦，需要设计算法还不好兼容旧版就没做，只改个最大值凑合一下，