### PR TITLE
refactor pc player panel

### DIFF
--- a/lib/bean/widget/collect_button.dart
+++ b/lib/bean/widget/collect_button.dart
@@ -99,13 +99,13 @@ class _CollectButtonState extends State<CollectButton> {
                 Icon(getIconByInt(index),
                     color: index == collectType
                         ? Theme.of(context).colorScheme.primary
-                        : Colors.white),
+                        : null),
                 Text(
                   ' ${getTypeStringByInt(index)}',
                   style: TextStyle(
                       color: index == collectType
                           ? Theme.of(context).colorScheme.primary
-                          : Colors.white),
+                          : null),
                 ),
               ],
             ),

--- a/lib/bean/widget/collect_button.dart
+++ b/lib/bean/widget/collect_button.dart
@@ -65,33 +65,53 @@ class _CollectButtonState extends State<CollectButton> {
   @override
   Widget build(BuildContext context) {
     collectType = collectController.getCollectType(widget.bangumiItem);
-    return PopupMenuButton(
-      tooltip: '',
-      icon: Icon(
-        getIconByInt(collectType),
-        color: widget.color,
-      ),
-      itemBuilder: (context) {
-        return List.generate(
-          6,
-          (i) => PopupMenuItem(
-            value: i,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(getIconByInt(i)),
-                Text(' ${getTypeStringByInt(i)}'),
-              ],
-            ),
+    return MenuAnchor(
+      builder:
+          (BuildContext context, MenuController controller, Widget? child) {
+        return IconButton(
+          onPressed: () {
+            if (controller.isOpen) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+          icon: Icon(
+            getIconByInt(collectType),
+            color: widget.color,
           ),
         );
       },
-      onSelected: (value) {
-        if (value != collectType && mounted) {
-          collectController.addCollect(widget.bangumiItem, type: value);
-          setState(() {});
-        }
-      },
+      menuChildren: List<MenuItemButton>.generate(
+        6,
+        (int index) => MenuItemButton(
+          onPressed: () {
+            if (index != collectType && mounted) {
+              collectController.addCollect(widget.bangumiItem, type: index);
+              setState(() {});
+            }
+          },
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(0, 10, 10, 10),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(getIconByInt(index),
+                    color: index == collectType
+                        ? Theme.of(context).colorScheme.primary
+                        : Colors.white),
+                Text(
+                  ' ${getTypeStringByInt(index)}',
+                  style: TextStyle(
+                      color: index == collectType
+                          ? Theme.of(context).colorScheme.primary
+                          : Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -225,7 +225,6 @@ class _InfoPageState extends State<InfoPage>
               onPressed: () async {
                 showModalBottomSheet(
                     isScrollControlled: true,
-                    enableDrag: false,
                     constraints: BoxConstraints(
                         maxHeight: MediaQuery.of(context).size.height * 3 / 4,
                         maxWidth: (Utils.isDesktop() || Utils.isTablet())

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 import 'package:kazumi/pages/player/player_item_panel.dart';
+import 'package:kazumi/pages/player/smallest_player_item_panel.dart';
 import 'package:kazumi/utils/logger.dart';
 import 'package:kazumi/utils/utils.dart';
 import 'package:kazumi/utils/webdav.dart';
@@ -509,8 +510,6 @@ class _PlayerItemState extends State<PlayerItem>
       vsync: this,
     );
     webDavEnable = setting.get(SettingBoxKey.webDavEnable, defaultValue: false);
-    playerController.danmakuOn =
-        setting.get(SettingBoxKey.danmakuEnabledByDefault, defaultValue: false);
     _border = setting.get(SettingBoxKey.danmakuBorder, defaultValue: true);
     _opacity = setting.get(SettingBoxKey.danmakuOpacity, defaultValue: 1.0);
     _duration = 8;
@@ -787,20 +786,36 @@ class _PlayerItemState extends State<PlayerItem>
                       ),
                     ),
                     // 播放器控制面板
-                    PlayerItemPanel(
-                      onBackPressed: widget.onBackPressed,
-                      setPlaybackSpeed: setPlaybackSpeed,
-                      showDanmakuSwitch: showDanmakuSwitch,
-                      changeEpisode: widget.changeEpisode,
-                      openMenu: widget.openMenu,
-                      handleFullscreen: handleFullscreen,
-                      handleProgressBarDragStart: handleProgressBarDragStart,
-                      handleProgressBarDragEnd: handleProgressBarDragEnd,
-                      animationController: animationController!,
-                      keyboardFocus: widget.keyboardFocus,
-                      handleHove: handleHove,
-                      sendDanmaku: widget.sendDanmaku,
-                    ),
+                    (Utils.isDesktop() ||
+                            Utils.isTablet() ||
+                            videoPageController.isFullscreen)
+                        ? PlayerItemPanel(
+                            onBackPressed: widget.onBackPressed,
+                            setPlaybackSpeed: setPlaybackSpeed,
+                            showDanmakuSwitch: showDanmakuSwitch,
+                            changeEpisode: widget.changeEpisode,
+                            openMenu: widget.openMenu,
+                            handleFullscreen: handleFullscreen,
+                            handleProgressBarDragStart:
+                                handleProgressBarDragStart,
+                            handleProgressBarDragEnd: handleProgressBarDragEnd,
+                            animationController: animationController!,
+                            keyboardFocus: widget.keyboardFocus,
+                            handleHove: handleHove,
+                            sendDanmaku: widget.sendDanmaku,
+                          )
+                        : SmallestPlayerItemPanel(
+                            onBackPressed: widget.onBackPressed,
+                            setPlaybackSpeed: setPlaybackSpeed,
+                            showDanmakuSwitch: showDanmakuSwitch,
+                            handleFullscreen: handleFullscreen,
+                            handleProgressBarDragStart:
+                                handleProgressBarDragStart,
+                            handleProgressBarDragEnd: handleProgressBarDragEnd,
+                            animationController: animationController!,
+                            keyboardFocus: widget.keyboardFocus,
+                            handleHove: handleHove,
+                          ),
                     // 播放器手势控制
                     Positioned.fill(
                         left: 16,
@@ -839,10 +854,6 @@ class _PlayerItemState extends State<PlayerItem>
                                 final double sectionWidth = totalWidth / 2;
                                 final double delta = details.delta.dy;
 
-                                /// 非全屏时禁用
-                                if (!videoPageController.isFullscreen) {
-                                  return;
-                                }
                                 if (tapPosition < sectionWidth) {
                                   // 左边区域
                                   playerController.brightnessSeeking = true;

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -141,7 +141,7 @@ class _PlayerItemState extends State<PlayerItem>
     }
   }
 
-  void _handleHove() {
+  void handleHove() {
     if (!playerController.showVideoController) {
       displayVideoController();
     }
@@ -581,7 +581,7 @@ class _PlayerItemState extends State<PlayerItem>
                 // workaround for android.
                 // I don't know why, but android tap event will trigger onHover event.
                 if (Utils.isDesktop()) {
-                  _handleHove();
+                  handleHove();
                 }
               },
               child: Listener(
@@ -795,6 +795,8 @@ class _PlayerItemState extends State<PlayerItem>
                       handleProgressBarDragStart: handleProgressBarDragStart,
                       handleProgressBarDragEnd: handleProgressBarDragEnd,
                       animationController: animationController!,
+                      keyboardFocus: widget.keyboardFocus,
+                      handleHove: handleHove,
                     ),
                     // 播放器手势控制
                     Positioned.fill(

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -37,6 +37,7 @@ class PlayerItem extends StatefulWidget {
     required this.changeEpisode,
     required this.onBackPressed,
     required this.keyboardFocus,
+    required this.sendDanmaku,
   });
 
   final VoidCallback openMenu;
@@ -44,6 +45,7 @@ class PlayerItem extends StatefulWidget {
   final Future<void> Function(int episode, {int currentRoad, int offset})
       changeEpisode;
   final void Function(BuildContext) onBackPressed;
+  final void Function(String) sendDanmaku;
   final FocusNode keyboardFocus;
 
   @override
@@ -797,6 +799,7 @@ class _PlayerItemState extends State<PlayerItem>
                       animationController: animationController!,
                       keyboardFocus: widget.keyboardFocus,
                       handleHove: handleHove,
+                      sendDanmaku: widget.sendDanmaku,
                     ),
                     // 播放器手势控制
                     Positioned.fill(

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -94,6 +94,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
       constraints: Utils.isDesktop()
           ? const BoxConstraints(maxWidth: 500, maxHeight: 33)
           : const BoxConstraints(maxHeight: 33),
+      padding: EdgeInsets.symmetric(horizontal: 8),
       child: TextField(
         style: TextStyle(fontSize: Utils.isDesktop() ? 15 : 13),
         controller: textController,
@@ -101,7 +102,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
         decoration: InputDecoration(
           enabled: playerController.danmakuOn,
           filled: true,
-          fillColor: Utils.isDesktop() ? Colors.white38 : Colors.white70,
+          fillColor: Colors.white70,
           floatingLabelBehavior: FloatingLabelBehavior.never,
           hintText: playerController.danmakuOn ? '发个友善的弹幕见证当下' : '已关闭弹幕',
           hintStyle: TextStyle(fontSize: Utils.isDesktop() ? 15 : 13),

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -15,7 +15,6 @@ import 'package:kazumi/pages/info/info_controller.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:hive/hive.dart';
 import 'package:kazumi/utils/storage.dart';
-import 'package:canvas_danmaku/canvas_danmaku.dart';
 import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 
 class PlayerItemPanel extends StatefulWidget {
@@ -102,7 +101,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
         decoration: InputDecoration(
           enabled: playerController.danmakuOn,
           filled: true,
-          fillColor: Colors.white30,
+          fillColor: Utils.isDesktop() ? Colors.white38 : Colors.white70,
           floatingLabelBehavior: FloatingLabelBehavior.never,
           hintText: playerController.danmakuOn ? '发个友善的弹幕见证当下' : '已关闭弹幕',
           hintStyle: TextStyle(fontSize: Utils.isDesktop() ? 15 : 13),
@@ -366,7 +365,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
               child: SlideTransition(
                 position: bottomOffsetAnimation,
                 child: Container(
-                  height: 60,
+                  height: 80,
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
                       begin: Alignment.topCenter,
@@ -391,7 +390,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                         Container(
                           padding: const EdgeInsets.all(8.0),
                           decoration: BoxDecoration(
-                            color: Colors.black.withOpacity(0.5),
+                            color: Colors.black54,
                             borderRadius: BorderRadius.circular(8.0), // 圆角
                           ),
                           child: Text(
@@ -418,7 +417,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                         Container(
                           padding: const EdgeInsets.all(8.0),
                           decoration: BoxDecoration(
-                            color: Colors.black.withOpacity(0.5),
+                            color: Colors.black54,
                             borderRadius: BorderRadius.circular(8.0), // 圆角
                           ),
                           child: const Row(
@@ -446,7 +445,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                         Container(
                             padding: const EdgeInsets.all(8.0),
                             decoration: BoxDecoration(
-                              color: Colors.black.withOpacity(0.5),
+                              color: Colors.black54,
                               borderRadius: BorderRadius.circular(8.0), // 圆角
                             ),
                             child: Row(
@@ -474,7 +473,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                         Container(
                             padding: const EdgeInsets.all(8.0),
                             decoration: BoxDecoration(
-                              color: Colors.black.withOpacity(0.5),
+                              color: Colors.black54,
                               borderRadius: BorderRadius.circular(8.0), // 圆角
                             ),
                             child: Row(
@@ -501,33 +500,35 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                   bottom: 0,
                   child: SlideTransition(
                     position: leftOffsetAnimation,
-                    child: Column(children: [
-                      const Spacer(),
-                      (playerController.lockPanel)
-                          ? Container()
-                          : IconButton(
-                              icon: const Icon(
-                                Icons.photo_camera_outlined,
-                                color: Colors.white,
+                    child: Column(
+                      children: [
+                        const Spacer(),
+                        (playerController.lockPanel)
+                            ? Container()
+                            : IconButton(
+                                icon: const Icon(
+                                  Icons.photo_camera_outlined,
+                                  color: Colors.white,
+                                ),
+                                onPressed: () {
+                                  _handleScreenshot();
+                                },
                               ),
-                              onPressed: () {
-                                _handleScreenshot();
-                              },
-                            ),
-                      IconButton(
-                        icon: Icon(
-                          playerController.lockPanel
-                              ? Icons.lock_outline
-                              : Icons.lock_open,
-                          color: Colors.white,
+                        IconButton(
+                          icon: Icon(
+                            playerController.lockPanel
+                                ? Icons.lock_outline
+                                : Icons.lock_open,
+                            color: Colors.white,
+                          ),
+                          onPressed: () {
+                            playerController.lockPanel =
+                                !playerController.lockPanel;
+                          },
                         ),
-                        onPressed: () {
-                          playerController.lockPanel =
-                              !playerController.lockPanel;
-                        },
-                      ),
-                      const Spacer(),
-                    ]),
+                        const Spacer(),
+                      ],
+                    ),
                   ),
                 ),
           // 自定义顶部组件
@@ -563,64 +564,66 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                     const Expanded(
                       child: dtb.DragToMoveArea(child: SizedBox(height: 40)),
                     ),
+                    // 跳过
                     forwardIcon(),
                     // 追番
                     CollectButton(bangumiItem: infoController.bangumiItem),
                     MenuAnchor(
-                        builder: (BuildContext context,
-                            MenuController controller, Widget? child) {
-                          return IconButton(
-                            onPressed: () {
-                              if (controller.isOpen) {
-                                controller.close();
-                              } else {
-                                controller.open();
+                      builder: (BuildContext context, MenuController controller,
+                          Widget? child) {
+                        return IconButton(
+                          onPressed: () {
+                            if (controller.isOpen) {
+                              controller.close();
+                            } else {
+                              controller.open();
+                            }
+                          },
+                          icon: const Icon(
+                            Icons.more_vert,
+                            color: Colors.white,
+                          ),
+                        );
+                      },
+                      menuChildren: [
+                        MenuItemButton(
+                          onPressed: () {
+                            widget.showDanmakuSwitch();
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("弹幕切换"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            showVideoInfo();
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("视频详情"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            bool needRestart = playerController.playing;
+                            playerController.pause();
+                            RemotePlay()
+                                .castVideo(context,
+                                    videoPageController.currentPlugin.referer)
+                                .whenComplete(() {
+                              if (needRestart) {
+                                playerController.play();
                               }
-                            },
-                            icon: const Icon(
-                              Icons.more_vert,
-                              color: Colors.white,
-                            ),
-                          );
-                        },
-                        menuChildren: [
-                          MenuItemButton(
-                            onPressed: () {
-                              widget.showDanmakuSwitch();
-                            },
-                            child: const Padding(
-                              padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
-                              child: Text("弹幕切换"),
-                            ),
+                            });
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("远程播放"),
                           ),
-                          MenuItemButton(
-                            onPressed: () {
-                              showVideoInfo();
-                            },
-                            child: const Padding(
-                              padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
-                              child: Text("视频详情"),
-                            ),
-                          ),
-                          MenuItemButton(
-                            onPressed: () {
-                              bool needRestart = playerController.playing;
-                              playerController.pause();
-                              RemotePlay()
-                                  .castVideo(context,
-                                      videoPageController.currentPlugin.referer)
-                                  .whenComplete(() {
-                                if (needRestart) {
-                                  playerController.play();
-                                }
-                              });
-                            },
-                            child: const Padding(
-                              padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
-                              child: Text("远程播放"),
-                            ),
-                          ),
-                        ]),
+                        ),
+                      ],
+                    ),
                   ],
                 ),
               ),
@@ -793,20 +796,22 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                   ? '关闭弹幕(d)'
                                   : '打开弹幕(d)',
                             ),
-                            IconButton(
-                              tooltip: '弹幕设置',
-                              onPressed: () {
-                                widget.keyboardFocus.requestFocus();
-                                KazumiDialog.show(builder: (context) {
-                                  return DanmakuSettingsWindow(
-                                      danmakuController:
-                                          playerController.danmakuController);
-                                });
-                              },
-                              color: Colors.white,
-                              icon: const Icon(Icons.tune_rounded),
-                            ),
-                            Expanded(child: danmakuTextField()),
+                            if (playerController.danmakuOn) ...[
+                              IconButton(
+                                tooltip: '弹幕设置',
+                                onPressed: () {
+                                  KazumiDialog.show(builder: (context) {
+                                    return DanmakuSettingsWindow(
+                                        danmakuController:
+                                            playerController.danmakuController);
+                                  });
+                                },
+                                color: Colors.white,
+                                icon: const Icon(Icons.tune_rounded),
+                              ),
+                              Expanded(child: danmakuTextField()),
+                            ],
+                            if (!playerController.danmakuOn) const Spacer(),
                           ],
                           // 超分辨率
                           MenuAnchor(
@@ -847,7 +852,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                           ? Theme.of(context)
                                               .colorScheme
                                               .primary
-                                          : Colors.white,
+                                          : null,
                                     ),
                                   ),
                                 ),
@@ -892,7 +897,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                                   ? Theme.of(context)
                                                       .colorScheme
                                                       .primary
-                                                  : Colors.white),
+                                                  : null),
                                     ),
                                   ),
                                 ),
@@ -937,7 +942,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                             ? Theme.of(context)
                                                 .colorScheme
                                                 .primary
-                                            : Colors.white),
+                                            : null),
                                   ),
                                 ),
                               ),

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -1,0 +1,631 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:kazumi/utils/utils.dart';
+import 'package:kazumi/pages/video/video_controller.dart';
+import 'package:kazumi/bean/dialog/dialog_helper.dart';
+import 'package:kazumi/pages/player/player_controller.dart';
+import 'package:saver_gallery/saver_gallery.dart';
+import 'package:flutter/services.dart';
+import 'package:kazumi/utils/remote.dart';
+import 'package:kazumi/pages/settings/danmaku/danmaku_settings_window.dart';
+import 'package:kazumi/bean/widget/collect_button.dart';
+import 'package:kazumi/pages/info/info_controller.dart';
+import 'package:kazumi/utils/constants.dart';
+import 'package:hive/hive.dart';
+import 'package:kazumi/utils/storage.dart';
+import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
+
+class SmallestPlayerItemPanel extends StatefulWidget {
+  const SmallestPlayerItemPanel({
+    super.key,
+    required this.onBackPressed,
+    required this.setPlaybackSpeed,
+    required this.showDanmakuSwitch,
+    required this.handleFullscreen,
+    required this.handleProgressBarDragStart,
+    required this.handleProgressBarDragEnd,
+    required this.animationController,
+    required this.keyboardFocus,
+    required this.handleHove,
+  });
+
+  final void Function(BuildContext) onBackPressed;
+  final Future<void> Function(double) setPlaybackSpeed;
+  final void Function() showDanmakuSwitch;
+  final void Function() handleFullscreen;
+  final void Function(ThumbDragDetails details) handleProgressBarDragStart;
+  final void Function() handleProgressBarDragEnd;
+  final void Function() handleHove;
+  final AnimationController animationController;
+  final FocusNode keyboardFocus;
+
+  @override
+  State<SmallestPlayerItemPanel> createState() =>
+      _SmallestPlayerItemPanelState();
+}
+
+class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
+  Box setting = GStorage.setting;
+  late bool haEnable;
+  late Animation<Offset> topOffsetAnimation;
+  late Animation<Offset> bottomOffsetAnimation;
+  late Animation<Offset> leftOffsetAnimation;
+  final VideoPageController videoPageController =
+      Modular.get<VideoPageController>();
+  final InfoController infoController = Modular.get<InfoController>();
+  final PlayerController playerController = Modular.get<PlayerController>();
+  final TextEditingController textController = TextEditingController();
+
+  void _handleDanmaku() {
+    if (playerController.danDanmakus.isEmpty) {
+      widget.showDanmakuSwitch();
+      return;
+    }
+    playerController.danmakuController.onClear();
+    playerController.danmakuOn = !playerController.danmakuOn;
+  }
+
+  void showVideoInfo() async {
+    String currentDemux = await Utils.getCurrentDemux();
+    KazumiDialog.show(
+        // onDismiss: () {
+        //   _focusNode.requestFocus();
+        // },
+        builder: (context) {
+      return AlertDialog(
+        title: const Text('视频详情'),
+        content: SelectableText.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: '规则: ${videoPageController.currentPlugin.name}\n'),
+              TextSpan(text: '硬件解码: ${haEnable ? '启用' : '禁用'}\n'),
+              TextSpan(text: '解复用器: $currentDemux\n'),
+              const TextSpan(text: '资源地址: '),
+              TextSpan(
+                text: playerController.videoUrl,
+              ),
+            ],
+          ),
+          style: Theme.of(context).textTheme.bodyLarge!,
+        ),
+        actions: const [
+          TextButton(onPressed: KazumiDialog.dismiss, child: Text('取消')),
+        ],
+      );
+    });
+  }
+
+  void showForwardChange() {
+    KazumiDialog.show(builder: (context) {
+      String input = "";
+      return AlertDialog(
+        title: const Text('跳过秒数'),
+        content: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+          return TextField(
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly, // 只允许输入数字
+            ],
+            decoration: InputDecoration(
+              floatingLabelBehavior:
+                  FloatingLabelBehavior.never, // 控制label的显示方式
+              labelText: playerController.forwardTime.toString(),
+            ),
+            onChanged: (value) {
+              input = value;
+            },
+          );
+        }),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => KazumiDialog.dismiss(),
+            child: Text(
+              '取消',
+              style: TextStyle(color: Theme.of(context).colorScheme.outline),
+            ),
+          ),
+          TextButton(
+            onPressed: () async {
+              if (input != "") {
+                playerController.setForwardTime(int.parse(input));
+                KazumiDialog.dismiss();
+              } else {
+                KazumiDialog.dismiss();
+              }
+            },
+            child: const Text('确定'),
+          ),
+        ],
+      );
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    topOffsetAnimation = Tween<Offset>(
+      begin: const Offset(0.0, -1.0),
+      end: const Offset(0.0, 0.0),
+    ).animate(CurvedAnimation(
+      parent: widget.animationController,
+      curve: Curves.easeInOut,
+    ));
+    bottomOffsetAnimation = Tween<Offset>(
+      begin: const Offset(0.0, 1.0),
+      end: const Offset(0.0, 0.0),
+    ).animate(CurvedAnimation(
+      parent: widget.animationController,
+      curve: Curves.easeInOut,
+    ));
+    leftOffsetAnimation = Tween<Offset>(
+      begin: const Offset(1.0, 0.0),
+      end: const Offset(0.0, 0.0),
+    ).animate(CurvedAnimation(
+      parent: widget.animationController,
+      curve: Curves.easeInOut,
+    ));
+    haEnable = setting.get(SettingBoxKey.hAenable, defaultValue: true);
+  }
+
+  Widget forwardIcon() {
+    return Tooltip(
+      message: '长按修改时间',
+      child: GestureDetector(
+        onLongPress: () => showForwardChange(),
+        child: IconButton(
+          icon: Image.asset(
+            'assets/images/forward_80.png',
+            color: Colors.white,
+            height: 24,
+          ),
+          onPressed: () {
+            playerController.seek(playerController.currentPosition +
+                Duration(seconds: playerController.forwardTime));
+          },
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Observer(builder: (context) {
+      return Stack(
+        alignment: Alignment.center,
+        children: [
+          //顶部渐变区域
+          AnimatedPositioned(
+            duration: const Duration(seconds: 1),
+            top: 0,
+            left: 0,
+            right: 0,
+            child: Visibility(
+              visible: !playerController.lockPanel,
+              child: SlideTransition(
+                position: topOffsetAnimation,
+                child: Container(
+                  height: 50,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.black.withOpacity(0.9),
+                        Colors.transparent,
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          //底部渐变区域
+          AnimatedPositioned(
+            duration: const Duration(seconds: 1),
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Visibility(
+              visible: !playerController.lockPanel,
+              child: SlideTransition(
+                position: bottomOffsetAnimation,
+                child: Container(
+                  height: 50,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.transparent,
+                        Colors.black.withOpacity(0.9),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          // 顶部进度条
+          Positioned(
+              top: 25,
+              child: playerController.showSeekTime
+                  ? Wrap(
+                      alignment: WrapAlignment.center,
+                      children: <Widget>[
+                        Container(
+                          padding: const EdgeInsets.all(8.0),
+                          decoration: BoxDecoration(
+                            color: Colors.black54,
+                            borderRadius: BorderRadius.circular(8.0), // 圆角
+                          ),
+                          child: Text(
+                            playerController.currentPosition.compareTo(
+                                        playerController.playerPosition) >
+                                    0
+                                ? '快进 ${playerController.currentPosition.inSeconds - playerController.playerPosition.inSeconds} 秒'
+                                : '快退 ${playerController.playerPosition.inSeconds - playerController.currentPosition.inSeconds} 秒',
+                            style: const TextStyle(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                  : Container()),
+          // 顶部播放速度条
+          Positioned(
+              top: 25,
+              child: playerController.showPlaySpeed
+                  ? Wrap(
+                      alignment: WrapAlignment.center,
+                      children: <Widget>[
+                        Container(
+                          padding: const EdgeInsets.all(8.0),
+                          decoration: BoxDecoration(
+                            color: Colors.black54,
+                            borderRadius: BorderRadius.circular(8.0), // 圆角
+                          ),
+                          child: const Row(
+                            children: <Widget>[
+                              Icon(Icons.fast_forward, color: Colors.white),
+                              Text(
+                                ' 倍速播放',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    )
+                  : Container()),
+          // 亮度条
+          Positioned(
+              top: 25,
+              child: playerController.showBrightness
+                  ? Wrap(
+                      alignment: WrapAlignment.center,
+                      children: <Widget>[
+                        Container(
+                            padding: const EdgeInsets.all(8.0),
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(8.0), // 圆角
+                            ),
+                            child: Row(
+                              children: <Widget>[
+                                const Icon(Icons.brightness_7,
+                                    color: Colors.white),
+                                Text(
+                                  ' ${(playerController.brightness * 100).toInt()} %',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ],
+                            )),
+                      ],
+                    )
+                  : Container()),
+          // 音量条
+          Positioned(
+              top: 25,
+              child: playerController.showVolume
+                  ? Wrap(
+                      alignment: WrapAlignment.center,
+                      children: <Widget>[
+                        Container(
+                            padding: const EdgeInsets.all(8.0),
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(8.0), // 圆角
+                            ),
+                            child: Row(
+                              children: <Widget>[
+                                const Icon(Icons.volume_down,
+                                    color: Colors.white),
+                                Text(
+                                  ' ${playerController.volume.toInt()}%',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ],
+                            )),
+                      ],
+                    )
+                  : Container()),
+          // 自定义顶部组件
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: Visibility(
+              visible: !playerController.lockPanel,
+              child: SlideTransition(
+                position: topOffsetAnimation,
+                child: Row(
+                  children: [
+                    IconButton(
+                      color: Colors.white,
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      onPressed: () {
+                        widget.onBackPressed(context);
+                      },
+                    ),
+                    const Spacer(),
+                    // 跳过
+                    forwardIcon(),
+                    // 弹幕开关
+                    IconButton(
+                      color: Colors.white,
+                      icon: Icon(playerController.danmakuOn
+                          ? Icons.subtitles_rounded
+                          : Icons.subtitles_off_rounded),
+                      onPressed: () {
+                        _handleDanmaku();
+                        setState(() {});
+                      },
+                      tooltip: playerController.danmakuOn ? '关闭弹幕' : '打开弹幕',
+                    ),
+                    // 追番
+                    CollectButton(bangumiItem: infoController.bangumiItem),
+                    MenuAnchor(
+                      builder: (BuildContext context, MenuController controller,
+                          Widget? child) {
+                        return IconButton(
+                          onPressed: () {
+                            if (controller.isOpen) {
+                              controller.close();
+                            } else {
+                              controller.open();
+                            }
+                          },
+                          icon: const Icon(
+                            Icons.more_vert,
+                            color: Colors.white,
+                          ),
+                        );
+                      },
+                      menuChildren: [
+                        SubmenuButton(
+                          menuChildren: List<MenuItemButton>.generate(
+                            3,
+                            (int index) => MenuItemButton(
+                              onPressed: () =>
+                                  playerController.aspectRatioType = index + 1,
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(0, 10, 10, 10),
+                                child: Text(
+                                  index + 1 == 1
+                                      ? '自动'
+                                      : index + 1 == 2
+                                          ? '裁切填充'
+                                          : '拉伸填充',
+                                  style: TextStyle(
+                                      color: index + 1 ==
+                                              playerController.aspectRatioType
+                                          ? Theme.of(context)
+                                              .colorScheme
+                                              .primary
+                                          : null),
+                                ),
+                              ),
+                            ),
+                          ),
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("视频比例"),
+                          ),
+                        ),
+                        SubmenuButton(
+                          menuChildren: [
+                            for (final double i
+                                in defaultPlaySpeedList) ...<MenuItemButton>[
+                              MenuItemButton(
+                                onPressed: () async {
+                                  await widget.setPlaybackSpeed(i);
+                                },
+                                child: Padding(
+                                  padding:
+                                      const EdgeInsets.fromLTRB(0, 10, 10, 10),
+                                  child: Text(
+                                    '${i}x',
+                                    style: TextStyle(
+                                        color: i == playerController.playerSpeed
+                                            ? Theme.of(context)
+                                                .colorScheme
+                                                .primary
+                                            : null),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("倍速"),
+                          ),
+                        ),
+                        SubmenuButton(
+                          menuChildren: List<MenuItemButton>.generate(
+                            3,
+                            (int index) => MenuItemButton(
+                              onPressed: () =>
+                                  playerController.setShader(index + 1),
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(0, 10, 10, 10),
+                                child: Text(
+                                  index + 1 == 1
+                                      ? '关闭'
+                                      : index + 1 == 2
+                                          ? '效率档'
+                                          : '质量档',
+                                  style: TextStyle(
+                                    color: playerController
+                                                .superResolutionType ==
+                                            index + 1
+                                        ? Theme.of(context).colorScheme.primary
+                                        : null,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("超分辨率"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            widget.showDanmakuSwitch();
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("弹幕切换"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            KazumiDialog.show(builder: (context) {
+                              return DanmakuSettingsWindow(
+                                  danmakuController:
+                                      playerController.danmakuController);
+                            });
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("弹幕设置"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            showVideoInfo();
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("视频详情"),
+                          ),
+                        ),
+                        MenuItemButton(
+                          onPressed: () {
+                            bool needRestart = playerController.playing;
+                            playerController.pause();
+                            RemotePlay()
+                                .castVideo(context,
+                                    videoPageController.currentPlugin.referer)
+                                .whenComplete(() {
+                              if (needRestart) {
+                                playerController.play();
+                              }
+                            });
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(0, 10, 10, 10),
+                            child: Text("远程播放"),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          // 自定义播放器底部组件
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Visibility(
+              visible: !playerController.lockPanel,
+              child: SlideTransition(
+                position: bottomOffsetAnimation,
+                child: Row(
+                  children: [
+                    IconButton(
+                      color: Colors.white,
+                      icon: Icon(playerController.playing
+                          ? Icons.pause_rounded
+                          : Icons.play_arrow_rounded),
+                      onPressed: () {
+                        playerController.playOrPause();
+                      },
+                    ),
+                    Expanded(
+                      child: ProgressBar(
+                        thumbRadius: 8,
+                        thumbGlowRadius: 18,
+                        timeLabelLocation: TimeLabelLocation.none,
+                        progress: playerController.currentPosition,
+                        buffered: playerController.buffer,
+                        total: playerController.duration,
+                        onSeek: (duration) {
+                          playerController.seek(duration);
+                        },
+                        onDragStart: (details) {
+                          widget.handleProgressBarDragStart(details);
+                        },
+                        onDragUpdate: (details) => {
+                          playerController.currentPosition = details.timeStamp
+                        },
+                        onDragEnd: () {
+                          widget.handleProgressBarDragEnd();
+                        },
+                      ),
+                    ),
+                    Text(
+                      "    ${Utils.durationToString(playerController.currentPosition)} / ${Utils.durationToString(playerController.duration)}",
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12.0,
+                        fontFeatures: [
+                          FontFeature.tabularFigures(),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      color: Colors.white,
+                      icon: Icon(videoPageController.isFullscreen
+                          ? Icons.fullscreen_exit_rounded
+                          : Icons.fullscreen_rounded),
+                      onPressed: () {
+                        widget.handleFullscreen();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    });
+  }
+}

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -238,7 +238,7 @@ class _VideoPageState extends State<VideoPage>
     }
     // Todo 接口方限制
 
-    KazumiDialog.showToast(message: '发送成功 $msg');
+    KazumiDialog.showToast(message: '发送成功');
     playerController.danmakuController
         .addDanmaku(DanmakuContentItem(msg, selfSend: true));
   }
@@ -836,50 +836,47 @@ class _VideoPageState extends State<VideoPage>
                 ),
                 if (!Utils.isDesktop() && !Utils.isTablet()) ...[
                   const Spacer(),
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
+                  Container(
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(25),
                       border: Border.all(
-                        color: Theme.of(context).dividerColor,
+                        color: playerController.danmakuOn
+                            ? Theme.of(context).hintColor
+                            : Theme.of(context).disabledColor,
                         width: 0.5,
                       ),
                     ),
-                    width: playerController.danmakuOn ? 120 : 41,
+                    width: 120,
                     height: 31,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        if (playerController.danmakuOn)
-                          Expanded(
-                            child: GestureDetector(
-                              onTap: () {
-                                showMobileDanmakuInput();
-                              },
-                              child: Text(
-                                '  点我发弹幕',
-                                softWrap: false,
-                                overflow: TextOverflow.clip,
-                                style: TextStyle(
-                                  color: Theme.of(context).colorScheme.outline,
-                                ),
-                              ),
+                    child: GestureDetector(
+                      onTap: () {
+                        if (playerController.danmakuOn) {
+                          showMobileDanmakuInput();
+                        } else {
+                          KazumiDialog.showToast(message: '请先打开弹幕');
+                        }
+                      },
+                      child: Row(
+                        children: [
+                          Text(
+                            '  点我发弹幕  ',
+                            softWrap: false,
+                            overflow: TextOverflow.clip,
+                            style: TextStyle(
+                              color: playerController.danmakuOn
+                                  ? Theme.of(context).hintColor
+                                  : Theme.of(context).disabledColor,
                             ),
                           ),
-                        IconButton(
-                          iconSize: 20,
-                          visualDensity: VisualDensity.compact,
-                          onPressed: () {
-                            playerController.danmakuOn =
-                                !playerController.danmakuOn;
-                          },
-                          icon: Icon(
-                            playerController.danmakuOn
-                                ? Icons.subtitles
-                                : Icons.subtitles_off_rounded,
+                          Icon(
+                            Icons.send_rounded,
+                            size: 20,
+                            color: playerController.danmakuOn
+                                ? Theme.of(context).hintColor
+                                : Theme.of(context).disabledColor,
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ],

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:canvas_danmaku/models/danmaku_content_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
@@ -217,6 +218,91 @@ class _VideoPageState extends State<VideoPage>
       videoPageController.isFullscreen = false;
     }
     Navigator.of(context).pop();
+  }
+
+  /// 发送弹幕 由于接口限制, 暂时未提交云端
+  void sendDanmaku(String msg) async {
+    keyboardFocus.requestFocus();
+    if (playerController.danDanmakus.isEmpty) {
+      KazumiDialog.showToast(
+        message: '当前剧集不支持弹幕发送的说',
+      );
+      return;
+    }
+    if (msg.isEmpty) {
+      KazumiDialog.showToast(message: '弹幕内容为空');
+      return;
+    } else if (msg.length > 100) {
+      KazumiDialog.showToast(message: '弹幕内容过长');
+      return;
+    }
+    // Todo 接口方限制
+
+    KazumiDialog.showToast(message: '发送成功 $msg');
+    playerController.danmakuController
+        .addDanmaku(DanmakuContentItem(msg, selfSend: true));
+  }
+
+  void showMobileDanmakuInput() {
+    final TextEditingController textController = TextEditingController();
+    showModalBottomSheet(
+      shape: const BeveledRectangleBorder(),
+      isScrollControlled: true,
+      context: context,
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom,
+            left: 8,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Container(
+                  constraints: const BoxConstraints(maxHeight: 34),
+                  child: TextField(
+                    style: const TextStyle(fontSize: 15),
+                    controller: textController,
+                    autofocus: true,
+                    textAlignVertical: TextAlignVertical.center,
+                    decoration: const InputDecoration(
+                      filled: true,
+                      floatingLabelBehavior: FloatingLabelBehavior.never,
+                      hintText: '发个友善的弹幕见证当下',
+                      hintStyle: TextStyle(fontSize: 14),
+                      alignLabelWithHint: true,
+                      contentPadding:
+                          EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                      border: OutlineInputBorder(
+                        borderSide: BorderSide.none,
+                        borderRadius: BorderRadius.all(Radius.circular(20)),
+                      ),
+                    ),
+                    onSubmitted: (msg) {
+                      sendDanmaku(msg);
+                      textController.clear();
+                      Navigator.pop(context);
+                    },
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () {
+                  sendDanmaku(textController.text);
+                  textController.clear();
+                  Navigator.pop(context);
+                },
+                icon: Icon(
+                  Icons.send_rounded,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              )
+            ],
+          ),
+        );
+      },
+    );
   }
 
   @override
@@ -526,6 +612,7 @@ class _VideoPageState extends State<VideoPage>
                   changeEpisode: changeEpisode,
                   onBackPressed: onBackPressed,
                   keyboardFocus: keyboardFocus,
+                  sendDanmaku: sendDanmaku,
                 ),
         ),
 
@@ -729,22 +816,77 @@ class _VideoPageState extends State<VideoPage>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            TabBar(
-              dividerHeight: Utils.isDesktop() ? 0.5 : 0.2,
-              isScrollable: true,
-              tabAlignment: TabAlignment.start,
-              labelPadding:
-                  const EdgeInsetsDirectional.only(start: 30, end: 30),
-              onTap: (index) {
-                if (index == 0) {
-                  menuJumpToCurrentEpisode();
-                }
-              },
-              tabs: const [
-                Tab(text: '选集'),
-                Tab(text: '评论'),
+            Row(
+              children: [
+                TabBar(
+                  dividerHeight: 0,
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.start,
+                  labelPadding:
+                      const EdgeInsetsDirectional.only(start: 30, end: 30),
+                  onTap: (index) {
+                    if (index == 0) {
+                      menuJumpToCurrentEpisode();
+                    }
+                  },
+                  tabs: const [
+                    Tab(text: '选集'),
+                    Tab(text: '评论'),
+                  ],
+                ),
+                if (!Utils.isDesktop() && !Utils.isTablet()) ...[
+                  const Spacer(),
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(25),
+                      border: Border.all(
+                        color: Theme.of(context).dividerColor,
+                        width: 0.5,
+                      ),
+                    ),
+                    width: playerController.danmakuOn ? 120 : 41,
+                    height: 31,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        if (playerController.danmakuOn)
+                          Expanded(
+                            child: GestureDetector(
+                              onTap: () {
+                                showMobileDanmakuInput();
+                              },
+                              child: Text(
+                                '  点我发弹幕',
+                                softWrap: false,
+                                overflow: TextOverflow.clip,
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.outline,
+                                ),
+                              ),
+                            ),
+                          ),
+                        IconButton(
+                          iconSize: 20,
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () {
+                            playerController.danmakuOn =
+                                !playerController.danmakuOn;
+                          },
+                          icon: Icon(
+                            playerController.danmakuOn
+                                ? Icons.subtitles
+                                : Icons.subtitles_off_rounded,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+                const SizedBox(width: 8),
               ],
             ),
+            Divider(height: Utils.isDesktop() ? 0.5 : 0.2),
             Expanded(
               child: TabBarView(
                 children: [

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -238,7 +238,6 @@ class _VideoPageState extends State<VideoPage>
     }
     // Todo 接口方限制
 
-    KazumiDialog.showToast(message: '发送成功');
     playerController.danmakuController
         .addDanmaku(DanmakuContentItem(msg, selfSend: true));
   }


### PR DESCRIPTION
要修改的东西非常多，目前只改了 PC 端的界面，先传上来 review 一下，多平台的适配后面再慢慢改，有可能需要复制一份 player_item_panel.dart 单独展示手机端的界面

PopUpMenuButton 官方文档推荐改为使用 MenuAnchor，我试了一下 hover 的 highlight 看着好看了很多，于是我全部改了（


https://github.com/user-attachments/assets/492aaafa-fecf-490d-956c-b1aa6fc1ba25


https://github.com/user-attachments/assets/09dfa57e-20fd-45c2-a59e-892e95f3eacf

