### PR TITLE
mod: move episode comments to menu

### DIFF
--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -15,7 +15,8 @@ class EpisodeCommentsSheet extends StatefulWidget {
   State<EpisodeCommentsSheet> createState() => _EpisodeCommentsSheetState();
 }
 
-class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
+class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet>
+    with AutomaticKeepAliveClientMixin {
   final infoController = Modular.get<InfoController>();
   bool isLoading = false;
   bool commentsQueryTimeout = false;
@@ -137,52 +138,53 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   void showEpisodeSelection() {
     final TextEditingController textController = TextEditingController();
     KazumiDialog.show(
-        builder: (context) {
-          return AlertDialog(
-            title: const Text('输入集数'),
-            content: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-              return TextField(
-                inputFormatters: <TextInputFormatter>[
-                  FilteringTextInputFormatter.digitsOnly
-                ],
-                controller: textController,
-              );
-            }),
-            actions: [
-              TextButton(
-                onPressed: () => KazumiDialog.dismiss(),
-                child: Text(
-                  '取消',
-                  style:
-                      TextStyle(color: Theme.of(context).colorScheme.outline),
-                ),
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('输入集数'),
+          content: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+            return TextField(
+              inputFormatters: <TextInputFormatter>[
+                FilteringTextInputFormatter.digitsOnly
+              ],
+              controller: textController,
+            );
+          }),
+          actions: [
+            TextButton(
+              onPressed: () => KazumiDialog.dismiss(),
+              child: Text(
+                '取消',
+                style: TextStyle(color: Theme.of(context).colorScheme.outline),
               ),
-              TextButton(
-                onPressed: () {
-                  if (textController.text.isEmpty) {
-                    KazumiDialog.showToast(message: '请输入集数');
-                    return;
-                  }
-                  final ep = int.tryParse(textController.text) ?? 0;
-                  if (ep == 0) {
-                    return;
-                  }
-                  setState(() {
-                    isLoading = true;
-                  });
-                  loadComments(ep);
-                  KazumiDialog.dismiss();
-                },
-                child: const Text('刷新'),
-              ),
-            ],
-          );
-        });
+            ),
+            TextButton(
+              onPressed: () {
+                if (textController.text.isEmpty) {
+                  KazumiDialog.showToast(message: '请输入集数');
+                  return;
+                }
+                final ep = int.tryParse(textController.text) ?? 0;
+                if (ep == 0) {
+                  return;
+                }
+                setState(() {
+                  isLoading = true;
+                });
+                loadComments(ep);
+                KazumiDialog.dismiss();
+              },
+              child: const Text('刷新'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Scaffold(
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -190,4 +192,7 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -182,6 +182,8 @@ class _PlayerItemState extends State<PlayerItem>
     if (!showVideoController) {
       displayVideoController();
     }
+    hideTimer?.cancel();
+    startHideTimer();
   }
 
   void _handleMouseScroller() {

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -31,7 +31,6 @@ import 'package:kazumi/modules/danmaku/danmaku_episode_response.dart';
 import 'package:kazumi/bean/appbar/drag_to_move_bar.dart' as dtb;
 import 'package:kazumi/pages/settings/danmaku/danmaku_settings_window.dart';
 import 'package:kazumi/utils/constants.dart';
-import 'package:kazumi/pages/player/episode_comments_sheet.dart';
 import 'package:saver_gallery/saver_gallery.dart';
 import 'package:mobx/mobx.dart' as mobx;
 import 'package:kazumi/bean/widget/collect_button.dart';
@@ -373,7 +372,10 @@ class _PlayerItemState extends State<PlayerItem>
     _handleFullscreenChange(context);
     if (videoPageController.isFullscreen) {
       Utils.exitFullScreen();
-      widget.locateEpisode();
+      if (!Utils.isDesktop()) {
+        widget.locateEpisode();
+        videoPageController.showTabBody = true;
+      }
     } else {
       Utils.enterFullScreen();
       videoPageController.showTabBody = false;
@@ -1395,64 +1397,7 @@ class _PlayerItemState extends State<PlayerItem>
                                       fontWeight: FontWeight.bold),
                                 ),
                               ),
-                              IconButton(
-                                color: Colors.white,
-                                icon: const Icon(Icons.comment),
-                                onPressed: () {
-                                  bool needRestart = playerController.playing;
-                                  playerController.pause();
-                                  episodeNum = Utils.extractEpisodeNumber(
-                                      videoPageController
-                                              .roadList[videoPageController
-                                                  .currentRoad]
-                                              .identifier[
-                                          videoPageController.currentEpisode -
-                                              1]);
-                                  if (episodeNum == 0 ||
-                                      episodeNum >
-                                          videoPageController
-                                              .roadList[videoPageController
-                                                  .currentRoad]
-                                              .identifier
-                                              .length) {
-                                    episodeNum =
-                                        videoPageController.currentEpisode;
-                                  }
-                                  showModalBottomSheet(
-                                      isScrollControlled: true,
-                                      constraints: BoxConstraints(
-                                          maxHeight: MediaQuery.of(context)
-                                                  .size
-                                                  .height *
-                                              3 /
-                                              4,
-                                          maxWidth: (MediaQuery.of(context)
-                                                      .size
-                                                      .width >
-                                                  MediaQuery.of(context)
-                                                      .size
-                                                      .height)
-                                              ? MediaQuery.of(context)
-                                                      .size
-                                                      .width *
-                                                  9 /
-                                                  16
-                                              : MediaQuery.of(context)
-                                                  .size
-                                                  .width),
-                                      clipBehavior: Clip.antiAlias,
-                                      context: context,
-                                      builder: (context) {
-                                        return EpisodeCommentsSheet(
-                                            episode: episodeNum);
-                                      }).whenComplete(() {
-                                    if (needRestart) {
-                                      playerController.play();
-                                    }
-                                    _focusNode.requestFocus();
-                                  });
-                                },
-                              ),
+                              forwardIcon(),
                               // 追番
                               CollectButton(
                                   bangumiItem: infoController.bangumiItem),
@@ -1582,7 +1527,6 @@ class _PlayerItemState extends State<PlayerItem>
                                       },
                                     )
                                   : Container(),
-                              forwardIcon(),
                               Expanded(
                                 child: ProgressBar(
                                   timeLabelLocation: TimeLabelLocation.none,

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -19,6 +19,7 @@ import 'package:flutter/services.dart';
 import 'package:kazumi/bean/appbar/drag_to_move_bar.dart' as dtb;
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:kazumi/pages/player/episode_comments_sheet.dart';
 
 class VideoPage extends StatefulWidget {
   const VideoPage({super.key});
@@ -51,10 +52,13 @@ class _VideoPageState extends State<VideoPage>
 
   // webview init events listener
   late final StreamSubscription<bool> _initSubscription;
+
   // webview logs events listener
   late final StreamSubscription<String> _logSubscription;
+
   // webview video loaded events listener
   late final StreamSubscription<bool> _videoLoadedSubscription;
+
   // webview video source events listener
   // The first parameter is the video source URL and the second parameter is the video offset (start position)
   late final StreamSubscription<(String, int)> _videoURLSubscription;
@@ -202,6 +206,7 @@ class _VideoPageState extends State<VideoPage>
     if (videoPageController.isFullscreen && !Utils.isTablet()) {
       menuJumpToCurrentEpisode();
       await Utils.exitFullScreen();
+      videoPageController.showTabBody = true;
       videoPageController.isFullscreen = false;
       return;
     }
@@ -235,6 +240,7 @@ class _VideoPageState extends State<VideoPage>
               videoPageController.isFullscreen) {
             videoPageController.exitFullScreen();
             menuJumpToCurrentEpisode();
+            videoPageController.showTabBody = true;
           }
         }
         return Observer(builder: (context) {
@@ -247,7 +253,8 @@ class _VideoPageState extends State<VideoPage>
                   )),
             body: SafeArea(
               top: !videoPageController.isFullscreen,
-              bottom: false, // set iOS and Android navigation bar to immersive
+              // set iOS and Android navigation bar to immersive
+              bottom: false,
               left: !videoPageController.isFullscreen,
               right: !videoPageController.isFullscreen,
               child: (Utils.isDesktop()) ||
@@ -258,11 +265,12 @@ class _VideoPageState extends State<VideoPage>
                       alignment: Alignment.centerRight,
                       children: [
                         Container(
-                            color: Colors.black,
-                            height: MediaQuery.of(context).size.height,
-                            width: MediaQuery.of(context).size.width,
-                            child: playerBody),
-                        if (videoPageController.showTabBody) ...[
+                          color: Colors.black,
+                          height: MediaQuery.of(context).size.height,
+                          width: MediaQuery.of(context).size.width,
+                          child: playerBody,
+                        ),
+                        if (videoPageController.showTabBody)
                           GestureDetector(
                             onTap: () {
                               closeTabBodyAnimated();
@@ -273,90 +281,76 @@ class _VideoPageState extends State<VideoPage>
                               height: double.infinity,
                             ),
                           ),
-                          SlideTransition(
-                              position: _rightOffsetAnimation,
-                              child: SizedBox(
-                                  height: MediaQuery.of(context).size.height,
-                                  width: MediaQuery.of(context).size.width *
-                                              1 /
-                                              3 >
-                                          420
-                                      ? 420
-                                      : MediaQuery.of(context).size.width *
-                                          1 /
-                                          3,
-                                  child: Container(
-                                      color: Theme.of(context).canvasColor,
-                                      child: GridViewObserver(
-                                        controller: observerController,
-                                        child: Column(
-                                          children: [
-                                            tabBar,
-                                            tabBody,
-                                          ],
-                                        ),
-                                      ))))
-                        ]
+                        SlideTransition(
+                          position: _rightOffsetAnimation,
+                          child: SizedBox(
+                            height: MediaQuery.of(context).size.height,
+                            width:
+                                MediaQuery.of(context).size.width * 1 / 3 > 420
+                                    ? 420
+                                    : MediaQuery.of(context).size.width * 1 / 3,
+                            child: tabBody,
+                          ),
+                        ),
                       ],
                     )
                   : (!videoPageController.isFullscreen)
                       ? Column(
                           children: [
                             Container(
-                                color: Colors.black,
-                                height:
-                                    MediaQuery.of(context).size.width * 9 / 16,
-                                width: MediaQuery.of(context).size.width,
-                                child: playerBody),
+                              color: Colors.black,
+                              height:
+                                  MediaQuery.of(context).size.width * 9 / 16,
+                              width: MediaQuery.of(context).size.width,
+                              child: playerBody,
+                            ),
                             Expanded(
-                                child: GridViewObserver(
-                              controller: observerController,
-                              child: Column(
-                                children: [
-                                  tabBar,
-                                  tabBody,
-                                ],
-                              ),
-                            ))
+                              child: tabBody,
+                            ),
                           ],
                         )
-                      : Stack(alignment: Alignment.centerRight, children: [
-                          Container(
-                              color: Colors.black,
-                              height: MediaQuery.of(context).size.height,
-                              width: MediaQuery.of(context).size.width,
-                              child: playerBody),
-                          if (videoPageController.showTabBody) ...[
-                            GestureDetector(
-                              onTap: () {
-                                closeTabBodyAnimated();
-                              },
-                              child: Container(
-                                color: Colors.black38,
-                                width: double.infinity,
-                                height: double.infinity,
+                      : Stack(
+                          alignment: Alignment.centerRight,
+                          children: [
+                            Container(
+                                color: Colors.black,
+                                height: MediaQuery.of(context).size.height,
+                                width: MediaQuery.of(context).size.width,
+                                child: playerBody),
+                            if (videoPageController.showTabBody)
+                              GestureDetector(
+                                onTap: () {
+                                  closeTabBodyAnimated();
+                                },
+                                child: Container(
+                                  color: Colors.black38,
+                                  width: double.infinity,
+                                  height: double.infinity,
+                                ),
+                              ),
+                            SlideTransition(
+                              position: _rightOffsetAnimation,
+                              child: SizedBox(
+                                height: MediaQuery.of(context).size.height,
+                                width: (Utils.isTablet())
+                                    ? MediaQuery.of(context).size.width / 2
+                                    : MediaQuery.of(context).size.height,
+                                child: Container(
+                                  color: Theme.of(context).canvasColor,
+                                  child: GridViewObserver(
+                                    controller: observerController,
+                                    child: Column(
+                                      children: [
+                                        menuBar,
+                                        menuBody,
+                                      ],
+                                    ),
+                                  ),
+                                ),
                               ),
                             ),
-                            SlideTransition(
-                                position: _rightOffsetAnimation,
-                                child: SizedBox(
-                                    height: MediaQuery.of(context).size.height,
-                                    width: (Utils.isTablet())
-                                        ? MediaQuery.of(context).size.width / 2
-                                        : MediaQuery.of(context).size.height,
-                                    child: Container(
-                                        color: Theme.of(context).canvasColor,
-                                        child: GridViewObserver(
-                                          controller: observerController,
-                                          child: Column(
-                                            children: [
-                                              tabBar,
-                                              tabBody,
-                                            ],
-                                          ),
-                                        ))))
-                          ]
-                        ]),
+                          ],
+                        ),
             ),
           );
         });
@@ -543,7 +537,7 @@ class _VideoPageState extends State<VideoPage>
     );
   }
 
-  Widget get tabBar {
+  Widget get menuBar {
     return Padding(
       padding: const EdgeInsets.all(8),
       child: Row(
@@ -619,7 +613,7 @@ class _VideoPageState extends State<VideoPage>
     );
   }
 
-  Widget get tabBody {
+  Widget get menuBody {
     var cardList = <Widget>[];
     for (var road in videoPageController.roadList) {
       if (road.name == '播放列表${currentRoad + 1}') {
@@ -706,6 +700,67 @@ class _VideoPageState extends State<VideoPage>
           itemBuilder: (context, index) {
             return cardList[index];
           },
+        ),
+      ),
+    );
+  }
+
+  Widget get tabBody {
+    int episodeNum = 0;
+    episodeNum = Utils.extractEpisodeNumber(videoPageController
+        .roadList[videoPageController.currentRoad]
+        .identifier[videoPageController.currentEpisode - 1]);
+    if (episodeNum == 0 ||
+        episodeNum >
+            videoPageController
+                .roadList[videoPageController.currentRoad].identifier.length) {
+      episodeNum = videoPageController.currentEpisode;
+    }
+
+    return Visibility(
+      maintainState: true,
+      visible: videoPageController.showTabBody,
+      child: Container(
+        color: Theme.of(context).canvasColor,
+        child: DefaultTabController(
+          length: 2,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TabBar(
+                dividerHeight: Utils.isDesktop() ? 0.5 : 0.2,
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                labelPadding:
+                    const EdgeInsetsDirectional.only(start: 30, end: 30),
+                onTap: (index) {
+                  if (index == 0) {
+                    menuJumpToCurrentEpisode();
+                  }
+                },
+                tabs: const [
+                  Tab(text: '选集'),
+                  Tab(text: '评论'),
+                ],
+              ),
+              Expanded(
+                child: TabBarView(
+                  children: [
+                    GridViewObserver(
+                      controller: observerController,
+                      child: Column(
+                        children: [
+                          menuBar,
+                          menuBody,
+                        ],
+                      ),
+                    ),
+                    EpisodeCommentsSheet(episode: episodeNum),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -317,7 +317,7 @@ class _VideoPageState extends State<VideoPage>
                                 height: MediaQuery.of(context).size.height,
                                 width: MediaQuery.of(context).size.width,
                                 child: playerBody),
-                            if (videoPageController.showTabBody)
+                            if (videoPageController.showTabBody) ...[
                               GestureDetector(
                                 onTap: () {
                                   closeTabBodyAnimated();
@@ -328,27 +328,28 @@ class _VideoPageState extends State<VideoPage>
                                   height: double.infinity,
                                 ),
                               ),
-                            SlideTransition(
-                              position: _rightOffsetAnimation,
-                              child: SizedBox(
-                                height: MediaQuery.of(context).size.height,
-                                width: (Utils.isTablet())
-                                    ? MediaQuery.of(context).size.width / 2
-                                    : MediaQuery.of(context).size.height,
-                                child: Container(
-                                  color: Theme.of(context).canvasColor,
-                                  child: GridViewObserver(
-                                    controller: observerController,
-                                    child: Column(
-                                      children: [
-                                        menuBar,
-                                        menuBody,
-                                      ],
+                              SlideTransition(
+                                position: _rightOffsetAnimation,
+                                child: SizedBox(
+                                  height: MediaQuery.of(context).size.height,
+                                  width: (Utils.isTablet())
+                                      ? MediaQuery.of(context).size.width / 2
+                                      : MediaQuery.of(context).size.height,
+                                  child: Container(
+                                    color: Theme.of(context).canvasColor,
+                                    child: GridViewObserver(
+                                      controller: observerController,
+                                      child: Column(
+                                        children: [
+                                          menuBar,
+                                          menuBody,
+                                        ],
+                                      ),
                                     ),
                                   ),
                                 ),
                               ),
-                            ),
+                            ],
                           ],
                         ),
             ),


### PR DESCRIPTION
修复上一个 PR 的 Timer 问题

移动评论区，和选集放在一起。这样做的好处是比较整齐，后续有 bangumi 登录之后也可以增加发送评论的功能，会比较好看

- maintain state 和 keep alive 是为了避免反复构建评论区造成的卡顿
- 手机端全屏只会呼出选集，不会呼出评论区

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ff177b65-24fe-460b-9673-c148f2116404" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/07b6a827-7bdd-42a0-95f2-9673ed7d311d" />
<img width="846" alt="image" src="https://github.com/user-attachments/assets/889c47d6-60ae-4c56-9cea-9ccf43fa3116" />
