### PR TITLE
fix snackbar bug

### DIFF
--- a/lib/bean/dialog/dialog_helper.dart
+++ b/lib/bean/dialog/dialog_helper.dart
@@ -163,7 +163,9 @@ class KazumiDialogObserver extends NavigatorObserver {
 
   void _removeCurrentSnackBar(Route<dynamic>? route) {
     if (route?.navigator?.context != null) {
-      ScaffoldMessenger.of(route!.navigator!.context).removeCurrentSnackBar();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ScaffoldMessenger.of(route!.navigator!.context).removeCurrentSnackBar();
+      });
     }
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b79b374c-85f4-4c2f-9f13-525b364a6a43)
当有snackbar时进行didPush时会报这种错，虽然好像不影响使用，

另外发现好多page例如history_page在build时先进行了一行`WidgetsBinding.instance.addPostFrameCallback((_) {});`，这是什么原因，我注释掉后页面也能正常打开