### PR TITLE
optimize history card

### DIFF
--- a/lib/bean/card/bangumi_history_card.dart
+++ b/lib/bean/card/bangumi_history_card.dart
@@ -163,28 +163,29 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
                         ],
                       ),
                     ),
+                  Positioned(
+                      top: 10,
+                      right: 10,
+                      child: Column(
+                        children: [
+                          CollectButton(
+                              bangumiItem: widget.historyItem.bangumiItem),
+                          if (widget.showDelete)
+                              IconButton(
+                                  icon: const Icon(Icons.delete),
+                                  onPressed: () {
+                                    historyController
+                                        .deleteHistory(widget.historyItem);
+                                  },
+                                )
+                        ],
+                      ),
+                    )
                   ],
                 ),
               ),
             ),
           ),
-          Positioned(
-            top: 10,
-            right: 10,
-            child: Column(
-              children: [
-                CollectButton(bangumiItem: widget.historyItem.bangumiItem),
-                widget.showDelete
-                    ? IconButton(
-                        icon: const Icon(Icons.delete),
-                        onPressed: () {
-                          historyController.deleteHistory(widget.historyItem);
-                        },
-                      )
-                    : Container(),
-              ],
-            ),
-          )
         ],
       ),
     );

--- a/lib/bean/widget/collect_button.dart
+++ b/lib/bean/widget/collect_button.dart
@@ -65,7 +65,8 @@ class _CollectButtonState extends State<CollectButton> {
     collectType = collectController.getCollectType(widget.bangumiItem);
     return PopupMenuButton(
       tooltip: '',
-      child: widget.withRounder
+      padding: const EdgeInsets.all(0),
+      icon: widget.withRounder
           ? NonClickableIconButton(
               icon: getIconByInt(collectType),
             )
@@ -127,7 +128,7 @@ class NonClickableIconButton extends StatelessWidget {
         color: effectiveBackgroundColor,
         shape: BoxShape.circle,
       ),
-      child: Icon(icon, color: effectiveIconColor),
+      child: Icon(icon),
     );
   }
 }


### PR DESCRIPTION
优化历史记录中的卡片，防止按钮盖住番剧名
![image](https://github.com/user-attachments/assets/08b6ee21-79e6-4b35-bb1b-2a113b0910af)
感觉这个按钮的正方形阴影和背景不同挺不自然的，查了一下，好像是PopupMenuButton的问题，我找不到方法解决

