### PR TITLE
fix(bbcode): link can be triggered when masked

### DIFF
--- a/lib/bbcode/bbcode_widget.dart
+++ b/lib/bbcode/bbcode_widget.dart
@@ -80,7 +80,7 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
                   recognizer: TapGestureRecognizer()
                     ..onTap = (e.link != null || e.masked)
                         ? () {
-                            if (e.link != null) {
+                            if (_isVisible && e.link != null) {
                               launchUrl(Uri.parse(e.link!));
                             } else if (e.masked) {
                               setState(() {


### PR DESCRIPTION
Mujica 第二集评论区，如果遮罩底下是超链接会无视遮罩直接跳转网页

<img width="333" alt="image" src="https://github.com/user-attachments/assets/6269b2f8-eb14-4b02-bc53-f30a0b92616d" />
<img width="316" alt="image" src="https://github.com/user-attachments/assets/a7903cbe-02b4-4f71-a85d-132bb7b2d693" />

这个修复太小了，我有考虑过直接开个 issue 等攒多一点 bbcode 相关的问题再一起修复，想想算了，应该碰不到那么多问题（
