### PR TITLE
fix: webdav自动上传与历史记录保存冲突

### DIFF
--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -45,6 +45,10 @@ abstract class _PlayerController with Store {
   @observable
   int syncplayClientRtt = 0;
 
+  // WebDAV状态
+  @observable
+  bool isWebDavUploading = false;
+
   /// 视频比例类型
   /// 1. AUTO
   /// 2. COVER

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -45,10 +45,6 @@ abstract class _PlayerController with Store {
   @observable
   int syncplayClientRtt = 0;
 
-  // WebDAV状态
-  @observable
-  bool isWebDavUploading = false;
-
   /// 视频比例类型
   /// 1. AUTO
   /// 2. COVER

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -191,13 +191,29 @@ class _PlayerItemState extends State<PlayerItem>
     });
   }
 
+  Future<void> _uploadHistoryToWebDav() async {
+    if (webDavEnable && webDavEnableHistory) {
+      if(!playerController.isWebDavUploading){
+        try {
+          playerController.isWebDavUploading = true;
+          var webDav = WebDav();
+          await webDav.ping();
+          await webDav.updateHistory();
+        } catch (e) {
+          KazumiLogger().log(Level.error, 'webDav update history failed $e');
+        } finally {
+          playerController.isWebDavUploading = false;
+        }
+      }
+    }
+  }
+
   void _handleFullscreenChange(BuildContext context) async {
     playerController.lockPanel = false;
     playerController.danmakuController.clear();
-    if (webDavEnable && webDavEnableHistory) {
-      var webDav = WebDav();
-      webDav.updateHistory();
-    }
+    
+    _uploadHistoryToWebDav();
+
   }
 
   void handleProgressBarDragStart(ThumbDragDetails details) {
@@ -355,7 +371,8 @@ class _PlayerItemState extends State<PlayerItem>
       }
       // 历史记录相关
       if (playerController.playerPlaying && !videoPageController.loading) {
-        historyController.updateHistory(
+        if (!playerController.isWebDavUploading){
+          historyController.updateHistory(
             videoPageController.currentEpisode,
             videoPageController.currentRoad,
             videoPageController.currentPlugin.name,
@@ -364,6 +381,7 @@ class _PlayerItemState extends State<PlayerItem>
             videoPageController.src,
             videoPageController.roadList[videoPageController.currentRoad]
                 .identifier[videoPageController.currentEpisode - 1]);
+        }
       }
       // 自动播放下一集
       if (playerController.completed &&

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -193,26 +193,20 @@ class _PlayerItemState extends State<PlayerItem>
 
   Future<void> _uploadHistoryToWebDav() async {
     if (webDavEnable && webDavEnableHistory) {
-      if(!playerController.isWebDavUploading){
         try {
-          playerController.isWebDavUploading = true;
           var webDav = WebDav();
-          await webDav.ping();
           await webDav.updateHistory();
         } catch (e) {
           KazumiLogger().log(Level.error, 'webDav update history failed $e');
-        } finally {
-          playerController.isWebDavUploading = false;
         }
-      }
     }
   }
 
   void _handleFullscreenChange(BuildContext context) async {
     playerController.lockPanel = false;
     playerController.danmakuController.clear();
-    
-    _uploadHistoryToWebDav();
+
+    await _uploadHistoryToWebDav();
 
   }
 
@@ -371,7 +365,7 @@ class _PlayerItemState extends State<PlayerItem>
       }
       // 历史记录相关
       if (playerController.playerPlaying && !videoPageController.loading) {
-        if (!playerController.isWebDavUploading){
+        if (!WebDav().isHistorySyncing){
           historyController.updateHistory(
             videoPageController.currentEpisode,
             videoPageController.currentRoad,

--- a/lib/pages/webdav_editor/webdav_setting.dart
+++ b/lib/pages/webdav_editor/webdav_setting.dart
@@ -146,7 +146,6 @@ class _PlayerSettingsPageState extends State<WebDavSettingsPage> {
                           } catch (e) {
                             webDavEnable = false;
                             KazumiDialog.showToast(message: 'WEBDAV初始化失败 $e');
-                            return;
                           }  
                         }
                         if (!webDavEnable) {

--- a/lib/pages/webdav_editor/webdav_setting.dart
+++ b/lib/pages/webdav_editor/webdav_setting.dart
@@ -141,7 +141,13 @@ class _PlayerSettingsPageState extends State<WebDavSettingsPage> {
                       onToggle: (value) async {
                         webDavEnable = value ?? !webDavEnable;
                         if (!WebDav().initialized && webDavEnable) {
-                          WebDav().init();
+                          try{
+                            await WebDav().init();
+                          } catch (e) {
+                            webDavEnable = false;
+                            KazumiDialog.showToast(message: 'WEBDAV初始化失败 $e');
+                            return;
+                          }  
                         }
                         if (!webDavEnable) {
                           webDavEnableHistory = false;

--- a/lib/utils/webdav.dart
+++ b/lib/utils/webdav.dart
@@ -86,7 +86,8 @@ class WebDav {
   Future<void> updateHistory() async {
     if (isHistorySyncing) {
       KazumiLogger().log(Level.warning, 'History is currently syncing');
-      throw Exception('History is currently syncing');
+      //throw Exception('History is currently syncing');
+      return;
     }
     isHistorySyncing = true;
     try {

--- a/lib/utils/webdav.dart
+++ b/lib/utils/webdav.dart
@@ -32,6 +32,10 @@ class WebDav {
         setting.get(SettingBoxKey.webDavUsername, defaultValue: '');
     webDavPassword =
         setting.get(SettingBoxKey.webDavPassword, defaultValue: '');
+    if (webDavURL.isEmpty) {
+      //KazumiLogger().log(Level.warning, 'WebDAV URL is not set');
+      throw Exception('请先填写WebDAV URL');
+    }
     client = webdav.newClient(
       webDavURL,
       user: webDavUsername,

--- a/lib/utils/webdav.dart
+++ b/lib/utils/webdav.dart
@@ -58,10 +58,12 @@ class WebDav {
 
   Future<void> update(String boxName) async {
     var directory = await getApplicationSupportDirectory();
+    await File('${directory.path}/hive/$boxName.hive')
+          .copy('${directory.path}/hive/$boxName.hive.tmp');
     try {
       await client.remove('/kazumiSync/$boxName.tmp.cache');
     } catch (_) {}
-    await client.writeFromFile('${directory.path}/hive/$boxName.hive',
+    await client.writeFromFile('${directory.path}/hive/$boxName.hive.tmp',
         '/kazumiSync/$boxName.tmp.cache', onProgress: (c, t) {
       // print(c / t);
     });
@@ -72,6 +74,9 @@ class WebDav {
     }
     await client.rename(
         '/kazumiSync/$boxName.tmp.cache', '/kazumiSync/$boxName.tmp', true);
+    try {
+      await File('${directory.path}/hive/$boxName.hive.tmp').delete();
+    } catch (_) {}
   }
 
   Future<void> updateHistory() async {


### PR DESCRIPTION
fix #1179  ，加强了webdav初始化验证

debug模式下每次上传都会输出
```shell
[🔔 Dio] _FileStream cannot be used to imply a default content-type, please set a proper content-type in the request.
[🔔 Dio] #0      ImplyContentTypeInterceptor.onRequest (package:dio/src/interceptors/imply_content_type.dart:33:22)
imply_content_type.dart:33
         #1      DioMixin.fetch.requestInterceptorWrapper.<anonymous closure>.<anonymous closure> (package:dio/src/dio_mixin.dart:401:17)
dio_mixin.dart:401
         #2      new Future.<anonymous closure> (dart:async/future.dart:260:40)
future.dart:260
         #3      Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
timer_patch.dart:18
         #4      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:410:19)
timer_impl.dart:410
         #5      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:441:5)
timer_impl.dart:441
         #6      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
isolate_patch.dart:193
```
不知道有没有问题
