### PR TITLE
optimize panel hide logic

### DIFF
--- a/lib/bean/widget/collect_button.dart
+++ b/lib/bean/widget/collect_button.dart
@@ -4,11 +4,18 @@ import 'package:kazumi/pages/collect/collect_controller.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class CollectButton extends StatefulWidget {
-  const CollectButton(
-      {super.key, required this.bangumiItem, this.color = Colors.white});
+  const CollectButton({
+    super.key,
+    required this.bangumiItem,
+    this.color = Colors.white,
+    this.onOpen,
+    this.onClose,
+  });
 
   final BangumiItem bangumiItem;
   final Color color;
+  final void Function()? onOpen;
+  final void Function()? onClose;
 
   @override
   State<CollectButton> createState() => _CollectButtonState();
@@ -67,6 +74,8 @@ class _CollectButtonState extends State<CollectButton> {
     collectType = collectController.getCollectType(widget.bangumiItem);
     return MenuAnchor(
       consumeOutsideTap: true,
+      onClose: widget.onClose,
+      onOpen: widget.onOpen,
       builder:
           (BuildContext context, MenuController controller, Widget? child) {
         return IconButton(

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -70,6 +70,8 @@ abstract class _PlayerController with Store {
   bool brightnessSeeking = false;
   @observable
   bool volumeSeeking = false;
+  @observable
+  bool canHidePlayerPanel = true;
 
   // 视频地址
   String videoUrl = '';

--- a/lib/pages/player/player_controller.g.dart
+++ b/lib/pages/player/player_controller.g.dart
@@ -233,6 +233,22 @@ mixin _$PlayerController on _PlayerController, Store {
     });
   }
 
+  late final _$canHidePlayerPanelAtom =
+      Atom(name: '_PlayerController.canHidePlayerPanel', context: context);
+
+  @override
+  bool get canHidePlayerPanel {
+    _$canHidePlayerPanelAtom.reportRead();
+    return super.canHidePlayerPanel;
+  }
+
+  @override
+  set canHidePlayerPanel(bool value) {
+    _$canHidePlayerPanelAtom.reportWrite(value, super.canHidePlayerPanel, () {
+      super.canHidePlayerPanel = value;
+    });
+  }
+
   late final _$loadingAtom =
       Atom(name: '_PlayerController.loading', context: context);
 
@@ -378,6 +394,7 @@ showVolume: ${showVolume},
 showPlaySpeed: ${showPlaySpeed},
 brightnessSeeking: ${brightnessSeeking},
 volumeSeeking: ${volumeSeeking},
+canHidePlayerPanel: ${canHidePlayerPanel},
 loading: ${loading},
 playing: ${playing},
 isBuffering: ${isBuffering},

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -28,6 +28,8 @@ class SmallestPlayerItemPanel extends StatefulWidget {
     required this.animationController,
     required this.keyboardFocus,
     required this.handleHove,
+    required this.startHideTimer,
+    required this.cancelHideTimer,
   });
 
   final void Function(BuildContext) onBackPressed;
@@ -39,6 +41,8 @@ class SmallestPlayerItemPanel extends StatefulWidget {
   final void Function() handleHove;
   final AnimationController animationController;
   final FocusNode keyboardFocus;
+  final void Function() startHideTimer;
+  final void Function() cancelHideTimer;
 
   @override
   State<SmallestPlayerItemPanel> createState() =>
@@ -206,12 +210,12 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                 position: topOffsetAnimation,
                 child: Container(
                   height: 50,
-                  decoration: BoxDecoration(
+                  decoration: const BoxDecoration(
                     gradient: LinearGradient(
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,
                       colors: [
-                        Colors.black.withOpacity(0.9),
+                        Colors.black87,
                         Colors.transparent,
                       ],
                     ),
@@ -233,13 +237,13 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                 position: bottomOffsetAnimation,
                 child: Container(
                   height: 50,
-                  decoration: BoxDecoration(
+                  decoration: const BoxDecoration(
                     gradient: LinearGradient(
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,
                       colors: [
                         Colors.transparent,
-                        Colors.black.withOpacity(0.9),
+                        Colors.black87,
                       ],
                     ),
                   ),
@@ -392,9 +396,29 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                       tooltip: playerController.danmakuOn ? '关闭弹幕' : '打开弹幕',
                     ),
                     // 追番
-                    CollectButton(bangumiItem: infoController.bangumiItem),
+                    CollectButton(
+                      bangumiItem: infoController.bangumiItem,
+                      onOpen: () {
+                        widget.cancelHideTimer();
+                        playerController.canHidePlayerPanel = false;
+                      },
+                      onClose: () {
+                        widget.cancelHideTimer();
+                        widget.startHideTimer();
+                        playerController.canHidePlayerPanel = true;
+                      },
+                    ),
                     MenuAnchor(
                       consumeOutsideTap: true,
+                      onOpen: () {
+                        widget.cancelHideTimer();
+                        playerController.canHidePlayerPanel = false;
+                      },
+                      onClose: () {
+                        widget.cancelHideTimer();
+                        widget.startHideTimer();
+                        playerController.canHidePlayerPanel = true;
+                      },
                       builder: (BuildContext context, MenuController controller,
                           Widget? child) {
                         return IconButton(

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -861,7 +861,9 @@ class _VideoPageState extends State<VideoPage>
                       child: Row(
                         children: [
                           Text(
-                            '  点我发弹幕  ',
+                            playerController.danmakuOn
+                                ? '  点我发弹幕  '
+                                : '  已关闭弹幕  ',
                             softWrap: false,
                             overflow: TextOverflow.clip,
                             style: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,14 +22,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.0"
-  ansicolor:
-    dependency: transitive
-    description:
-      name: ansicolor
-      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
   archive:
     dependency: transitive
     description:
@@ -473,14 +465,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.4"
-  flutter_native_splash:
-    dependency: "direct dev"
-    description:
-      name: flutter_native_splash
-      sha256: "1152ab0067ca5a2ebeb862fe0a762057202cceb22b7e62692dcbabf6483891bb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -157,7 +157,7 @@ dev_dependencies:
   mobx_codegen: ^2.3.0
   hive_generator: ^2.0.0
   flutter_launcher_icons: "^0.13.1"
-  flutter_native_splash: ^2.4.3
+#  flutter_native_splash: ^2.4.3
   msix: ^3.16.8
   
 
@@ -182,14 +182,14 @@ flutter_launcher_icons:
     image_path: assets/images/logo/logo_rounded.png
     icon_size: 256 # min:48, max:256, default: 48
 
-flutter_native_splash:
-  android: false
-  ios: true
-  web: false
-  color_ios: "#ffffff"
-  color_dark_ios: "#212121"
-  image_ios: assets/images/logo/logo_ios.png
-  image_dark_ios: assets/images/logo/logo_ios.png
+#flutter_native_splash:
+#  android: false
+#  ios: true
+#  web: false
+#  color_ios: "#ffffff"
+#  color_dark_ios: "#212121"
+#  image_ios: assets/images/logo/logo_ios.png
+#  image_dark_ios: assets/images/logo/logo_ios.png
 
 msix_config:
   display_name: Kazumi


### PR DESCRIPTION
Xcode 升级完罢工了，CocoaPod broken。

电脑端因为升级前就一直开着软件所以 hot reload 可以调试，手机端直接调不了了

最令我无语的是不知道为什么安卓也调试失败了 :(

电脑端应该没啥问题，鼠标进入 player panel 后不会隐藏，打开 MenuAnchor 禁止隐藏，关闭时恢复