### PR TITLE
simplify time code

### DIFF
--- a/lib/pages/timeline/timeline_controller.dart
+++ b/lib/pages/timeline/timeline_controller.dart
@@ -39,4 +39,9 @@ abstract class _TimelineController with Store {
       bangumiCalendar.addAll(resBangumiCalendar);
     }
   }
+
+  void tryEnterSeason(DateTime date) {
+    selectedDate = date;
+    seasonString = "加载中 ٩(◦`꒳´◦)۶";
+  }
 }

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -125,7 +125,6 @@ class _TimelinePageState extends State<TimelinePage>
                       var currDate = DateTime.now();
                       final years = List.generate(20, (index) => currDate.year - index);
                       List<DateTime> buttons = [];
-                      currDate = DateTime(2026);
                       for (final i in years){
                         for (final s in seasons){
                           buttons.add(generateDateTime(i, s));

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -82,6 +82,17 @@ class _TimelinePageState extends State<TimelinePage>
     Tab(text: '日'),
   ];
 
+  final seasons = [
+    '秋',
+    '夏',
+    '春',
+    '冬'
+  ];
+
+  String getStringByDateTime(DateTime d){
+    return d.year.toString() + Utils.getSeasonStringByMonth(d.month);
+  }
+
   @override
   Widget build(BuildContext context) {
     return OrientationBuilder(builder: (context, orientation) {
@@ -111,6 +122,15 @@ class _TimelinePageState extends State<TimelinePage>
                       showingTimeMachineDialog = false;
                     },
                     builder: (context) {
+                      var currDate = DateTime.now();
+                      final years = List.generate(20, (index) => currDate.year - index);
+                      List<DateTime> buttons = [];
+                      currDate = DateTime(2026);
+                      for (final i in years){
+                        for (final s in seasons){
+                          buttons.add(generateDateTime(i, s));
+                        }
+                      }
                     return AlertDialog(
                       title: const Text("时间机器"),
                       content: SingleChildScrollView(
@@ -118,68 +138,17 @@ class _TimelinePageState extends State<TimelinePage>
                           spacing: 8,
                           runSpacing: Utils.isCompact() ? 2 : 8,
                           children: [
-                            for (final int i in List.generate(
-                                20, (index) => DateTime.now().year - index))
-                              for (final String selectedSeason in [
-                                '秋',
-                                '夏',
-                                '春',
-                                '冬'
-                              ])
-                                DateTime.now().isAfter(
-                                        generateDateTime(i, selectedSeason))
-                                    ? timelineController.selectedDate ==
-                                            generateDateTime(i, selectedSeason)
+                            for (final date in buttons)
+                                currDate.isAfter(date)
+                                    ? timelineController.selectedDate == date
                                         ? FilledButton(
-                                            onPressed: () async {
-                                              if (timelineController
-                                                      .selectedDate !=
-                                                  generateDateTime(
-                                                      i, selectedSeason)) {
-                                                KazumiDialog.dismiss();
-                                                timelineController
-                                                        .selectedDate =
-                                                    generateDateTime(
-                                                        i, selectedSeason);
-                                                timelineController
-                                                        .seasonString =
-                                                    "加载中 ٩(◦`꒳´◦)۶";
-                                                if (AnimeSeason(
-                                                            timelineController
-                                                                .selectedDate)
-                                                        .toString() ==
-                                                    AnimeSeason(DateTime.now())
-                                                        .toString()) {
-                                                  await timelineController
-                                                      .getSchedules();
-                                                } else {
-                                                  await timelineController
-                                                      .getSchedulesBySeason();
-                                                }
-                                                timelineController
-                                                    .seasonString = AnimeSeason(
-                                                        timelineController
-                                                            .selectedDate)
-                                                    .toString();
-                                              }
-                                            },
-                                            child: Text(i.toString() +
-                                                selectedSeason.toString()),
+                                            onPressed: () {},
+                                            child: Text(getStringByDateTime(date)),
                                           )
                                         : FilledButton.tonal(
                                             onPressed: () async {
-                                              if (timelineController
-                                                      .selectedDate !=
-                                                  generateDateTime(
-                                                      i, selectedSeason)) {
-                                                KazumiDialog.dismiss();
-                                                timelineController
-                                                        .selectedDate =
-                                                    generateDateTime(
-                                                        i, selectedSeason);
-                                                timelineController
-                                                        .seasonString =
-                                                    "加载中 ٩(◦`꒳´◦)۶";
+                                              KazumiDialog.dismiss();
+                                                timelineController.tryEnterSeason(date);
                                                 if (AnimeSeason(
                                                             timelineController
                                                                 .selectedDate)
@@ -197,10 +166,8 @@ class _TimelinePageState extends State<TimelinePage>
                                                         timelineController
                                                             .selectedDate)
                                                     .toString();
-                                              }
                                             },
-                                            child: Text(i.toString() +
-                                                selectedSeason.toString()),
+                                            child: Text(getStringByDateTime(date)),
                                           )
                                     : Container(),
                           ],

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -540,17 +540,11 @@ class Utils {
   static Future<String> getCurrentDemux() async {
     return 'MPV';
   }
-  
-  static String getSeasonStringByMonth(int month){
-    if (month<=3) {
-      return '冬';
-    }
-    if(month<=6){
-      return '春';
-    }
-    if (month<=9) {
-      return '夏';
-    }
+
+  static String getSeasonStringByMonth(int month) {
+    if (month <= 3) return '冬';
+    if (month <= 6) return '春';
+    if (month <= 9) return '夏';
     return '秋';
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -540,4 +540,17 @@ class Utils {
   static Future<String> getCurrentDemux() async {
     return 'MPV';
   }
+  
+  static String getSeasonStringByMonth(int month){
+    if (month<=3) {
+      return '冬';
+    }
+    if(month<=6){
+      return '春';
+    }
+    if (month<=9) {
+      return '夏';
+    }
+    return '秋';
+  }
 }


### PR DESCRIPTION
时间机器这边代码太乱了，就整理了下。

有个问题，目前点击时间机器中按钮时，有判断是不是当前季度，并执行不同获取操作。

我认为可以简化如下代码
```
if (AnimeSeason(
            timelineController
                .selectedDate)
        .toString() ==
    AnimeSeason(DateTime.now())
        .toString()) {
  await timelineController
      .getSchedules();
} else {
  await timelineController
      .getSchedulesBySeason();
}
```
变成这样
```
await timelineController .getSchedulesBySeason();
```
![image](https://github.com/user-attachments/assets/7c260b11-e062-4645-b60a-8a486482a081)
![image](https://github.com/user-attachments/assets/e678f94d-e131-4f5f-ae0f-d85c6da10da8)
发现获取到的动画有区别，能简化吗