### PR TITLE
fix keyword when searching

### DIFF
--- a/lib/bean/card/bangumi_card.dart
+++ b/lib/bean/card/bangumi_card.dart
@@ -42,13 +42,9 @@ class BangumiCardV extends StatelessWidget {
               return;
             }
             infoController.bangumiItem = bangumiItem;
-            if (!popularController.isSearching) {
-              popularController.keyword = bangumiItem.nameCn == ''
-                  ? bangumiItem.name
-                  : (bangumiItem.nameCn);
-            } else {
-              popularController.keyword = popularController.searchKeyword;
-            }
+            popularController.keyword = bangumiItem.nameCn == ''
+                ? bangumiItem.name
+                : (bangumiItem.nameCn);
             Modular.to.pushNamed('/info/');
           },
           child: Column(


### PR DESCRIPTION
按我的理解，PopularController.keyword是用来检索视频源的关键词，在每次点进番剧卡片时被赋值为番剧名字。但是原本这儿做了个判断，如果是在搜索结果中就直接使用搜索时的关键词。

我把这个判断去掉了，因为他会造成几个问题：
1.每个搜索结果点开，下面的视频源都是一样的
2.在搜索中点开该番剧，与在追番中点开该番剧看到的视频源不同
3.番剧名与下面的视频不匹配

举个例子，搜索“摇曳百合”，下面也会出现“摇曳露营Δ”，点开“摇曳露营Δ”，下面出现的还是摇曳百合相关的视频源
1.5.8 release:
![Screenshot_20250220-113055_Kazumi](https://github.com/user-attachments/assets/9acda9e1-096e-4efc-a568-7b608f5f5259)

![Screenshot_20250220-113058_Kazumi](https://github.com/user-attachments/assets/8ce20431-5777-4e14-8e46-9c8663ac97d9)

修复后：
![Screenshot_20250220-113436_Kazumi](https://github.com/user-attachments/assets/e9288077-045a-4c1a-adeb-4493668c5f67)


