### PR TITLE
fix search

### DIFF
--- a/lib/bean/card/bangumi_card.dart
+++ b/lib/bean/card/bangumi_card.dart
@@ -42,7 +42,7 @@ class BangumiCardV extends StatelessWidget {
               return;
             }
             infoController.bangumiItem = bangumiItem;
-            if (popularController.searchKeyword == '') {
+            if (!popularController.isSearching) {
               popularController.keyword = bangumiItem.nameCn == ''
                   ? bangumiItem.name
                   : (bangumiItem.nameCn);

--- a/lib/pages/popular/popular_controller.dart
+++ b/lib/pages/popular/popular_controller.dart
@@ -13,6 +13,7 @@ abstract class _PopularController with Store {
 
   String keyword = '';
   String searchKeyword = '';
+  bool isSearching = false;
 
   @observable
   String currentTag = '';
@@ -28,7 +29,8 @@ abstract class _PopularController with Store {
   @observable
   bool isTimeOut = false;
 
-  void setSearchKeyword(String s){
+  void setSearchKeyword(String s) {
+    isSearching = s.isNotEmpty;
     searchKeyword = s;
   }
 

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -50,11 +50,13 @@ class _PopularPageState extends State<PopularPage>
     if (popularController.bangumiList.isEmpty) {
       popularController.queryBangumiListFeed();
     }
+    popularController.isSearching = popularController.searchKeyword.isNotEmpty;
     showSearchBar = popularController.searchKeyword.isNotEmpty;
   }
 
   @override
   void dispose() {
+    popularController.isSearching = false;
     _focusNode.dispose();
     scrollController.removeListener(() {});
     super.dispose();
@@ -319,8 +321,8 @@ class _PopularPageState extends State<PopularPage>
                             onPressed: () async {
                               _focusNode.unfocus();
                               scrollController.jumpTo(0.0);
+                              popularController.setSearchKeyword('');
                               setState(() {
-                                popularController.setSearchKeyword('');
                                 showSearchBar = false;
                               });
                               await popularController


### PR DESCRIPTION
#579 相关，

仍有问题：
![image](https://github.com/user-attachments/assets/48f8a0c7-5495-4f66-8a88-d492b7932da4)
![image](https://github.com/user-attachments/assets/13cf2b15-a147-45bf-b4a2-bf64d2ce8a4e)
点击搜索栏右边的×后，
![image](https://github.com/user-attachments/assets/c7d6793c-402e-4ce5-acab-aabb705be12d)
![image](https://github.com/user-attachments/assets/2ff5537b-9e08-4a9e-8842-4f40df057481)

即通过searchKeyword进入info变成了通过bangumi.name。这是正常的表现吗，看了一下，之前的代码应该也有这种问题。
