### PR TITLE
fix #598(pause before hide player)

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -668,6 +668,7 @@ class _PlayerItemState extends State<PlayerItem>
                                     videoPageController.isFullscreen =
                                         !videoPageController.isFullscreen;
                                   } else if (!Platform.isMacOS) {
+                                    playerController.pause();
                                     windowManager.hide();
                                   }
                                 }


### PR DESCRIPTION
在windowManager.hide()前添加pause