### PR TITLE
fix(ui): comments and svg appearance

### DIFF
--- a/lib/bean/card/character_comments_card.dart
+++ b/lib/bean/card/character_comments_card.dart
@@ -40,7 +40,7 @@ class CharacterCommentsCard extends StatelessWidget {
             BBCodeWidget(bbcode: commentItem.comment.comment),
             if (commentItem.replies.isNotEmpty)
               ListView.builder(
-                // Don't know why but iOS has bottom padding,
+                // Don't know why but some device has bottom padding,
                 // needs to set to 0 manually.
                 padding: const EdgeInsets.only(bottom: 0),
                 physics: const NeverScrollableScrollPhysics(),

--- a/lib/bean/card/character_comments_card.dart
+++ b/lib/bean/card/character_comments_card.dart
@@ -40,6 +40,9 @@ class CharacterCommentsCard extends StatelessWidget {
             BBCodeWidget(bbcode: commentItem.comment.comment),
             if (commentItem.replies.isNotEmpty)
               ListView.builder(
+                // Don't know why but iOS has bottom padding,
+                // needs to set to 0 manually.
+                padding: const EdgeInsets.only(bottom: 0),
                 physics: const NeverScrollableScrollPhysics(),
                 shrinkWrap: true,
                 itemCount: commentItem.replies.length,

--- a/lib/bean/card/episode_comments_card.dart
+++ b/lib/bean/card/episode_comments_card.dart
@@ -40,6 +40,9 @@ class EpisodeCommentsCard extends StatelessWidget {
             BBCodeWidget(bbcode: commentItem.comment.comment),
             if (commentItem.replies.isNotEmpty)
               ListView.builder(
+                // Don't know why but ohos has bottom padding,
+                // needs to set to 0 manually.
+                padding: const EdgeInsets.only(bottom: 0),
                 physics: const NeverScrollableScrollPhysics(),
                 shrinkWrap: true,
                 itemCount: commentItem.replies.length,

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -309,7 +309,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   @override
   Widget build(BuildContext context) {
     final svgString = danmakuOnSvg.replaceFirst(
-        '#00AEEC',
+        '00AEEC',
         Theme.of(context)
             .colorScheme
             .primary

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -162,7 +162,7 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
   @override
   Widget build(BuildContext context) {
     final svgString = danmakuOnSvg.replaceFirst(
-        '#00AEEC',
+        '00AEEC',
         Theme.of(context)
             .colorScheme
             .primary


### PR DESCRIPTION
颜色替换是缺少 `#`，反而桌面端可以正常工作比较不正常。

有 replies 的 card 会有奇怪的表现，不知道安卓是不是也会这样。剧集评论区只有 ohos 会出现，但是角色评论卡在 iOS 上也出现了相同的问题，所以就统一加上了 9d07682ae6948a62c02c56898fdf2ba12890dae3

<img width="375" alt="image" src="https://github.com/user-attachments/assets/44f92e85-ea9e-4a3e-9411-ddb6a234c88a" />
