### PR TITLE
fix: 优化番剧弹幕匹配度

### DIFF
--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -165,7 +165,10 @@ abstract class _PlayerController with Store {
     if (episodeFromTitle == 0) {
       episodeFromTitle = videoPageController.currentEpisode;
     }
-    getDanDanmaku(videoPageController.title, episodeFromTitle);
+
+    List<String> titleList = [videoPageController.title, videoPageController.bangumiItem.nameCn, videoPageController.bangumiItem.name].where((title) => title.isNotEmpty).toList();
+    // 根据标题列表获取弹幕,优先级: 视频源标题 > 番剧中文名 > 番剧日文名
+    getDanDanmaku(titleList, episodeFromTitle);
     mediaPlayer = await createVideoController(offset: offset);
     playerSpeed =
         setting.get(SettingBoxKey.defaultPlaySpeed, defaultValue: 1.0);
@@ -412,11 +415,11 @@ abstract class _PlayerController with Store {
     forwardTime = time;
   }
 
-  Future<void> getDanDanmaku(String title, int episode) async {
-    KazumiLogger().log(Level.info, '尝试获取弹幕 $title');
+  Future<void> getDanDanmaku(List<String> titleList, int episode) async {
+    KazumiLogger().log(Level.info, '尝试获取弹幕 $titleList');
     try {
       danDanmakus.clear();
-      bangumiID = await DanmakuRequest.getBangumiID(title);
+      bangumiID = await DanmakuRequest.getBangumiIDByTitles(titleList);
       var res = await DanmakuRequest.getDanDanmaku(bangumiID, episode);
       addDanmakus(res);
     } catch (e) {

--- a/lib/request/damaku.dart
+++ b/lib/request/damaku.dart
@@ -8,8 +8,22 @@ import 'package:kazumi/utils/mortis.dart';
 import 'package:kazumi/modules/danmaku/danmaku_module.dart';
 import 'package:kazumi/modules/danmaku/danmaku_search_response.dart';
 import 'package:kazumi/modules/danmaku/danmaku_episode_response.dart';
+import 'package:kazumi/utils/string_match.dart';
 
 class DanmakuRequest {
+
+  // 从标题列表中获取番剧ID
+  static Future<int> getBangumiIDByTitles(List<String> titleList) async {
+    int minAnimeId = 100000;
+    for (var title in titleList) {
+      int bangumiID = await getBangumiID(title);
+      if (bangumiID != minAnimeId) {
+        return bangumiID;
+      }
+    }
+    return minAnimeId;
+  }
+
   //获取弹弹Play集合，需要进一步处理
   static Future<int> getBangumiID(String title) async {
     DanmakuSearchResponse danmakuSearchResponse =
@@ -19,8 +33,11 @@ class DanmakuRequest {
     int minAnimeId = 100000;
     for (var anime in danmakuSearchResponse.animes) {
       int animeId = anime.animeId;
-      if (animeId < minAnimeId && animeId >= 2) {
+      String animeTitle = anime.animeTitle;
+      double similarity = calculateSimilarity(animeTitle, title);
+      if (animeId < minAnimeId && animeId >= 2 && similarity > 0.9) {
         minAnimeId = animeId;
+        KazumiLogger().log(Level.debug, '匹配番剧弹幕 $title --- $animeTitle 相似度: $similarity');
       }
     }
     return minAnimeId;

--- a/lib/request/damaku.dart
+++ b/lib/request/damaku.dart
@@ -31,16 +31,30 @@ class DanmakuRequest {
 
     // 保留此判断以防止错误匹配
     int minAnimeId = 100000;
+    int bestAnimeId = minAnimeId;
+    double maxSimilarity = 0;
+
     for (var anime in danmakuSearchResponse.animes) {
       int animeId = anime.animeId;
+      if (animeId >= minAnimeId || animeId < 2) {
+        continue;
+      }
+
       String animeTitle = anime.animeTitle;
       double similarity = calculateSimilarity(animeTitle, title);
-      if (animeId < minAnimeId && animeId >= 2 && similarity > 0.9) {
-        minAnimeId = animeId;
+      if (similarity == 1) {
+        KazumiLogger().log(Level.debug, '完全匹配番剧弹幕 $title');
+        return animeId;
+      }
+
+      if (similarity > maxSimilarity) {
+        maxSimilarity = similarity;
+        bestAnimeId = animeId;
         KazumiLogger().log(Level.debug, '匹配番剧弹幕 $title --- $animeTitle 相似度: $similarity');
       }
     }
-    return minAnimeId;
+
+    return bestAnimeId;
   }
 
   //从BangumiID获取分集ID
@@ -147,8 +161,7 @@ class DanmakuRequest {
     Map<String, String> withRelated = {
       'withRelated': 'true',
     };
-    final res = await Request().get(
-        endPoint,
+    final res = await Request().get(endPoint,
         data: withRelated,
         options: Options(headers: httpHeaders),
         extra: {'customError': '弹幕检索错误: 获取弹幕失败'});

--- a/lib/utils/string_match.dart
+++ b/lib/utils/string_match.dart
@@ -1,0 +1,33 @@
+import 'dart:math';
+
+int levenshteinDistance(String s1, String s2) {
+  if (s1 == s2) return 0;
+  if (s1.isEmpty) return s2.length;
+  if (s2.isEmpty) return s1.length;
+
+  List<int> v0 = List<int>.generate(s2.length + 1, (i) => i);
+  List<int> v1 = List<int>.filled(s2.length + 1, 0);
+
+  for (int i = 0; i < s1.length; i++) {
+    v1[0] = i + 1;
+
+    for (int j = 0; j < s2.length; j++) {
+      int cost = (s1[i] == s2[j]) ? 0 : 1;
+      v1[j + 1] = min(v1[j] + 1, min(v0[j + 1] + 1, v0[j] + cost));
+    }
+
+    for (int j = 0; j < v0.length; j++) {
+      v0[j] = v1[j];
+    }
+  }
+
+  return v1[s2.length];
+}
+
+// 计算相似度百分比
+double calculateSimilarity(String s1, String s2) {
+  int maxLength = max(s1.length, s2.length);
+  if (maxLength == 0) return 1.0;
+  if (s1 == s2) return 1.0;
+  return (1.0 - levenshteinDistance(s1, s2) / maxLength);
+}


### PR DESCRIPTION
fix issue: #789 
目前匹配弹幕由于是通过视屏源标题来搜索dandanplay上的弹幕，在面对多季的番剧或者有BD/无修番剧时搜索不到。
采取两个方案来优化弹幕匹配

1. 通过匹配视频源标题 与 dandanplay返回的标题相似度
eg:  无职转生Ⅱ ～到了异世界就拿出真本事～ 第2部分 
![image](https://github.com/user-attachments/assets/dd0d2542-bdd9-4100-89bb-5f0c84647874)
之前会匹配到第一部

修改过后:
![image](https://github.com/user-attachments/assets/ef7f7e8b-71e9-490f-b0f0-2650b8eb21fe)

2.当视频源标题查询不到时，搜索Bangumi标题
eg: 梦想成为魔法少女(WEB无修) 

![image](https://github.com/user-attachments/assets/46de1898-5af5-4af1-ba4c-5692b5140b12)

