### PR TITLE
chore: update issue template and workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -43,7 +43,14 @@ body:
     attributes:
       label: 日志信息
       description: 请在 “我的 - 关于 - 错误日志” 界面复制错误日志，并粘贴在这里。
-      render: shell
+      value: |
+        <details open><summary>Log</summary>
+
+        ```shell
+        [在此处粘贴你的日志]
+        ```
+
+        </details>
     validations:
       required: true
   - type: checkboxes

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,8 +10,10 @@
           - ready_for_review
         paths-ignore:
           - 'static/**'
-          - 'README.md'
+          - '**.md'
           - '.gitignore'
+          - '.github/ISSUE_TEMPLATE/**'
+          - 'fastlane/**'
       workflow_dispatch:
         inputs:
           logLevel:

--- a/lib/request/interceptor.dart
+++ b/lib/request/interceptor.dart
@@ -4,9 +4,11 @@ import 'package:hive/hive.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:logger/logger.dart';
 
 class ApiInterceptor extends Interceptor {
   static Box setting = GStorage.setting;
+
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     // Github mirror
@@ -28,11 +30,11 @@ class ApiInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     String url = err.requestOptions.uri.toString();
-    if (!url.contains('heartBeat') && err.requestOptions.extra['customError'] != '') {
+    if (!url.contains('heartBeat') &&
+        err.requestOptions.extra['customError'] != '') {
       if (err.requestOptions.extra['customError'] == null) {
-        KazumiDialog.showToast(
-          message: await dioError(err),
-        );
+        final errCode = await dioError(err);
+        Logger().log(Level.error, errCode);
       } else {
         KazumiDialog.showToast(
           message: err.requestOptions.extra['customError'],

--- a/lib/request/interceptor.dart
+++ b/lib/request/interceptor.dart
@@ -4,11 +4,9 @@ import 'package:hive/hive.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:logger/logger.dart';
 
 class ApiInterceptor extends Interceptor {
   static Box setting = GStorage.setting;
-
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     // Github mirror
@@ -30,11 +28,11 @@ class ApiInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     String url = err.requestOptions.uri.toString();
-    if (!url.contains('heartBeat') &&
-        err.requestOptions.extra['customError'] != '') {
+    if (!url.contains('heartBeat') && err.requestOptions.extra['customError'] != '') {
       if (err.requestOptions.extra['customError'] == null) {
-        final errCode = await dioError(err);
-        Logger().log(Level.error, errCode);
+        KazumiDialog.showToast(
+          message: await dioError(err),
+        );
       } else {
         KazumiDialog.showToast(
           message: err.requestOptions.extra['customError'],


### PR DESCRIPTION
close #775 

影响使用的错误都有 GeneralWidget 可以重发请求，没有影响的也不是很需要显示 toast

用 Logger 避免被记录在日志文件里(感觉不是很需要被记录下来)

template 的修改是可以隐藏过长的 log，不然有时候要划好久（