### PR TITLE
fix(ci): preserve symlinks when copying macOS app bundle

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -256,7 +256,7 @@
           - name: Create DMG
             run: |
               mkdir -p build/dist
-              cp -r build/macos/Build/Products/Release/kazumi.app build/dist/
+              cp -a build/macos/Build/Products/Release/kazumi.app build/dist/
               ln -s /Applications build/dist/Applications
               hdiutil create -format UDZO -srcfolder build/dist -volname kazumi Kazumi_macos_canary.dmg
           - name: Upload MacOS build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -311,7 +311,7 @@
           - name: Create DMG
             run: |
               mkdir -p build/dist
-              cp -r build/macos/Build/Products/Release/kazumi.app build/dist/
+              cp -a build/macos/Build/Products/Release/kazumi.app build/dist/
               ln -s /Applications build/dist/Applications
               hdiutil create -format UDZO -srcfolder build/dist -volname kazumi Kazumi_macos_${{ env.tag }}.dmg
           - name: Upload MacOS build


### PR DESCRIPTION
Use `cp -a` instead of `cp -r` to preserve symlinks when copying the macOS app bundle. This prevents symlinks from being converted to regular files, which would unnecessarily increase the final DMG size.

https://github.com/Predidit/Kazumi/pull/517