### PR TITLE
fix: fix exceptions thrown from windowManager

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -39,8 +39,10 @@ class _AppWidgetState extends State<AppWidget>
   }
 
   void setPreventClose() async {
-    await windowManager.setPreventClose(true);
-    setState(() {});
+    if (Utils.isDesktop()) {
+      await windowManager.setPreventClose(true);
+      setState(() {});
+    }
   }
 
   @override

--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -280,6 +280,7 @@ class _AppWidgetState extends State<AppWidget>
         );
       },
     );
+    Modular.setObservers([KazumiDialog.observer]);
 
     // 强制设置高帧率
     if (Platform.isAndroid) {

--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -280,7 +280,6 @@ class _AppWidgetState extends State<AppWidget>
         );
       },
     );
-    Modular.setObservers([KazumiDialog.observer]);
 
     // 强制设置高帧率
     if (Platform.isAndroid) {

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -122,6 +122,9 @@ class _InitPageState extends State<InitPage> {
       // setDynamic here to avoid white screen flash when themeMode is dark.
       themeProvider.setDynamic(
           setting.get(SettingBoxKey.useDynamicColor, defaultValue: false));
+      // Workaround. Put this in app_widget will throw exception.
+      Modular.setObservers([KazumiDialog.observer]);
+      // Navigate to popular_page
       Modular.to.navigate('/tab/popular/');
     }
   }

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -122,9 +122,6 @@ class _InitPageState extends State<InitPage> {
       // setDynamic here to avoid white screen flash when themeMode is dark.
       themeProvider.setDynamic(
           setting.get(SettingBoxKey.useDynamicColor, defaultValue: false));
-      // Workaround. Put this in app_widget will throw exception.
-      Modular.setObservers([KazumiDialog.observer]);
-      // Navigate to popular_page
       Modular.to.navigate('/tab/popular/');
     }
   }

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -86,7 +86,9 @@ abstract class _VideoPageController with Store {
   }
 
   void isDesktopFullscreen() async {
-    isFullscreen = await windowManager.isFullScreen();
+    if (Utils.isDesktop()) {
+      isFullscreen = await windowManager.isFullScreen();
+    }
   }
 
   void handleOnEnterFullScreen() async {


### PR DESCRIPTION
Modular.setObservers([KazumiDialog.observer]); 貌似会报错，和之前动态取色类似的错误。
```
setState() or markNeedsBuild() called during build.
This ScaffoldMessenger widget cannot be marked as needing to build because the framework is already in the process of building widgets. A widget can be marked as needing to be built during the build phase only if one of its ancestors is currently building. This exception is allowed because the framework builds parent widgets before children, which means a dirty descendant will always be built. Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  ScaffoldMessenger
The widget which was currently being built when the offending call was made was:
  Builder
```