### PR TITLE
chore: use size to decide which panel is used

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -799,9 +799,7 @@ class _PlayerItemState extends State<PlayerItem>
                       ),
                     ),
                     // 播放器控制面板
-                    ((Utils.isDesktop() && !videoPageController.isPip) ||
-                            Utils.isTablet() ||
-                            videoPageController.isFullscreen)
+                    (MediaQuery.of(context).size.width >= 600)
                         ? PlayerItemPanel(
                             onBackPressed: widget.onBackPressed,
                             setPlaybackSpeed: setPlaybackSpeed,

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -582,27 +582,27 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                             widget.onBackPressed(context);
                           },
                         ),
-                        (videoPageController.isFullscreen || Utils.isDesktop())
-                            ? Text(
-                                ' ${videoPageController.title} [${videoPageController.roadList[videoPageController.currentRoad].identifier[videoPageController.currentEpisode - 1]}]',
-                                style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: Theme.of(context)
-                                        .textTheme
-                                        .titleMedium!
-                                        .fontSize),
-                              )
-                            : Container(),
                         // 拖动条
-                        const Expanded(
-                          child:
-                              dtb.DragToMoveArea(child: SizedBox(height: 40)),
+                        Expanded(
+                          child: dtb.DragToMoveArea(
+                            child: Text(
+                              ' ${videoPageController.title} [${videoPageController.roadList[videoPageController.currentRoad].identifier[videoPageController.currentEpisode - 1]}]',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium!
+                                    .fontSize,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ),
                         ),
                         // 跳过
                         forwardIcon(),
                         if (Utils.isDesktop() &&
-                          !videoPageController.isFullscreen)
-                        IconButton(
+                            !videoPageController.isFullscreen)
+                          IconButton(
                             onPressed: () {
                               if (videoPageController.isPip) {
                                 Utils.exitDesktopPIPWindow();
@@ -612,8 +612,11 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                               videoPageController.isPip =
                                   !videoPageController.isPip;
                             },
-                            icon: const Icon(Icons.picture_in_picture,
-                                color: Colors.white)),
+                            icon: const Icon(
+                              Icons.picture_in_picture,
+                              color: Colors.white,
+                            ),
+                          ),
                         // 追番
                         CollectButton(
                           bangumiItem: infoController.bangumiItem,


### PR DESCRIPTION
PR 的起因是 ohos 的小窗横屏需要用最小面板，所以用 size 代替判断

应该没啥问题，600 是 material 3 的 compact layout breakpoint

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/fd23fa16-3465-41c3-bb81-a761e4ee874b" />

把 Text 放 DragToMoveArea 里解决选集名称太长导致的溢出问题和无法拖动窗口的问题