### PR TITLE
fix: bbcode widget appearance

### DIFF
--- a/lib/bbcode/bbcode_widget.dart
+++ b/lib/bbcode/bbcode_widget.dart
@@ -80,7 +80,7 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
                   recognizer: TapGestureRecognizer()
                     ..onTap = (e.link != null || e.masked)
                         ? () {
-                            if (_isVisible && e.link != null) {
+                            if ((!e.masked || _isVisible) && e.link != null) {
                               launchUrl(Uri.parse(e.link!));
                             } else if (e.masked) {
                               setState(() {

--- a/lib/bbcode/bbcode_widget.dart
+++ b/lib/bbcode/bbcode_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:antlr4/antlr4.dart';
@@ -173,6 +174,7 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
               }
             }).toList(),
           ),
+          selectionHeightStyle: ui.BoxHeightStyle.max,
         ),
       ],
     );

--- a/lib/bbcode/bbcode_widget.dart
+++ b/lib/bbcode/bbcode_widget.dart
@@ -75,6 +75,15 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
           TextSpan(
             children: bbcodeBaseListener.bbcode.map((e) {
               if (e is BBCodeText) {
+                Color? textColor = (!_isVisible && e.masked)
+                    ? Colors.transparent
+                    : (e.link != null)
+                        ? Colors.blue
+                        : (e.quoted)
+                            ? Theme.of(context).colorScheme.outline
+                            : (e.color != null)
+                                ? _parseColor(e.color!)
+                                : null;
                 return TextSpan(
                   text: e.text,
                   mouseCursor: (e.link != null || e.masked)
@@ -95,24 +104,17 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
                   style: TextStyle(
                     fontWeight: (e.bold) ? FontWeight.bold : null,
                     fontStyle: (e.italic) ? FontStyle.italic : null,
-                    decoration: (e.underline)
-                        ? TextDecoration.underline
-                        : (e.strikeThrough)
-                            ? TextDecoration.lineThrough
-                            : null,
+                    decoration: TextDecoration.combine([
+                      if (e.underline || e.link != null)
+                        TextDecoration.underline,
+                      if (e.strikeThrough) TextDecoration.lineThrough,
+                    ]),
+                    decorationColor: textColor,
                     fontSize: e.size.toDouble(),
-                    color: (!_isVisible && e.masked)
-                        ? Colors.transparent
-                        : (e.link != null)
-                            ? Colors.blue
-                            : (e.quoted)
-                                ? Theme.of(context).colorScheme.outline
-                                : (e.color != null)
-                                    ? _parseColor(e.color!)
-                                    : null,
-                    backgroundColor: (!_isVisible && e.masked)
-                        ? Theme.of(context).colorScheme.outline
-                        : null,
+                    color: textColor,
+                    backgroundColor:
+                        (!_isVisible && e.masked) ? Color(0xFF555555) : null,
+                    fontFeatures: [FontFeature.tabularFigures()],
                   ),
                 );
               } else if (e is BBCodeImg) {

--- a/lib/bbcode/bbcode_widget.dart
+++ b/lib/bbcode/bbcode_widget.dart
@@ -77,6 +77,9 @@ class _BBCodeWidgetState extends State<BBCodeWidget> {
               if (e is BBCodeText) {
                 return TextSpan(
                   text: e.text,
+                  mouseCursor: (e.link != null || e.masked)
+                      ? SystemMouseCursors.click
+                      : SystemMouseCursors.text,
                   recognizer: TapGestureRecognizer()
                     ..onTap = (e.link != null || e.masked)
                         ? () {


### PR DESCRIPTION
* 修复没有遮罩的链接无法正确跳转
* 优化鼠标悬浮表现
* 增加超链接下划线
* 统一文本选择高亮的高度

mask 的问题与这个有关，而且还没有圆角。暂时没找到更好的表现方式，如果用 WidgetSpan + Stack 叠加无法正确的换行。

https://github.com/flutter/flutter/issues/144753

目前和 Bangumi 的做法类似，但是没办法实现这样的效果

```html
<span class="text_mask" style="background-color:#555;color:#555;border:1px solid #555;">soyo女士又开启了黑脸模式，我害怕</span>
```

```css
span.text_mask {
    -webkit-border-radius: 2px;
    -moz-border-radius: 2px;
    border-radius: 2px;
    -moz-background-clip: padding;
    -webkit-background-clip: padding-box;
    background-clip: padding-box;
    -webkit-transition: all .5s linear;
    -moz-transition: all .5s linear;
    -ms-transition: all .5s linear;
    -o-transition: all .5s linear;
    text-shadow: #555 0 0 20px
}

span.text_mask:hover {
    color: #FFF !important;
    text-shadow: #FFF 0 0 0px
}
```