### PR TITLE
fix refresh bug

### DIFF
--- a/lib/pages/popular/popular_controller.dart
+++ b/lib/pages/popular/popular_controller.dart
@@ -58,6 +58,10 @@ abstract class _PopularController with Store {
     return false;
   }
 
+  Future<bool> queryBangumiListFeedByRefresh() async{
+    return await queryBangumiListFeedByTag(currentTag);
+  }
+
   Future<void> queryBangumi(String keyword) async {
     isLoadingMore = true;
     var result = await BangumiHTTP.bangumiSearch(keyword);

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -91,7 +91,7 @@ class _PopularPageState extends State<PopularPage>
         },
         child: RefreshIndicator(
           onRefresh: () async {
-            await popularController.queryBangumiListFeed();
+            await popularController.queryBangumiListFeedByRefresh();
           },
           child: Scaffold(
               appBar: SysAppBar(
@@ -182,7 +182,7 @@ class _PopularPageState extends State<PopularPage>
                               await popularController.queryBangumi(popularController.searchKeyword);
                             } else {
                               popularController.searchKeyword = '';
-                              await popularController.queryBangumiListFeedByTag("");
+                              await popularController.queryBangumiListFeedByTag('');
                             }
                           },
                         ),


### PR DESCRIPTION
问题在于方法使用错误，新刷新到的番剧显示在了当前番剧下面而不是覆盖当前番剧。

由于`RefreshIndicator`获取不到`filter`所以又新增了个`queryBangumiListFeedByRefresh`方法。

有个问题，
```
  Future<bool> queryBangumiListFeedByRefresh() async{
    return await queryBangumiListFeedByTag(currentTag);
  }
```
与
```
  Future<bool> queryBangumiListFeedByRefresh(){
    return queryBangumiListFeedByTag(currentTag);
  }
```
在这种情况下似乎作用是相同的，在目前没有try catch的需求下，是使用上面方法，与别的`queryBangumi`方法达成格式一致好；还是使用下面的，力求代码简洁呢。