### PR TITLE
mod: pip tap logic and appearance

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -130,7 +130,7 @@ class _PlayerItemState extends State<PlayerItem>
   }
 
   void _handleDoubleTap() {
-    if (Utils.isDesktop()) {
+    if (Utils.isDesktop() && !videoPageController.isPip) {
       handleFullscreen();
     } else {
       playerController.playOrPause();
@@ -685,7 +685,9 @@ class _PlayerItemState extends State<PlayerItem>
                                 // F键被按下
                                 if (event.logicalKey ==
                                     LogicalKeyboardKey.keyF) {
-                                  handleFullscreen();
+                                  if (!videoPageController.isPip) {
+                                    handleFullscreen();
+                                  }
                                 }
                                 // D键盘被按下
                                 if (event.logicalKey ==

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -651,16 +651,17 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                         ],
                       ),
                     ),
-                    if (!videoPageController.isPip)
-                      IconButton(
-                        color: Colors.white,
-                        icon: Icon(videoPageController.isFullscreen
-                            ? Icons.fullscreen_exit_rounded
-                            : Icons.fullscreen_rounded),
-                        onPressed: () {
-                          widget.handleFullscreen();
-                        },
-                      ),
+                    (!videoPageController.isPip)
+                        ? IconButton(
+                            color: Colors.white,
+                            icon: Icon(videoPageController.isFullscreen
+                                ? Icons.fullscreen_exit_rounded
+                                : Icons.fullscreen_rounded),
+                            onPressed: () {
+                              widget.handleFullscreen();
+                            },
+                          )
+                        : const Text('    '),
                   ],
                 ),
               ),

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -23,19 +23,19 @@ abstract class _VideoPageController with Store {
   @observable
   int currentRoad = 0;
 
-  // 全屏状态
+  /// 全屏状态
   @observable
   bool isFullscreen = false;
 
-  // PIP状态
+  /// 画中画状态
   @observable
   bool isPip = false;
 
-  // 播放列表显示状态
+  /// 播放列表显示状态
   @observable
   bool showTabBody = true;
 
-  // 上次观看位置
+  /// 上次观看位置
   @observable
   int historyOffset = 0;
 


### PR DESCRIPTION
- 画中画模式时禁用双击全屏和快捷键全屏
- 画中画模式时底部时间指示器右侧没有 padding
- 修改了 videoPageController 的注释，`PIP 模式` 一开始我没看懂是什么

另外为什么画中画模式禁止修改窗口大小？有时候觉得太大或者太小会想要修改一下大小