### PR TITLE
ci: 添加發布 armv7 和 x86_64 APK

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,10 @@
             run: flutter build apk --split-per-abi
             shell: bash
           - name: Package android build output
-            run: cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk Kazumi_android_${env:tag}.apk
+            run: |
+              cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk Kazumi_android_${env:tag}.apk
+              cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk Kazumi_android_${env:tag}_armv7.apk
+              cp build/app/outputs/flutter-apk/app-x86_64-release.apk Kazumi_android_${env:tag}_x86_64.apk
             shell: bash
 
           - name: Upload android outputs


### PR DESCRIPTION
https://github.com/Predidit/Kazumi/issues/735

如您所說，遙控器操控是一大問題，但我可以用藍芽滑鼠控制，並且剛剛在 Google Cast With Google TV 測試運作正常，但由於 API Key 問題，我還是希望您能發布它，不然就加個警語吧，或是在 issue template 說 Android TV 不要回報

為了不破壞可能的自動腳本規則，我沒有更動 arm64 的檔名規則，如果想要，可再自行修改