### PR TITLE
feat: support searching by bangumi_id

### DIFF
--- a/lib/pages/popular/popular_controller.dart
+++ b/lib/pages/popular/popular_controller.dart
@@ -75,9 +75,21 @@ abstract class _PopularController with Store {
   Future<void> queryBangumi(String keyword) async {
     currentTag = '';
     isLoadingMore = true;
-    var result = await BangumiHTTP.bangumiSearch(keyword);
-    bangumiList.clear();
-    bangumiList.addAll(result);
+    if (RegExp(r'^[0-9]+$').hasMatch(keyword)) {
+      // 纯数字时调用ID查询
+      final id = int.parse(keyword);
+      final BangumiItem? item = await BangumiHTTP.getBangumiInfoByID(id);
+      
+      bangumiList.clear();
+      if (item != null) {
+        bangumiList.add(item); // 单个结果转为列表
+      }
+    } else {
+      // 非数字时调用普通搜索
+      var result = await BangumiHTTP.bangumiSearch(keyword);
+      bangumiList.clear();
+      bangumiList.addAll(result);
+    }
     isLoadingMore = false;
   }
 }


### PR DESCRIPTION
依据https://github.com/Predidit/Kazumi/issues/53#issuecomment-2665352386 进行修改，
得益于https://github.com/Predidit/Kazumi/pull/742 ，可以直接修改输入框部分的代码而不会影响源的搜索内容。

添加可以直接在搜索框中根据bangumi_ID搜索的功能，用来解决部分新番由于打分人数过少被筛选掉的问题。
同时纯数字搜索才会触发，不会影响到针对于正常内容的搜索。

经过测试，正常通过ID进行搜索：
![image](https://github.com/user-attachments/assets/7cb003fb-2d1c-4f4c-80b4-6d5caf13cb5e)
对于其他内容的搜索仍然正常，未破坏原有功能：
![image](https://github.com/user-attachments/assets/fa4da59e-26f0-4015-81ad-a17afb50827f)
对于返回的单个结果或是多个结果都保持了原有功能：
![image](https://github.com/user-attachments/assets/f941573c-afc3-467c-91ec-bc7cd9eda940)

