### PR TITLE
feat: migrate from webview_flutter to flutter_inappwebview for Apple platforms

### DIFF
--- a/lib/pages/webview/webview_controller_impel/webview_apple_controller_impel.dart
+++ b/lib/pages/webview/webview_controller_impel/webview_apple_controller_impel.dart
@@ -2,329 +2,252 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kazumi/utils/utils.dart';
 import 'package:kazumi/pages/webview/webview_controller.dart';
-import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
-// The following code using almost the same code from lib/pages/webview/webview_controller.dart.
-// It's a workaround for webview_flutter lib (It behaves differently on macOS/iOS and Android).
-// 1. We need onPageFinished rather than onUrlChanged to execute JavaScript code when document created.
-// 2. We need encode all url received from JavaScript channel to avoid crash.
 class WebviewAppleItemControllerImpel
-    extends WebviewItemController<WebViewController> {
-  // workaround for webview_flutter lib.
-  // webview_flutter lib won't change currentUrl after redirect using window.location.href.
-  // which causes multiple redirects to the same url.
-  // so we need to store the currentUrl manually
-  String currentUrl = '';
-
-  Timer? ifrmaeParserTimer;
-  Timer? videoParserTimer;
+    extends WebviewItemController<InAppWebViewController> {
+  Timer? loadingMonitorTimer;
 
   @override
   Future<void> init() async {
-    webviewController ??= WebViewController();
     initEventController.add(true);
   }
 
   @override
   Future<void> loadUrl(String url, bool useNativePlayer, bool useLegacyParser,
       {int offset = 0}) async {
-    ifrmaeParserTimer?.cancel();
-    videoParserTimer?.cancel();
     await unloadPage();
-    await setDesktopUserAgent();
+    addJavaScriptHandlers(useNativePlayer, useLegacyParser);
+    await addUserScripts(useNativePlayer, useLegacyParser);
     count = 0;
-    currentUrl = '';
     this.offset = offset;
     isIframeLoaded = false;
     isVideoSourceLoaded = false;
     videoLoadingEventController.add(true);
-    await webviewController!
-        .setNavigationDelegate(NavigationDelegate(onPageFinished: (currentUrl) {
-      debugPrint('Current URL: $currentUrl');
-      if (useNativePlayer && !useLegacyParser) {
-        addBlobParser();
-        addInviewIframeBridge();
-      }
-      // addFullscreenListener();
-    }));
-    await webviewController!.setJavaScriptMode(JavaScriptMode.unrestricted);
-    await webviewController!.addJavaScriptChannel('JSBridgeDebug',
-        onMessageReceived: (JavaScriptMessage message) {
-      logEventController.add('Callback received: ${message.message}');
-      logEventController.add(
-          'If there is audio but no video, please report it to the rule developer.');
-      if ((message.message.contains('http') ||
-              message.message.startsWith('//')) &&
-          !message.message.contains('googleads') &&
-          !message.message.contains('googlesyndication.com') &&
-          !message.message.contains('prestrain.html') &&
-          !message.message.contains('prestrain%2Ehtml') &&
-          !message.message.contains('adtrafficquality') &&
-          currentUrl != message.message) {
-        logEventController.add('Parsing video source ${message.message}');
-        currentUrl = Uri.encodeFull(message.message);
-        redirctWithReferer(message.message);
-        if (Utils.decodeVideoSource(currentUrl) != Uri.encodeFull(currentUrl) &&
-            useNativePlayer &&
-            useLegacyParser) {
-          isIframeLoaded = true;
-          isVideoSourceLoaded = true;
-          videoLoadingEventController.add(false);
-          logEventController.add(
-              'Loading video source ${Utils.decodeVideoSource(currentUrl)}');
-          unloadPage();
-          videoParserEventController
-              .add((Utils.decodeVideoSource(currentUrl), offset));
-        }
-      }
-    });
-    await webviewController!.addJavaScriptChannel('IframeRedirectBridge',
-        onMessageReceived: (JavaScriptMessage message) {
-      logEventController.add('Redirect to: ${message.message}');
-      if (!useNativePlayer) {
-        Future.delayed(const Duration(seconds: 2), () {
-          isIframeLoaded = true;
-          videoLoadingEventController.add(false);
-        });
-      }
-    });
-    if (!useLegacyParser) {
-      await webviewController!.addJavaScriptChannel('VideoBridgeDebug',
-          onMessageReceived: (JavaScriptMessage message) {
-        logEventController.add('Callback received: ${message.message}');
-        if (message.message.contains('http') && !isVideoSourceLoaded) {
-          logEventController.add('Loading video source: ${message.message}');
-          isIframeLoaded = true;
-          isVideoSourceLoaded = true;
-          videoLoadingEventController.add(false);
-          if (useNativePlayer) {
-            unloadPage();
-            videoParserEventController.add((message.message, offset));
-          }
-        }
-      });
-    }
-    await webviewController!.loadRequest(Uri.parse(url));
 
-    ifrmaeParserTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (isIframeLoaded) {
+    await webviewController?.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
+
+    loadingMonitorTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (isVideoSourceLoaded) {
         timer.cancel();
       } else {
         count++;
-        parseIframeUrl();
+        if (count >= 15) {
+          timer.cancel();
+          isIframeLoaded = true;
+
+          logEventController.add('clear');
+          logEventController.add('解析视频资源超时');
+          logEventController.add('请切换到其他播放列表或视频源');
+          logEventController.add('showDebug');
+        }
       }
     });
-    if (useNativePlayer) {
-      videoParserTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-        if (isVideoSourceLoaded) {
-          timer.cancel();
-        } else {
-          if (count >= 15) {
-            timer.cancel();
-            isIframeLoaded = true;
-            logEventController.add('clear');
-            logEventController.add('解析视频资源超时');
-            logEventController.add('请切换到其他播放列表或视频源');
-            logEventController.add('showDebug');
-          } else {
-            if (!useLegacyParser) {
-              parseVideoSource();
+  }
+
+  void addJavaScriptHandlers(bool useNativePlayer, bool useLegacyParser) {
+    if (!useNativePlayer) {
+      debugPrint('[WebView] Adding IframeRedirectBridge handler');
+      webviewController?.addJavaScriptHandler(
+          handlerName: 'IframeRedirectBridge',
+          callback: (args) {
+            String message = args[0].toString();
+            logEventController.add('Redirect to: $message');
+            Future.delayed(const Duration(seconds: 2), () {
+              isIframeLoaded = true;
+              videoLoadingEventController.add(false);
+            });
+          });
+    } else if (useLegacyParser) {
+      debugPrint('[WebView] Adding JSBridgeDebug handler');
+      webviewController?.addJavaScriptHandler(
+          handlerName: 'JSBridgeDebug',
+          callback: (args) {
+            String message = args[0].toString();
+            logEventController.add('Callback received: $message');
+            logEventController.add(
+                'If there is audio but no video, please report it to the rule developer.');
+            if ((message.contains('http') || message.startsWith('//')) &&
+                !message.contains('googleads') &&
+                !message.contains('googlesyndication.com') &&
+                !message.contains('prestrain.html') &&
+                !message.contains('prestrain%2Ehtml') &&
+                !message.contains('adtrafficquality')) {
+              logEventController.add('Parsing video source $message');
+              String encodedUrl = Uri.encodeFull(message);
+              if (Utils.decodeVideoSource(encodedUrl) != encodedUrl) {
+                isIframeLoaded = true;
+                isVideoSourceLoaded = true;
+                videoLoadingEventController.add(false);
+                logEventController.add(
+                    'Loading video source ${Utils.decodeVideoSource(encodedUrl)}');
+                unloadPage();
+                videoParserEventController
+                    .add((Utils.decodeVideoSource(encodedUrl), offset));
+              }
+            }
+          });
+    } else {
+      debugPrint('[WebView] Adding VideoBridgeDebug handler');
+      webviewController?.addJavaScriptHandler(
+          handlerName: 'VideoBridgeDebug',
+          callback: (args) {
+            String message = args[0].toString();
+            logEventController.add('Callback received: $message');
+            if (message.contains('http') && !isVideoSourceLoaded) {
+              logEventController.add('Loading video source: $message');
+              isIframeLoaded = true;
+              isVideoSourceLoaded = true;
+              videoLoadingEventController.add(false);
+              unloadPage();
+              videoParserEventController.add((message, offset));
+            }
+          });
+    }
+  }
+
+  Future<void> addUserScripts(
+      bool useNativePlayer, bool useLegacyParser) async {
+    final List<UserScript> scripts = [];
+
+    if (!useNativePlayer) {
+      debugPrint('[WebView] Adding IframeRedirectBridge user script');
+      const String iframeRedirectScript = """
+        var iframes = document.getElementsByTagName('iframe');
+        for (var i = 0; i < iframes.length; i++) {
+              var iframe = iframes[i];
+              var src = iframe.getAttribute('src');
+              if (src && src.trim() !== '' && (src.startsWith('http') || src.startsWith('//')) && !src.includes('googleads') && !src.includes('adtrafficquality') && !src.includes('googlesyndication.com') && !src.includes('google.com') && !src.includes('prestrain.html') && !src.includes('prestrain%2Ehtml')) {
+                  window.flutter_inappwebview.callHandler('IframeRedirectBridge', src);
+                  window.location.href = src;
+                  break; 
+              }
+          }
+      """;
+      scripts.add(UserScript(
+        source: iframeRedirectScript,
+        injectionTime: UserScriptInjectionTime.AT_DOCUMENT_END,
+        forMainFrameOnly: true,
+      ));
+    } else if (useLegacyParser) {
+      debugPrint('[WebView] Adding JSBridgeDebug user script');
+      const String jsBridgeDebugScript = """
+        var iframes = document.getElementsByTagName('iframe');
+        window.flutter_inappwebview.callHandler('JSBridgeDebug', 'The number of iframe tags is' + iframes.length);
+        for (var i = 0; i < iframes.length; i++) {
+            var iframe = iframes[i];
+            var src = iframe.getAttribute('src');
+            if (src) {
+              window.flutter_inappwebview.callHandler('JSBridgeDebug', src);
+            }
+        }
+      """;
+      scripts.add(UserScript(
+        source: jsBridgeDebugScript,
+        injectionTime: UserScriptInjectionTime.AT_DOCUMENT_END,
+        forMainFrameOnly: false,
+      ));
+    } else {
+      debugPrint('[WebView] Adding VideoBridgeDebug user script');
+      const String blobParserScript = """
+        const _r_text = window.Response.prototype.text;
+        window.Response.prototype.text = function () {
+            return new Promise((resolve, reject) => {
+                _r_text.call(this).then((text) => {
+                    resolve(text);
+                    if (text.trim().startsWith("#EXTM3U")) {
+                        console.log('M3U8 source found:', this.url);
+                        window.flutter_inappwebview.callHandler('VideoBridgeDebug', this.url);
+                    }
+                }).catch(reject);
+            });
+        }
+
+        const _open = window.XMLHttpRequest.prototype.open;
+        window.XMLHttpRequest.prototype.open = function (...args) {
+            this.addEventListener("load", () => {
+                try {
+                    let content = this.responseText;
+                    if (content.trim().startsWith("#EXTM3U")) {
+                        console.log('M3U8 source found:', args[1]);
+                        window.flutter_inappwebview.callHandler('VideoBridgeDebug', args[1]);
+                    };
+                } catch {}
+            });
+            return _open.apply(this, args);
+        };
+      """;
+
+      const String videoTagParserScript = """
+        function processVideoElement(video) {
+          window.flutter_inappwebview.callHandler('VideoBridgeDebug', 'Scanning video tag for source URL');
+          let src = video.getAttribute('src');
+          if (src && src.trim() !== '' && !src.startsWith('blob:') && !src.includes('googleads')) {
+            console.log('VIDEO source found:', src);
+            window.flutter_inappwebview.callHandler('VideoBridgeDebug', src);
+            return;
+          }
+          const sources = video.getElementsByTagName('source');
+          for (let source of sources) {
+            src = source.getAttribute('src');
+            if (src && src.trim() !== '' && !src.startsWith('blob:') && !src.includes('googleads')) {
+              console.log('VIDEO source found (source tag):', src);
+              window.flutter_inappwebview.callHandler('VideoBridgeDebug', src);
+              return;
             }
           }
         }
-      });
+
+        document.querySelectorAll('video').forEach(processVideoElement);
+
+        const _observer = new MutationObserver((mutations) => {
+          mutations.forEach(mutation => {
+            if (mutation.type === 'attributes' && mutation.target.nodeName === 'VIDEO') {
+              processVideoElement(mutation.target);
+            }
+            mutation.addedNodes.forEach(node => {
+              if (node.nodeName === 'VIDEO') processVideoElement(node);
+              if (node.querySelectorAll) {
+                node.querySelectorAll('video').forEach(processVideoElement);
+              }
+            });
+          });  
+        });
+
+        _observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          attributeFilter: ['src']
+        });
+    """;
+      scripts.add(UserScript(
+        source: blobParserScript,
+        injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+        forMainFrameOnly: false,
+      ));
+      scripts.add(UserScript(
+        source: videoTagParserScript,
+        injectionTime: UserScriptInjectionTime.AT_DOCUMENT_END,
+        forMainFrameOnly: false,
+      ));
     }
+
+    await webviewController?.addUserScripts(
+      userScripts: scripts,
+    );
   }
 
   @override
   Future<void> unloadPage() async {
+    loadingMonitorTimer?.cancel();
+    await InAppWebViewController.clearAllCache();
     await webviewController!
-        .removeJavaScriptChannel('JSBridgeDebug')
-        .catchError((_) {});
-    await webviewController!
-        .removeJavaScriptChannel('VideoBridgeDebug')
-        .catchError((_) {});
-    await webviewController!
-        .removeJavaScriptChannel('IframeRedirectBridge')
-        .catchError((_) {});
-    await webviewController!.loadRequest(Uri.parse('about:blank'));
-    await webviewController!.clearCache();
-    ifrmaeParserTimer?.cancel();
-    videoParserTimer?.cancel();
+        .loadUrl(urlRequest: URLRequest(url: WebUri("about:blank")));
   }
 
   @override
   void dispose() {
-    unloadPage();
-  }
-
-  Future<void> parseIframeUrl() async {
-    await webviewController!.runJavaScript('''
-      var iframes = document.getElementsByTagName('iframe');
-      JSBridgeDebug.postMessage('The number of iframe tags is' + iframes.length);
-      for (var i = 0; i < iframes.length; i++) {
-          var iframe = iframes[i];
-          var src = iframe.getAttribute('src');
-          if (src) {
-            JSBridgeDebug.postMessage(src);
-          }
-
-          if (src && src.trim() !== '' && (src.startsWith('http') || src.startsWith('//')) && !src.includes('googleads') && !src.includes('adtrafficquality') && !src.includes('googlesyndication.com') && !src.includes('google.com') && !src.includes('prestrain.html') && !src.includes('prestrain%2Ehtml')) {
-              IframeRedirectBridge.postMessage(src);
-              break; 
-          }
-      }
-  ''');
-  }
-
-  Future<void> redirctWithReferer(String src) async {
-    await webviewController!.runJavaScript('window.location.href = "$src";');
-  }
-
-  // 非blob资源
-  Future<void> parseVideoSource() async {
-    await webviewController!.runJavaScript('''
-      var videos = document.querySelectorAll('video');
-      VideoBridgeDebug.postMessage('The number of video tags is' + videos.length);
-      for (var i = 0; i < videos.length; i++) {
-        var src = videos[i].getAttribute('src');
-        if (src && src.trim() !== '' && !src.startsWith('blob:') && !src.includes('googleads')) {
-          VideoBridgeDebug.postMessage(src);
-          break;
-        } 
-      }
-      document.querySelectorAll('iframe').forEach((iframe) => {
-        try {
-          iframe.contentWindow.eval(`
-            var videos = document.querySelectorAll('video');
-            window.parent.postMessage({ message: 'videoMessage:' + 'The number of video tags is' + videos.length }, "*");
-            for (var i = 0; i < videos.length; i++) {
-              var src = videos[i].getAttribute('src');
-              if (src && src.trim() !== '' && !src.startsWith('blob:') && !src.includes('googleads')) {
-                window.parent.postMessage({ message: 'videoMessage:' + src }, "*");
-              } 
-            }
-                  `);
-        } catch { }
-      });
-    ''');
-  }
-
-  // blob资源
-  Future<void> addBlobParser() async {
-    await webviewController!.runJavaScript('''
-      const _r_text = window.Response.prototype.text;
-      window.Response.prototype.text = function () {
-          return new Promise((resolve, reject) => {
-              _r_text.call(this).then((text) => {
-                  resolve(text);
-                  if (text.trim().startsWith("#EXTM3U")) {
-                      VideoBridgeDebug.postMessage(this.url);
-                  }
-              }).catch(reject);
-          });
-      }
-
-      const _open = window.XMLHttpRequest.prototype.open;
-      window.XMLHttpRequest.prototype.open = function (...args) {
-          this.addEventListener("load", () => {
-              try {
-                  let content = this.responseText;
-                  if (content.trim().startsWith("#EXTM3U")) {
-                      VideoBridgeDebug.postMessage(args[1]);
-                  };
-              } catch { }
-          });
-          return _open.apply(this, args);
-      }
-      
-      function injectIntoIframe(iframe) {
-        try {
-          const iframeWindow = iframe.contentWindow;
-          if (!iframeWindow) return;
-          
-          const iframe_r_text = iframeWindow.Response.prototype.text;
-          iframeWindow.Response.prototype.text = function () {
-            return new Promise((resolve, reject) => {
-              iframe_r_text.call(this).then((text) => {
-                resolve(text);
-                if (text.trim().startsWith("#EXTM3U")) {
-                  console.log(this.url);
-                  VideoBridgeDebug.postMessage(this.url);
-                }
-              }).catch(reject);
-            });
-          }
-          
-          const iframe_open = iframeWindow.XMLHttpRequest.prototype.open;
-          iframeWindow.XMLHttpRequest.prototype.open = function (...args) {
-            this.addEventListener("load", () => {
-              try {
-                let content = this.responseText;
-                if (content.trim().startsWith("#EXTM3U")) {
-                  console.log(args[1]);
-                  VideoBridgeDebug.postMessage(args[1]);
-                };
-              } catch { }
-            });
-            return iframe_open.apply(this, args);
-          }
-        } catch (e) {
-          console.error('iframe inject failed:', e);
-        }
-      }
-
-      function setupIframeListeners() {
-        document.querySelectorAll('iframe').forEach(iframe => {
-          if (iframe.contentDocument) {
-            injectIntoIframe(iframe);
-          }
-          iframe.addEventListener('load', () => injectIntoIframe(iframe));
-        });
-        
-        const observer = new MutationObserver(mutations => {
-          mutations.forEach(mutation => {
-            if (mutation.type === 'childList') {
-              mutation.addedNodes.forEach(node => {
-                if (node.nodeName === 'IFRAME') {
-                  node.addEventListener('load', () => injectIntoIframe(node));
-                }
-                if (node.querySelectorAll) {
-                  node.querySelectorAll('iframe').forEach(iframe => {
-                    iframe.addEventListener('load', () => injectIntoIframe(iframe));
-                  });
-                }
-              });
-            }
-          });
-        });
-        
-        observer.observe(document.body, { childList: true, subtree: true });
-      }
-
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', setupIframeListeners);
-      } else {
-        setupIframeListeners();
-      }   
-    ''');
-  }
-
-  Future<void> addInviewIframeBridge() async {
-    await webviewController!.runJavaScript('''
-      window.addEventListener("message", function(event) {
-        if (event.data) {
-          if (event.data.message && event.data.message.startsWith('videoMessage:')) {
-            VideoBridgeDebug.postMessage(event.data.message.replace(/^videoMessage:/, ''));
-          }
-        }
-      });
-    ''');
-  }
-
-  // 设定UA
-  Future<void> setDesktopUserAgent() async {
-    String desktopUserAgent = Utils.getRandomUA();
-    await webviewController!.setUserAgent(desktopUserAgent);
+    loadingMonitorTimer?.cancel();
   }
 }

--- a/lib/pages/webview/webview_item.dart
+++ b/lib/pages/webview/webview_item.dart
@@ -3,11 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:kazumi/pages/webview/webview_item_impel/webview_item_impel.dart';
 import 'package:kazumi/pages/webview/webview_item_impel/webview_windows_item_impel.dart';
 import 'package:kazumi/pages/webview/webview_item_impel/webview_linux_item_impel.dart';
+import 'package:kazumi/pages/webview/webview_item_impel/webview_apple_item_impel.dart';
 
 class WebviewItem extends StatefulWidget {
-  const WebviewItem({
-    super.key
-  });
+  const WebviewItem({super.key});
 
   @override
   State<WebviewItem> createState() => _WebviewItemState();
@@ -27,6 +26,8 @@ Widget get webviewUniversal {
   if (Platform.isLinux) {
     return const WebviewLinuxItemImpel();
   }
+  if (Platform.isMacOS || Platform.isIOS) {
+    return const WebviewAppleItemImpel();
+  }
   return const WebviewItemImpel();
 }
-

--- a/lib/pages/webview/webview_item_impel/webview_apple_item_impel.dart
+++ b/lib/pages/webview/webview_item_impel/webview_apple_item_impel.dart
@@ -1,0 +1,142 @@
+import 'dart:collection';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:kazumi/pages/webview/webview_controller.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:kazumi/utils/utils.dart';
+
+class WebviewAppleItemImpel extends StatefulWidget {
+  const WebviewAppleItemImpel({super.key});
+
+  @override
+  State<WebviewAppleItemImpel> createState() => _WebviewAppleItemImpelState();
+}
+
+class _WebviewAppleItemImpelState extends State<WebviewAppleItemImpel> {
+  final webviewAppleItemController = Modular.get<WebviewItemController>();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Widget get compositeView {
+    return InAppWebView(
+      initialUserScripts: UnmodifiableListView<UserScript>([
+        UserScript(
+          source: '''
+            function removeLazyLoading() {
+              document.querySelectorAll('iframe[loading="lazy"]').forEach(iframe => {
+                console.log('Removing lazy loading from:', iframe.src);
+                iframe.removeAttribute('loading');
+              });
+            }
+            if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', removeLazyLoading);
+            } else {
+              removeLazyLoading();
+            }
+          ''',
+          injectionTime: UserScriptInjectionTime.AT_DOCUMENT_END,
+        ),
+      ]),
+      initialSettings: InAppWebViewSettings(
+        userAgent: Utils.getRandomUA(),
+        mediaPlaybackRequiresUserGesture: true,
+        useOnLoadResource: false,
+        cacheEnabled: false,
+        isInspectable: false,
+        contentBlockers: [
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?devtools-detector\.js",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.SCRIPT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(urlFilter: '.*', resourceType: [
+              ContentBlockerTriggerResourceType.IMAGE,
+            ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?googleads",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.DOCUMENT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?googlesyndication\.com",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.DOCUMENT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?prestrain\.html",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.DOCUMENT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?prestrain%2Ehtml",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.DOCUMENT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+          ContentBlocker(
+            trigger: ContentBlockerTrigger(
+                urlFilter: r"^https?://.+?adtrafficquality",
+                resourceType: [
+                  ContentBlockerTriggerResourceType.DOCUMENT,
+                ]),
+            action: ContentBlockerAction(type: ContentBlockerActionType.BLOCK),
+          ),
+        ],
+      ),
+      onWebViewCreated: (controller) {
+        debugPrint('[WebView] Created');
+        webviewAppleItemController.webviewController = controller;
+        webviewAppleItemController.init();
+      },
+      onLoadStart: (controller, url) {
+        debugPrint('[WebView] Started loading: $url');
+      },
+      onLoadStop: (controller, url) {
+        debugPrint('[WebView] Loading completed: $url');
+      },
+      onConsoleMessage: (controller, consoleMessage) {
+        debugPrint(
+            '[WebView] Console.${consoleMessage.messageLevel}: ${consoleMessage.message}');
+      },
+      onLoadResource: (controller, resource) {
+        debugPrint(
+            '[WebView] Resource: ${resource.url} - ${resource.initiatorType}');
+      },
+      onReceivedError: (controller, request, error) {
+        debugPrint(
+            '[WebView] Error: ${error.toString()} - Request: ${request.url}');
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    webviewAppleItemController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return compositeView;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -460,6 +460,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  flutter_inappwebview:
+    dependency: "direct main"
+    description:
+      name: flutter_inappwebview
+      sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  flutter_inappwebview_android:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_android
+      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  flutter_inappwebview_ios:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_ios
+      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_macos:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_macos
+      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_platform_interface
+      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0+1"
+  flutter_inappwebview_web:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_web
+      sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_inappwebview_windows:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_windows
+      sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -108,6 +108,7 @@ dependencies:
       url: https://github.com/Predidit/media-kit.git
       ref: main
       path: ./libs/universal/media_kit_libs_video
+  flutter_inappwebview: ^6.1.5
 
 dependency_overrides:
   media_kit_libs_linux:


### PR DESCRIPTION
将 Apple 平台的 WebView 实现从 `webview_flutter` 迁移到 `flutter_inappwebview`，使用 User Scripts 机制彻底解决注入时机问题。

## 改进效果

- 使用 AT_DOCUMENT_START 确保在资源加载前注入
- User Scripts 可以直接注入到 iframe 中，不再需要考虑跨域问题
- 所有有效规则在 iOS/macOS 上都可以正常工作
- LegacyParser 规则在不使用 LegacyParser 的情况下也能正常工作  