### PR TITLE
feat: better search page appearance and obscure password

### DIFF
--- a/lib/bean/card/bangumi_card.dart
+++ b/lib/bean/card/bangumi_card.dart
@@ -23,7 +23,7 @@ class BangumiCardV extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: 0,
-      clipBehavior: Clip.hardEdge,
+      clipBehavior: Clip.antiAlias,
       margin: EdgeInsets.zero,
       child: GestureDetector(
         child: InkWell(

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -122,6 +122,18 @@ class _SearchPageState extends State<SearchPage> {
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
             child: SearchAnchor.bar(
               searchController: searchController,
+              barElevation: WidgetStateProperty<double>.fromMap(
+                <WidgetStatesConstraint, double>{WidgetState.any: 0},
+              ),
+              viewElevation: 0,
+              viewLeading: IconButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: Icon(Icons.arrow_back),
+              ),
+              isFullScreen: MediaQuery.sizeOf(context).width <
+                  LayoutBreakpoint.compact['width']!,
               suggestionsBuilder: (context, controller) => <Widget>[
                 Container(
                   height: 400,

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -119,7 +119,7 @@ class _SearchPageState extends State<SearchPage> {
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+            padding: const EdgeInsets.fromLTRB(8, 0, 8, 16),
             child: SearchAnchor.bar(
               searchController: searchController,
               barElevation: WidgetStateProperty<double>.fromMap(
@@ -175,6 +175,7 @@ class _SearchPageState extends State<SearchPage> {
               }
               return GridView.builder(
                 controller: scrollController,
+                padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                   mainAxisSpacing: StyleString.cardSpace - 2,
                   crossAxisSpacing: StyleString.cardSpace,
@@ -195,13 +196,9 @@ class _SearchPageState extends State<SearchPage> {
                     : 10,
                 itemBuilder: (context, index) {
                   return searchPageController.bangumiList.isNotEmpty
-                      ? Padding(
-                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-                          child: BangumiCardV(
-                            enableHero: false,
-                            bangumiItem:
-                                searchPageController.bangumiList[index],
-                          ),
+                      ? BangumiCardV(
+                          enableHero: false,
+                          bangumiItem: searchPageController.bangumiList[index],
                         )
                       : Container();
                 },

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -148,65 +148,66 @@ class _SearchPageState extends State<SearchPage> {
             ),
           ),
           Expanded(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-              child: Observer(builder: (context) {
-                if (searchPageController.isTimeOut) {
-                  return Center(
-                    child: SizedBox(
-                      height: 400,
-                      child: GeneralErrorWidget(
-                        errMsg: '什么都没有找到 (´;ω;`)',
-                        actions: [
-                          GeneralErrorButton(
-                            onPressed: () {
-                              searchPageController.searchBangumi(
-                                  searchController.text,
-                                  type: 'init');
-                            },
-                            text: '点击重试',
-                          ),
-                        ],
-                      ),
+            child: Observer(builder: (context) {
+              if (searchPageController.isTimeOut) {
+                return Center(
+                  child: SizedBox(
+                    height: 400,
+                    child: GeneralErrorWidget(
+                      errMsg: '什么都没有找到 (´;ω;`)',
+                      actions: [
+                        GeneralErrorButton(
+                          onPressed: () {
+                            searchPageController.searchBangumi(
+                                searchController.text,
+                                type: 'init');
+                          },
+                          text: '点击重试',
+                        ),
+                      ],
                     ),
-                  );
-                }
-                if (searchPageController.isLoading &&
-                    searchPageController.bangumiList.isEmpty) {
-                  return Center(child: CircularProgressIndicator());
-                }
-                return GridView.builder(
-                  controller: scrollController,
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    mainAxisSpacing: StyleString.cardSpace - 2,
-                    crossAxisSpacing: StyleString.cardSpace,
-                    crossAxisCount: MediaQuery.of(context).orientation !=
-                            Orientation.portrait
-                        ? 6
-                        : 3,
-                    mainAxisExtent: MediaQuery.of(context).size.width /
-                            (MediaQuery.of(context).orientation !=
-                                    Orientation.portrait
-                                ? 6
-                                : 3) /
-                            0.65 +
-                        MediaQuery.textScalerOf(context).scale(32.0),
                   ),
-                  itemCount: searchPageController.bangumiList.isNotEmpty
-                      ? searchPageController.bangumiList.length
-                      : 10,
-                  itemBuilder: (context, index) {
-                    return searchPageController.bangumiList.isNotEmpty
-                        ? BangumiCardV(
+                );
+              }
+              if (searchPageController.isLoading &&
+                  searchPageController.bangumiList.isEmpty) {
+                return Center(child: CircularProgressIndicator());
+              }
+              return GridView.builder(
+                controller: scrollController,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  mainAxisSpacing: StyleString.cardSpace - 2,
+                  crossAxisSpacing: StyleString.cardSpace,
+                  crossAxisCount:
+                      MediaQuery.of(context).orientation != Orientation.portrait
+                          ? 6
+                          : 3,
+                  mainAxisExtent: MediaQuery.of(context).size.width /
+                          (MediaQuery.of(context).orientation !=
+                                  Orientation.portrait
+                              ? 6
+                              : 3) /
+                          0.65 +
+                      MediaQuery.textScalerOf(context).scale(32.0),
+                ),
+                itemCount: searchPageController.bangumiList.isNotEmpty
+                    ? searchPageController.bangumiList.length
+                    : 10,
+                itemBuilder: (context, index) {
+                  return searchPageController.bangumiList.isNotEmpty
+                      ? Padding(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                          child: BangumiCardV(
                             enableHero: false,
                             bangumiItem:
-                                searchPageController.bangumiList[index])
-                        : Container();
-                  },
-                );
-              }),
-            ),
-          )
+                                searchPageController.bangumiList[index],
+                          ),
+                        )
+                      : Container();
+                },
+              );
+            }),
+          ),
         ],
       ),
     );

--- a/lib/pages/webdav_editor/webdav_editor_page.dart
+++ b/lib/pages/webdav_editor/webdav_editor_page.dart
@@ -21,6 +21,7 @@ class _WebDavEditorPageState extends State<WebDavEditorPage> {
   final TextEditingController webDavPasswordController =
       TextEditingController();
   Box setting = GStorage.setting;
+  bool passwordVisible = false;
 
   @override
   void initState() {
@@ -60,8 +61,21 @@ class _WebDavEditorPageState extends State<WebDavEditorPage> {
                 const SizedBox(height: 20),
                 TextField(
                   controller: webDavPasswordController,
-                  decoration: const InputDecoration(
-                      labelText: 'Password', border: OutlineInputBorder()),
+                  obscureText: !passwordVisible,
+                  decoration: InputDecoration(
+                    labelText: 'Password',
+                    border: const OutlineInputBorder(),
+                    suffixIcon: IconButton(
+                      onPressed: () {
+                        setState(() {
+                          passwordVisible = !passwordVisible;
+                        });
+                      },
+                      icon: Icon(passwordVisible
+                          ? Icons.visibility_rounded
+                          : Icons.visibility_off_rounded),
+                    ),
+                  ),
                 ),
                 // const SizedBox(height: 20),
                 // ExpansionTile(


### PR DESCRIPTION
- 删除了 search bar 和 search view 的阴影
- 手动实现 viewLeading 来使用 Material 3 的返回 icon (macOS 的 BackButton 一直在用错误的 icon)
- 全屏 searh view 用宽度来判断，flutter 默认是平台判断
- 隐藏 webdav 密码
- 移动了一些 padding，避免如图滚动条的出现
- clipBehavior 用 antiAlias，减少圆角锯齿

<img width="118" alt="image" src="https://github.com/user-attachments/assets/7053a700-33da-4f35-be1e-38cd4792e7ba" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/e7475b5e-4416-4dc0-82a4-461af2127398" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/981ed0b5-6cfb-4112-8f49-f78a71bf9875" />
