### PR TITLE
fix(danmaku): cannot close danmaku if danmaku become empty after search

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -167,14 +167,23 @@ class _PlayerItemState extends State<PlayerItem>
     });
   }
 
-  void _handleDanmaku() {
+  void handleDanmaku() {
+    danmakuController.clear();
+    // if true, turn off danmaku.
+    if (playerController.danmakuOn) {
+      setState(() {
+        playerController.danmakuOn = false;
+      });
+      return;
+    }
+    // if false and empty, show dialog.
     if (playerController.danDanmakus.isEmpty) {
       showDanmakuSwitch();
       return;
     }
-    danmakuController.clear();
+    // turn on danmaku.
     setState(() {
-      playerController.danmakuOn = !playerController.danmakuOn;
+      playerController.danmakuOn = true;
     });
   }
 
@@ -692,7 +701,7 @@ class _PlayerItemState extends State<PlayerItem>
                                 // D键盘被按下
                                 if (event.logicalKey ==
                                     LogicalKeyboardKey.keyD) {
-                                  _handleDanmaku();
+                                  handleDanmaku();
                                 }
                               } else if (event is KeyRepeatEvent) {
                                 // 右方向键长按
@@ -815,6 +824,7 @@ class _PlayerItemState extends State<PlayerItem>
                             sendDanmaku: widget.sendDanmaku,
                             startHideTimer: startHideTimer,
                             cancelHideTimer: cancelHideTimer,
+                            handleDanmaku: handleDanmaku,
                           )
                         : SmallestPlayerItemPanel(
                             onBackPressed: widget.onBackPressed,
@@ -829,6 +839,7 @@ class _PlayerItemState extends State<PlayerItem>
                             handleHove: _handleHove,
                             startHideTimer: startHideTimer,
                             cancelHideTimer: cancelHideTimer,
+                            handleDanmaku: handleDanmaku,
                           ),
                     // 播放器手势控制
                     Positioned.fill(

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -34,6 +34,7 @@ class PlayerItemPanel extends StatefulWidget {
     required this.sendDanmaku,
     required this.startHideTimer,
     required this.cancelHideTimer,
+    required this.handleDanmaku,
   });
 
   final void Function(BuildContext) onBackPressed;
@@ -48,6 +49,7 @@ class PlayerItemPanel extends StatefulWidget {
   final FocusNode keyboardFocus;
   final void Function() startHideTimer;
   final void Function() cancelHideTimer;
+  final void Function() handleDanmaku;
   final void Function(String) sendDanmaku;
 
   @override
@@ -82,15 +84,6 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
     } catch (e) {
       KazumiDialog.showToast(message: '截图失败：$e');
     }
-  }
-
-  void _handleDanmaku() {
-    if (playerController.danDanmakus.isEmpty) {
-      widget.showDanmakuSwitch();
-      return;
-    }
-    playerController.danmakuController.onClear();
-    playerController.danmakuOn = !playerController.danmakuOn;
   }
 
   Widget get danmakuTextField {
@@ -859,8 +852,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                                   : Icons
                                                       .subtitles_off_rounded),
                                               onPressed: () {
-                                                _handleDanmaku();
-                                                setState(() {});
+                                                widget.handleDanmaku();
                                               },
                                               tooltip:
                                                   playerController.danmakuOn
@@ -918,8 +910,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                       ? Icons.subtitles_rounded
                                       : Icons.subtitles_off_rounded),
                                   onPressed: () {
-                                    _handleDanmaku();
-                                    setState(() {});
+                                    widget.handleDanmaku();
                                   },
                                   tooltip: playerController.danmakuOn
                                       ? '关闭弹幕(d)'

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -31,11 +31,13 @@ class SmallestPlayerItemPanel extends StatefulWidget {
     required this.handleHove,
     required this.startHideTimer,
     required this.cancelHideTimer,
+    required this.handleDanmaku,
   });
 
   final void Function(BuildContext) onBackPressed;
   final Future<void> Function(double) setPlaybackSpeed;
   final void Function() showDanmakuSwitch;
+  final void Function() handleDanmaku;
   final void Function() handleFullscreen;
   final void Function(ThumbDragDetails details) handleProgressBarDragStart;
   final void Function() handleProgressBarDragEnd;
@@ -61,15 +63,6 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
   final InfoController infoController = Modular.get<InfoController>();
   final PlayerController playerController = Modular.get<PlayerController>();
   final TextEditingController textController = TextEditingController();
-
-  void _handleDanmaku() {
-    if (playerController.danDanmakus.isEmpty) {
-      widget.showDanmakuSwitch();
-      return;
-    }
-    playerController.danmakuController.onClear();
-    playerController.danmakuOn = !playerController.danmakuOn;
-  }
 
   void showVideoInfo() async {
     String currentDemux = await Utils.getCurrentDemux();
@@ -408,8 +401,7 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                             ? Icons.subtitles_rounded
                             : Icons.subtitles_off_rounded),
                         onPressed: () {
-                          _handleDanmaku();
-                          setState(() {});
+                          widget.handleDanmaku();
                         },
                         tooltip: playerController.danmakuOn ? '关闭弹幕' : '打开弹幕',
                       ),


### PR DESCRIPTION
场景：弹幕匹配错误，第七集匹配的第六集弹幕，但是手动搜索到第七集却没有弹幕，此时还是在正常播放第六集弹幕但是无法关闭

话说为什么有两个 danmakuController，一个 danmakuController 和一个 playerController.danmakuController

![Screenshot_20250213_235340_com predidit kazumi](https://github.com/user-attachments/assets/ab9e7dc8-e949-43e1-94b6-368633f276a3)
