### PR TITLE
fix status bar

### DIFF
--- a/lib/bean/appbar/sys_app_bar.dart
+++ b/lib/bean/appbar/sys_app_bar.dart
@@ -76,6 +76,7 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
           elevation: elevation,
           shape: shape,
           bottom: bottom,
+          forceMaterialTransparency: Platform.isMacOS ? true : false,
           systemOverlayStyle: SystemUiOverlayStyle(
             statusBarColor: Colors.transparent,
             statusBarIconBrightness:

--- a/lib/bean/widget/embedded_native_control_area.dart
+++ b/lib/bean/widget/embedded_native_control_area.dart
@@ -39,12 +39,8 @@ class _EmbeddedNativeControlAreaState extends State<EmbeddedNativeControlArea> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      left: false,
-      top: true,
-      right: false,
-      bottom: false,
-      minimum: getInsets,
+    return Padding(
+      padding: getInsets,
       child: widget.child,
     );
   }

--- a/lib/pages/settings/decoder_settings.dart
+++ b/lib/pages/settings/decoder_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:card_settings_ui/card_settings_ui.dart';
@@ -20,8 +21,8 @@ class _DecoderSettingsState extends State<DecoderSettings> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('硬件解码器'),
+      appBar: const SysAppBar(
+        title: Text('硬件解码器'),
       ),
       body: Center(
         child: SizedBox(

--- a/lib/pages/settings/super_resolution_settings.dart
+++ b/lib/pages/settings/super_resolution_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:card_settings_ui/card_settings_ui.dart';
 
@@ -22,8 +23,8 @@ class _SuperResolutionSettingsState extends State<SuperResolutionSettings> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('超分辨率'),
+      appBar: const SysAppBar(
+        title: Text('超分辨率'),
       ),
       body: Center(
         child: SizedBox(


### PR DESCRIPTION
没注意手机端的问题，safearea 会导致滚动区域的 statusbar 的颜色和 appbar 不一致，ohos 的 statusbar 上的 icon 颜色会出错

![telegram-cloud-photo-size-5-6138791637028029350-y](https://github.com/user-attachments/assets/87d5e43d-1ad9-4721-9286-78fb9fec7a64)

<img width="355" alt="image" src="https://github.com/user-attachments/assets/07609899-17bb-41dc-9627-231b14718249" />

macOS 的差色问题解决不了，唯一的办法是 `forceMaterialTransparency: true,` 也就是滚动区域滑动到 appbar 底下时不变色，但是这不符合 material 3 规范

<img width="265" alt="image" src="https://github.com/user-attachments/assets/fcf05f0a-b2cc-4d21-bf3f-1b7a674084e1" />

<img width="331" alt="image" src="https://github.com/user-attachments/assets/ccd1d4d1-80ba-49c5-8f26-ce871d6e1154" />
