### PR TITLE
theme improvments

### DIFF
--- a/lib/bean/card/network_img_layer.dart
+++ b/lib/bean/card/network_img_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:kazumi/utils/constants.dart';
@@ -17,6 +19,8 @@ class NetworkImgLayer extends StatelessWidget {
     // 图片质量 默认1%
     this.quality,
     this.origAspectRatio,
+    this.sigmaX = 0,
+    this.sigmaY = 0,
   });
 
   final String? src;
@@ -27,6 +31,8 @@ class NetworkImgLayer extends StatelessWidget {
   final Duration? fadeInDuration;
   final int? quality;
   final double? origAspectRatio;
+  final double sigmaX;
+  final double sigmaY;
 
   @override
   Widget build(BuildContext context) {
@@ -60,34 +66,43 @@ class NetworkImgLayer extends StatelessWidget {
     }
 
     return src != '' && src != null
-        ? ClipRRect(
-            clipBehavior: Clip.antiAlias,
-            borderRadius: BorderRadius.circular(
-              type == 'avatar'
-                  ? 50
-                  : type == 'emote'
-                      ? 0
-                      : StyleString.imgRadius.x,
-            ),
-            child: CachedNetworkImage(
-              imageUrl: imageUrl,
-              width: width,
-              height: height,
-              memCacheWidth: memCacheWidth,
-              memCacheHeight: memCacheHeight,
-              fit: BoxFit.cover,
-              fadeOutDuration:
-                  fadeOutDuration ?? const Duration(milliseconds: 120),
-              fadeInDuration:
-                  fadeInDuration ?? const Duration(milliseconds: 120),
-              filterQuality: FilterQuality.high,
-              errorListener: (e) {
-                KazumiLogger().log(Level.warning, "网络图片加载错误 ${e.toString()}");
-              },
-              errorWidget: (BuildContext context, String url, Object error) =>
-                  placeholder(context),
-              placeholder: (BuildContext context, String url) =>
-                  placeholder(context),
+        ? CachedNetworkImage(
+            imageUrl: imageUrl,
+            width: width,
+            height: height,
+            memCacheWidth: memCacheWidth,
+            memCacheHeight: memCacheHeight,
+            fadeOutDuration:
+                fadeOutDuration ?? const Duration(milliseconds: 120),
+            fadeInDuration: fadeInDuration ?? const Duration(milliseconds: 120),
+            errorListener: (e) {
+              KazumiLogger().log(Level.warning, "网络图片加载错误 ${e.toString()}");
+            },
+            errorWidget: (BuildContext context, String url, Object error) =>
+                placeholder(context),
+            placeholder: (BuildContext context, String url) =>
+                placeholder(context),
+            imageBuilder: (context, imageProvider) => Container(
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  filterQuality: FilterQuality.high,
+                  image: imageProvider,
+                  fit: BoxFit.cover,
+                ),
+                borderRadius: BorderRadius.circular(
+                  type == 'avatar'
+                      ? 50
+                      : type == 'emote'
+                          ? 0
+                          : StyleString.imgRadius.x,
+                ),
+              ),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY),
+                child: Container(
+                  color: Colors.transparent,
+                ),
+              ),
             ),
           )
         : placeholder(context);

--- a/lib/bean/settings/color_type.dart
+++ b/lib/bean/settings/color_type.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 final List<Map<String, dynamic>> colorThemeTypes = [
   {'color': Colors.green, 'label': '默认'},
-  {'color': const Color(0xff6750a4), 'label': 'MD3 默认'},
   {'color': Colors.lightGreen, 'label': '浅绿色'},
   {'color': Colors.teal, 'label': '青色'},
   {'color': Colors.cyan, 'label': '蓝绿色'},
@@ -10,6 +9,7 @@ final List<Map<String, dynamic>> colorThemeTypes = [
   {'color': Colors.blue, 'label': '蓝色'},
   {'color': Colors.indigo, 'label': '靛蓝色'},
   {'color': Colors.purple, 'label': '紫色'},
+  {'color': const Color(0xff6750a4), 'label': '紫罗兰色'},
   {'color': Colors.deepPurple, 'label': '深紫色'},
   {'color': Colors.pink, 'label': '粉红色'},
   {'color': Colors.red, 'label': '红色'},

--- a/lib/bean/settings/color_type.dart
+++ b/lib/bean/settings/color_type.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 final List<Map<String, dynamic>> colorThemeTypes = [
   {'color': Colors.green, 'label': '默认'},
+  {'color': const Color(0xff6750a4), 'label': 'MD3 默认'},
   {'color': Colors.lightGreen, 'label': '浅绿色'},
   {'color': Colors.teal, 'label': '青色'},
   {'color': Colors.cyan, 'label': '蓝绿色'},

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -81,6 +81,8 @@ class _InfoPageState extends State<InfoPage>
                   opacity: 0.2,
                   child: LayoutBuilder(builder: (context, boxConstraints) {
                     return NetworkImgLayer(
+                      sigmaX: 15,
+                      sigmaY: 15,
                       src: infoController.bangumiItem.images['large'] ?? '',
                       width: boxConstraints.maxWidth,
                       height: boxConstraints.maxHeight,

--- a/lib/pages/settings/theme_settings_page.dart
+++ b/lib/pages/settings/theme_settings_page.dart
@@ -154,11 +154,19 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                                                   e['color'].withOpacity(0.8),
                                             ),
                                           ),
-                                          child: const AnimatedOpacity(
-                                            opacity: 0,
+                                          child: AnimatedOpacity(
+                                            opacity: (e['color']
+                                                        .value
+                                                        .toRadixString(16) ==
+                                                    defaultThemeColor ||
+                                                (defaultThemeColor ==
+                                                        'default' &&
+                                                    index == 0))
+                                            ? 1
+                                            : 0,
                                             duration:
-                                                Duration(milliseconds: 200),
-                                            child: Icon(
+                                                const Duration(milliseconds: 200),
+                                            child: const Icon(
                                               Icons.done,
                                               color: Colors.black,
                                               size: 20,


### PR DESCRIPTION
- 增加背景虚化，我给的 15，可改

<img width="300" alt="image" src="https://github.com/user-attachments/assets/42bdfa9d-3fe5-4676-9692-89507c4d7717" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d626ad9d-127e-4149-ab75-307235e12d32" />

- 启用主题颜色指示器，加了个 Material Design 3 的默认颜色。(另外目前的颜色里面有几个几乎没什么区别，或许可以考虑减掉几个，参考 [ColorScheme.fromSeed constructor](https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html#material.ColorScheme.ColorScheme.fromSeed.1) Line 436-453)

<img width="952" alt="image" src="https://github.com/user-attachments/assets/f9c336ce-4ef0-43bc-bab1-361f32c5ea07" />
