### PR TITLE
Setup StartupWMClass in linux desktop file

### DIFF
--- a/assets/linux/io.github.Predidit.Kazumi.desktop
+++ b/assets/linux/io.github.Predidit.Kazumi.desktop
@@ -3,6 +3,7 @@ Name=Kazumi
 Comment=Watch Animes online with danmaku support.
 Comment[zh_CN]=一款好用的追番软件
 Exec=kazumi
+StartupWMClass=kazumi
 Icon=io.github.Predidit.Kazumi
 Terminal=false
 Type=Application


### PR DESCRIPTION
修复直接使用deb安装时任务栏不能正确显示图标的问题

before
![before](https://github.com/user-attachments/assets/aa3ba351-9e0b-40f6-b861-7f294358567f)

after
![after](https://github.com/user-attachments/assets/bd104212-e969-4da8-a03c-6a427c4af57a)

可能是Gnome DE下特有的问题，使用flatpak版本不存在此问题，不过应该也不会影响其他平台正常工作