### PR TITLE
fix: episode comments sheet missing animation

### DIFF
--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -6,10 +7,23 @@ import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/pages/info/info_controller.dart';
 import 'package:kazumi/bean/card/episode_comments_card.dart';
 
-class EpisodeCommentsSheet extends StatefulWidget {
-  const EpisodeCommentsSheet({super.key, required this.episode});
+class EpisodeInfo extends InheritedWidget {
+  /// This widget receives changes of episode and notify it's child,
+  /// trigger [didChangeDependencies] of it's child.
+  const EpisodeInfo({super.key, required this.episode, required super.child});
 
   final int episode;
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
+
+  static EpisodeInfo? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<EpisodeInfo>();
+  }
+}
+
+class EpisodeCommentsSheet extends StatefulWidget {
+  const EpisodeCommentsSheet({super.key});
 
   @override
   State<EpisodeCommentsSheet> createState() => _EpisodeCommentsSheetState();
@@ -17,37 +31,41 @@ class EpisodeCommentsSheet extends StatefulWidget {
 
 class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   final infoController = Modular.get<InfoController>();
-  bool isLoading = false;
   bool commentsQueryTimeout = false;
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
+      GlobalKey<RefreshIndicatorState>();
+
+  /// episode input by [showEpisodeSelection]
+  int ep = 0;
 
   @override
   void initState() {
     super.initState();
-    if (infoController.episodeCommentsList.isEmpty) {
-      setState(() {
-        isLoading = true;
-      });
-      loadComments(widget.episode);
-    }
   }
 
   Future<void> loadComments(int episode) async {
     commentsQueryTimeout = false;
-    infoController
+    await infoController
         .queryBangumiEpisodeCommentsByID(infoController.bangumiItem.id, episode)
         .then((_) {
       if (infoController.episodeCommentsList.isEmpty && mounted) {
         setState(() {
           commentsQueryTimeout = true;
-          isLoading = false;
-        });
-      }
-      if (infoController.episodeCommentsList.isNotEmpty && mounted) {
-        setState(() {
-          isLoading = false;
         });
       }
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    ep = 0;
+    // wait until currentState is not null
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (infoController.episodeCommentsList.isEmpty) {
+        _refreshIndicatorKey.currentState?.show();
+      }
+    });
+    super.didChangeDependencies();
   }
 
   @override
@@ -57,19 +75,19 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
 
   Widget get episodeCommentsBody {
     return CustomScrollView(
-      // Scrollbars' movement is not linear so hide it.
-      scrollBehavior: const ScrollBehavior().copyWith(scrollbars: false),
+      scrollBehavior: const ScrollBehavior().copyWith(
+        // Scrollbars' movement is not linear so hide it.
+        scrollbars: false,
+        // Enable mouse drag to refresh
+        dragDevices: {
+          PointerDeviceKind.mouse,
+          PointerDeviceKind.touch,
+        },
+      ),
       slivers: [
         SliverPadding(
           padding: const EdgeInsets.fromLTRB(4, 0, 4, 4),
           sliver: Observer(builder: (context) {
-            if (isLoading) {
-              return const SliverFillRemaining(
-                child: Center(
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            }
             if (commentsQueryTimeout) {
               return const SliverFillRemaining(
                 child: Center(
@@ -187,14 +205,11 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
                   KazumiDialog.showToast(message: '请输入集数');
                   return;
                 }
-                final ep = int.tryParse(textController.text) ?? 0;
+                ep = int.tryParse(textController.text) ?? 0;
                 if (ep == 0) {
                   return;
                 }
-                setState(() {
-                  isLoading = true;
-                });
-                loadComments(ep);
+                _refreshIndicatorKey.currentState?.show();
                 KazumiDialog.dismiss();
               },
               child: const Text('刷新'),
@@ -207,10 +222,18 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final int episode = EpisodeInfo.of(context)!.episode;
     return Scaffold(
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [commentsInfo, Expanded(child: episodeCommentsBody)],
+      body: RefreshIndicator(
+        key: _refreshIndicatorKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [commentsInfo, Expanded(child: episodeCommentsBody)],
+        ),
+        onRefresh: () async {
+          await loadComments(ep == 0 ? episode : ep);
+          setState(() {});
+        },
       ),
     );
   }

--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -62,6 +62,7 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
     // wait until currentState is not null
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (infoController.episodeCommentsList.isEmpty) {
+        // trigger RefreshIndicator onRefresh and show animation
         _refreshIndicatorKey.currentState?.show();
       }
     });

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -74,8 +74,8 @@ class _VideoPageState extends State<VideoPage>
     windowManager.addListener(this);
     // Check fullscreen when enter video page
     // in case user use system controls to enter fullscreen outside video page
-    tabController = TabController(length: 2, vsync: this);
     videoPageController.isDesktopFullscreen();
+    tabController = TabController(length: 2, vsync: this);
     observerController = GridObserverController(controller: scrollController);
     animation = AnimationController(
       duration: const Duration(milliseconds: 100),
@@ -206,12 +206,6 @@ class _VideoPageState extends State<VideoPage>
     videoPageController.loading = true;
     infoController.episodeInfo.reset();
     infoController.episodeCommentsList.clear();
-    // Query comments when tab is visible
-    // We need lazy load comments to avoid unnecessary API requests
-    // so we only query comments when the tab is visible rather than video is loaded
-    if (tabController.index == 1) {
-      infoController.queryBangumiEpisodeCommentsByID(infoController.bangumiItem.id, episode);
-    }
     await playerController.stop();
     await videoPageController.changeEpisode(episode,
         currentRoad: currentRoad, offset: offset);
@@ -897,7 +891,10 @@ class _VideoPageState extends State<VideoPage>
                       ],
                     ),
                   ),
-                  EpisodeCommentsSheet(episode: episodeNum),
+                  EpisodeInfo(
+                    episode: episodeNum,
+                    child: EpisodeCommentsSheet(),
+                  ),
                 ],
               ),
             ),


### PR DESCRIPTION
本来准备直接用 CircularProgressIndicator()，但是不知道为什么把这段代码放 `didChangeDependencies` 里面会导致重复请求多次评论；RefreshIndicator 只会请求一次，也不是 `addPostFrameCallback` 的原因

```dart
if (infoController.episodeCommentsList.isEmpty) {
  setState(() {
    isLoading = true;
  });
  loadComments(widget.episode);
}
```