### PR TITLE
refactor: query logic in popular page

### DIFF
--- a/lib/pages/popular/popular_controller.g.dart
+++ b/lib/pages/popular/popular_controller.g.dart
@@ -41,6 +41,22 @@ mixin _$PopularController on _PopularController, Store {
     });
   }
 
+  late final _$trendListAtom =
+      Atom(name: '_PopularController.trendList', context: context);
+
+  @override
+  ObservableList<BangumiItem> get trendList {
+    _$trendListAtom.reportRead();
+    return super.trendList;
+  }
+
+  @override
+  set trendList(ObservableList<BangumiItem> value) {
+    _$trendListAtom.reportWrite(value, super.trendList, () {
+      super.trendList = value;
+    });
+  }
+
   late final _$isLoadingMoreAtom =
       Atom(name: '_PopularController.isLoadingMore', context: context);
 
@@ -78,6 +94,7 @@ mixin _$PopularController on _PopularController, Store {
     return '''
 currentTag: ${currentTag},
 bangumiList: ${bangumiList},
+trendList: ${trendList},
 isLoadingMore: ${isLoadingMore},
 isTimeOut: ${isTimeOut}
     ''';

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -229,7 +229,8 @@ class _PopularPageState extends State<PopularPage>
                             );
                           }
                           return contentGrid(
-                              popularController.bangumiList.isEmpty
+                              popularController.bangumiList.isEmpty &&
+                                      !popularController.isLoadingMore
                                   ? popularController.trendList
                                   : popularController.bangumiList,
                               orientation);

--- a/lib/pages/popular/popular_page.dart
+++ b/lib/pages/popular/popular_page.dart
@@ -40,8 +40,8 @@ class _PopularPageState extends State<PopularPage>
   void initState() {
     super.initState();
     scrollController.addListener(scrollListener);
-    if (popularController.bangumiList.isEmpty) {
-      popularController.queryBangumiFeed();
+    if (popularController.trendList.isEmpty) {
+      popularController.queryBangumiByTrend();
     }
     showSearchBar = popularController.searchKeyword.isNotEmpty;
   }
@@ -67,9 +67,9 @@ class _PopularPageState extends State<PopularPage>
       if (popularController.searchKeyword == '') {
         KazumiLogger().log(Level.info, 'Popular is loading more');
         if (popularController.currentTag != '') {
-          popularController.queryBangumiList();
+          popularController.queryBangumiByTag();
         } else {
-          popularController.queryBangumiFeed();
+          popularController.queryBangumiByTrend();
         }
       }
     }
@@ -99,170 +99,153 @@ class _PopularPageState extends State<PopularPage>
           }
           onBackPressed(context);
         },
-        child: RefreshIndicator(
-          onRefresh: () async {
-            await popularController.queryBangumiByRefresh();
-          },
-          child: Scaffold(
-              appBar: SysAppBar(
-                needTopOffset: false,
-                // default 56 + 10
-                leadingWidth: 66,
-                leading: (navigationBarState.isBottom)
-                    ? Row(
-                        children: [
-                          const SizedBox(
-                            width: 10,
+        child: Scaffold(
+          appBar: SysAppBar(
+            needTopOffset: false,
+            // default 56 + 10
+            leadingWidth: 66,
+            leading: (navigationBarState.isBottom)
+                ? Row(
+                    children: [
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      ClipOval(
+                        child: InkWell(
+                          customBorder: const CircleBorder(),
+                          onTap: () {
+                            Modular.to.pushNamed('/settings/history');
+                          },
+                          child: Image.asset(
+                            'assets/images/logo/logo_android.png',
                           ),
-                          ClipOval(
-                            child: InkWell(
-                              customBorder: const CircleBorder(),
-                              onTap: () {
-                                Modular.to.pushNamed('/settings/history');
-                              },
-                              child: Image.asset(
-                                'assets/images/logo/logo_android.png',
-                              ),
-                            ),
-                          )
-                        ],
+                        ),
                       )
-                    : null,
-                backgroundColor: Colors.transparent,
-                actions: [
-                  IconButton(
-                      onPressed: () async {
-                        if (!showSearchBar) {
-                          setState(() {
-                            showSearchBar = true;
-                          });
-                          _focusNode.requestFocus();
-                        } else {
-                          if (popularController.searchKeyword == '') {
-                            _focusNode.unfocus();
-                            setState(() {
-                              showSearchBar = false;
-                            });
-                            popularController.setCurrentTag('');
-                            await popularController.queryBangumiFeed(
-                                type: 'init');
-                          } else {
-                            popularController.setSearchKeyword('');
-                            setState(() {
-                              showSearchBar = true;
-                            });
-                            _focusNode.requestFocus();
+                    ],
+                  )
+                : null,
+            backgroundColor: Colors.transparent,
+            actions: [
+              IconButton(
+                  onPressed: () async {
+                    if (!showSearchBar) {
+                      setState(() {
+                        showSearchBar = true;
+                      });
+                      _focusNode.requestFocus();
+                    } else {
+                      if (popularController.searchKeyword == '') {
+                        _focusNode.unfocus();
+                        setState(() {
+                          showSearchBar = false;
+                        });
+                        popularController.setCurrentTag('');
+                        popularController.clearBangumiList();
+                      } else {
+                        popularController.setSearchKeyword('');
+                        setState(() {
+                          showSearchBar = true;
+                        });
+                        _focusNode.requestFocus();
+                      }
+                    }
+                  },
+                  icon: showSearchBar
+                      ? const Icon(Icons.close)
+                      : const Icon(Icons.search))
+            ],
+            title: Stack(
+              children: [
+                Positioned.fill(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onPanStart: (_) => windowManager.startDragging(),
+                    child: Container(),
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(top: (Utils.isDesktop()) ? 8 : 0),
+                  child: Visibility(
+                    visible: showSearchBar,
+                    child: searchBar(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          body: Column(
+            children: [
+              SizedBox(
+                height: showTagFilter ? 50 : 0,
+                child: tagFilter(),
+              ),
+              Expanded(
+                child: CustomScrollView(
+                  controller: scrollController,
+                  slivers: [
+                    SliverToBoxAdapter(
+                      child: Observer(
+                        builder: (_) => Padding(
+                          padding: const EdgeInsets.only(
+                              top: 0, bottom: 10, left: 0),
+                          child: popularController.isLoadingMore
+                              ? const LinearProgressIndicator()
+                              : const SizedBox(
+                                  height: 4.0,
+                                ),
+                        ),
+                      ),
+                    ),
+                    SliverPadding(
+                        padding: const EdgeInsets.fromLTRB(
+                            StyleString.cardSpace, 0, StyleString.cardSpace, 0),
+                        sliver: Observer(builder: (context) {
+                          if (popularController.isTimeOut) {
+                            return SliverToBoxAdapter(
+                              child: SizedBox(
+                                height: 400,
+                                child: GeneralErrorWidget(
+                                  errMsg: '什么都没有找到 (´;ω;`)',
+                                  actions: [
+                                    GeneralErrorButton(
+                                      onPressed: () {
+                                        if (popularController.searchKeyword !=
+                                            '') {
+                                          popularController.searchBangumi(
+                                              popularController.searchKeyword);
+                                        } else if (popularController
+                                            .trendList.isEmpty) {
+                                          popularController
+                                              .queryBangumiByTrend();
+                                        } else {
+                                          popularController.queryBangumiByTag();
+                                        }
+                                      },
+                                      text: '点击重试',
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
                           }
-                        }
-                      },
-                      icon: showSearchBar
-                          ? const Icon(Icons.close)
-                          : const Icon(Icons.search))
-                ],
-                title: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.translucent,
-                        onPanStart: (_) => windowManager.startDragging(),
-                        child: Container(),
-                      ),
-                    ),
-                    Padding(
-                      padding:
-                          EdgeInsets.only(top: (Utils.isDesktop()) ? 8 : 0),
-                      child: Visibility(
-                        visible: showSearchBar,
-                        child: searchBar(),
-                      ),
-                    ),
+                          return contentGrid(
+                              popularController.bangumiList.isEmpty
+                                  ? popularController.trendList
+                                  : popularController.bangumiList,
+                              orientation);
+                        })),
                   ],
                 ),
               ),
-              body: Column(
-                children: [
-                  SizedBox(
-                    height: showTagFilter ? 50 : 0,
-                    child: tagFilter(),
-                  ),
-                  Expanded(
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: Observer(
-                            builder: (_) => Padding(
-                              padding: const EdgeInsets.only(
-                                  top: 0, bottom: 10, left: 0),
-                              child: popularController.isLoadingMore
-                                  ? const LinearProgressIndicator()
-                                  : const SizedBox(
-                                      height: 4.0,
-                                    ),
-                            ),
-                          ),
-                        ),
-                        SliverPadding(
-                            padding: const EdgeInsets.fromLTRB(
-                                StyleString.cardSpace,
-                                0,
-                                StyleString.cardSpace,
-                                0),
-                            sliver: Observer(builder: (context) {
-                              if (popularController.bangumiList.isEmpty &&
-                                  popularController.isTimeOut) {
-                                return SliverToBoxAdapter(
-                                  child: SizedBox(
-                                    height: 400,
-                                    child: GeneralErrorWidget(
-                                      errMsg: '什么都没有找到 (´;ω;`)',
-                                      actions: [
-                                        GeneralErrorButton(
-                                          onPressed: () {
-                                            popularController
-                                                .queryBangumiList();
-                                          },
-                                          text: '点击重试',
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                );
-                              }
-                              if (popularController.bangumiList.isEmpty &&
-                                  !popularController.isTimeOut) {
-                                return SliverToBoxAdapter(
-                                  child: SizedBox(
-                                      height:
-                                          (MediaQuery.of(context).size.height /
-                                              2),
-                                      child: const Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.center,
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.center,
-                                        children: [
-                                          CircularProgressIndicator(),
-                                        ],
-                                      )),
-                                );
-                              }
-                              return contentGrid(
-                                  popularController.bangumiList, orientation);
-                            })),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              floatingActionButton: FloatingActionButton(
-                onPressed: () {
-                  scrollController.jumpTo(0.0);
-                },
-                child: const Icon(Icons.arrow_upward),
-              )
-              // backgroundColor: themedata.colorScheme.primaryContainer,
-              ),
+            ],
+          ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {
+              scrollController.jumpTo(0.0);
+            },
+            child: const Icon(Icons.arrow_upward),
+          ),
+          // backgroundColor: themedata.colorScheme.primaryContainer,
         ),
       );
     });
@@ -333,8 +316,7 @@ class _PopularPageState extends State<PopularPage>
                             onPressed: () async {
                               scrollController.jumpTo(0.0);
                               popularController.setCurrentTag('');
-                              await popularController.queryBangumiFeed(
-                                  type: 'init');
+                              popularController.clearBangumiList();
                             },
                           )
                         : FilledButton.tonal(
@@ -347,7 +329,7 @@ class _PopularPageState extends State<PopularPage>
                                 showSearchBar = false;
                               });
                               popularController.setCurrentTag(filter);
-                              await popularController.queryBangumiList(
+                              await popularController.queryBangumiByTag(
                                   type: 'init');
                             },
                           ),
@@ -385,10 +367,11 @@ class _PopularPageState extends State<PopularPage>
       onSubmitted: (t) async {
         popularController.setSearchKeyword(t);
         if (t != '') {
-          await popularController.queryBangumi(popularController.searchKeyword);
+          await popularController
+              .searchBangumi(popularController.searchKeyword);
         } else {
           popularController.setCurrentTag('');
-          await popularController.queryBangumiFeed(type: 'init');
+          popularController.clearBangumiList();
         }
       },
     );

--- a/lib/request/bangumi.dart
+++ b/lib/request/bangumi.dart
@@ -140,7 +140,7 @@ class BangumiHTTP {
   }
 
   static Future<List<BangumiItem>> getBangumiTrendsList(
-      {int type = 2, int limit = 20, int offset = 0}) async {
+      {int type = 2, int limit = 24, int offset = 0}) async {
     List<BangumiItem> bangumiList = [];
     var params = <String, dynamic>{
       'type': type,


### PR DESCRIPTION
popular page 有三个刷新指示，删到只有一个 LinearProgressIndicator 了。
1. 增加了一个 trendList，因为现在的 trend 不会经常变化，所以缓存减少请求次数(减不了多少感觉)
2. 同样的原因，把下拉刷新删了
3. 改了点函数名字和返回值，改函数名是因为我不理解原来的函数含义是什么，大致理解了一下，可能改的不是很对。返回值因为我看完全没用到就删了改成空返回了
4. 现在一次性请求 24 个 bangumiItem，这样手机和电脑端最后一行都会被占满，加载更无感？

![IMAGE 2025-02-26 20:37:22](https://github.com/user-attachments/assets/30ffa893-6ca7-49a8-9487-7721403559f7)
