### PR TITLE
fix android dynamic theme is always in light mode

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -177,10 +177,12 @@ class _AppWidgetState extends State<AppWidget>
       builder: (theme, darkTheme) {
         if (themeProvider.useDynamicColor) {
           themeProvider.setTheme(
-            ThemeData(colorScheme: theme),
+            ThemeData(colorScheme: theme, brightness: Brightness.light),
             oledEnhance
-                ? Utils.oledDarkTheme(ThemeData(colorScheme: darkTheme))
-                : ThemeData(colorScheme: darkTheme),
+                ? Utils.oledDarkTheme(ThemeData(
+                    colorScheme: darkTheme, brightness: Brightness.dark))
+                : ThemeData(
+                    colorScheme: darkTheme, brightness: Brightness.dark),
             notify: false,
           );
         }

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -124,6 +124,8 @@ class _InitPageState extends State<InitPage> {
         },
       );
     } else {
+      // Workaround for dynamic_color. dynamic_color need PlatformChannel to get color, it takes time.
+      // setDynamic here to avoid white screen flash when themeMode is dark.
       themeProvider.setDynamic(
           setting.get(SettingBoxKey.useDynamicColor, defaultValue: false));
       Modular.to.navigate('/tab/popular/');


### PR DESCRIPTION
不知道是不是个例，我的手机上如果开启动态配色会一直是浅色模式

看上去像是 dynamic_color 包获取的问题，但逻辑怎么看都没什么问题