### PR TITLE
remove keepAlive in comments sheet

### DIFF
--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -15,11 +15,21 @@ class EpisodeCommentsSheet extends StatefulWidget {
   State<EpisodeCommentsSheet> createState() => _EpisodeCommentsSheetState();
 }
 
-class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet>
-    with AutomaticKeepAliveClientMixin {
+class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   final infoController = Modular.get<InfoController>();
   bool isLoading = false;
   bool commentsQueryTimeout = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (infoController.episodeCommentsList.isEmpty) {
+      setState(() {
+        isLoading = true;
+      });
+      loadComments(widget.episode);
+    }
+  }
 
   Future<void> loadComments(int episode) async {
     commentsQueryTimeout = false;
@@ -46,12 +56,6 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet>
   }
 
   Widget get episodeCommentsBody {
-    if (infoController.episodeCommentsList.isEmpty) {
-      setState(() {
-        isLoading = true;
-      });
-      loadComments(widget.episode);
-    }
     return CustomScrollView(
       // Scrollbars' movement is not linear so hide it.
       scrollBehavior: const ScrollBehavior().copyWith(scrollbars: false),
@@ -203,7 +207,6 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     return Scaffold(
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -211,7 +214,4 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet>
       ),
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }


### PR DESCRIPTION
还是不能用 AutomaticKeepAliveClientMixin 。吃一堑吃一堑（

手机端切集后会自动获取评论并加载一页，而不是 tab 切过去才获取

它在 ohos 上的表现和安卓，iOS 上的表现也会不一样，切集完全不会重新加载，应该有其他地方的原因