### PR TITLE
feat: new settings interface with slider

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -247,6 +247,7 @@ class _AppWidgetState extends State<AppWidget>
         brightness: Brightness.dark,
         colorSchemeSeed: color,
         progressIndicatorTheme: progressIndicatorTheme2024,
+        sliderTheme: sliderTheme2024,
         pageTransitionsTheme: pageTransitionsTheme2024);
     var oledDarkTheme = Utils.oledDarkTheme(defaultDarkTheme);
     themeProvider.setTheme(
@@ -255,6 +256,7 @@ class _AppWidgetState extends State<AppWidget>
           brightness: Brightness.light,
           colorSchemeSeed: color,
           progressIndicatorTheme: progressIndicatorTheme2024,
+          sliderTheme: sliderTheme2024,
           pageTransitionsTheme: pageTransitionsTheme2024),
       oledEnhance ? oledDarkTheme : defaultDarkTheme,
       notify: false,
@@ -267,17 +269,20 @@ class _AppWidgetState extends State<AppWidget>
                 colorScheme: theme,
                 brightness: Brightness.light,
                 progressIndicatorTheme: progressIndicatorTheme2024,
+                sliderTheme: sliderTheme2024,
                 pageTransitionsTheme: pageTransitionsTheme2024),
             oledEnhance
                 ? Utils.oledDarkTheme(ThemeData(
                     colorScheme: darkTheme,
                     brightness: Brightness.dark,
                     progressIndicatorTheme: progressIndicatorTheme2024,
+                    sliderTheme: sliderTheme2024,
                     pageTransitionsTheme: pageTransitionsTheme2024))
                 : ThemeData(
                     colorScheme: darkTheme,
                     brightness: Brightness.dark,
                     progressIndicatorTheme: progressIndicatorTheme2024,
+                    sliderTheme: sliderTheme2024,
                     pageTransitionsTheme: pageTransitionsTheme2024),
             notify: false,
           );

--- a/lib/pages/my/my_page.dart
+++ b/lib/pages/my/my_page.dart
@@ -44,89 +44,85 @@ class _MyPageState extends State<MyPage> {
       },
       child: Scaffold(
         appBar: const SysAppBar(title: Text('我的'), needTopOffset: false),
-        body: Center(
-          child: SizedBox(
-            width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-            child: SettingsList(
-              sections: [
-                SettingsSection(
-                  title: const Text('播放历史与视频源'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/history/');
-                      },
-                      leading: const Icon(Icons.history_rounded),
-                      title: const Text('历史记录'),
-                      description: const Text('查看播放历史记录'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/plugin/');
-                      },
-                      leading: const Icon(Icons.extension),
-                      title: const Text('规则管理'),
-                      description: const Text('管理番剧资源规则'),
-                    ),
-                  ],
+        body: SettingsList(
+          maxWidth: 1000,
+          sections: [
+            SettingsSection(
+              title: const Text('播放历史与视频源'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/history/');
+                  },
+                  leading: const Icon(Icons.history_rounded),
+                  title: const Text('历史记录'),
+                  description: const Text('查看播放历史记录'),
                 ),
-                SettingsSection(
-                  title: const Text('播放器设置'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/player');
-                      },
-                      leading: const Icon(Icons.display_settings_rounded),
-                      title: const Text('播放设置'),
-                      description: const Text('设置播放器相关参数'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/danmaku/');
-                      },
-                      leading: const Icon(Icons.subtitles_rounded),
-                      title: const Text('弹幕设置'),
-                      description: const Text('设置弹幕相关参数'),
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('应用与外观'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/theme');
-                      },
-                      leading: const Icon(Icons.palette_rounded),
-                      title: const Text('外观设置'),
-                      description: const Text('设置应用主题和刷新率'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/webdav/');
-                      },
-                      leading: const Icon(Icons.cloud),
-                      title: const Text('同步设置'),
-                      description: const Text('设置同步参数'),
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('其他'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/about/');
-                      },
-                      leading: const Icon(Icons.info_outline_rounded),
-                      title: const Text('关于'),
-                    ),
-                  ],
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/plugin/');
+                  },
+                  leading: const Icon(Icons.extension),
+                  title: const Text('规则管理'),
+                  description: const Text('管理番剧资源规则'),
                 ),
               ],
             ),
-          ),
+            SettingsSection(
+              title: const Text('播放器设置'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/player');
+                  },
+                  leading: const Icon(Icons.display_settings_rounded),
+                  title: const Text('播放设置'),
+                  description: const Text('设置播放器相关参数'),
+                ),
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/danmaku/');
+                  },
+                  leading: const Icon(Icons.subtitles_rounded),
+                  title: const Text('弹幕设置'),
+                  description: const Text('设置弹幕相关参数'),
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: const Text('应用与外观'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/theme');
+                  },
+                  leading: const Icon(Icons.palette_rounded),
+                  title: const Text('外观设置'),
+                  description: const Text('设置应用主题和刷新率'),
+                ),
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/webdav/');
+                  },
+                  leading: const Icon(Icons.cloud),
+                  title: const Text('同步设置'),
+                  description: const Text('设置同步参数'),
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: const Text('其他'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/about/');
+                  },
+                  leading: const Icon(Icons.info_outline_rounded),
+                  title: const Text('关于'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -193,12 +193,12 @@ class _PlayerItemState extends State<PlayerItem>
 
   Future<void> _uploadHistoryToWebDav() async {
     if (webDavEnable && webDavEnableHistory) {
-        try {
-          var webDav = WebDav();
-          await webDav.updateHistory();
-        } catch (e) {
-          KazumiLogger().log(Level.error, 'webDav update history failed $e');
-        }
+      try {
+        var webDav = WebDav();
+        await webDav.updateHistory();
+      } catch (e) {
+        KazumiLogger().log(Level.error, 'webDav update history failed $e');
+      }
     }
   }
 
@@ -207,7 +207,6 @@ class _PlayerItemState extends State<PlayerItem>
     playerController.danmakuController.clear();
 
     await _uploadHistoryToWebDav();
-
   }
 
   void handleProgressBarDragStart(ThumbDragDetails details) {
@@ -365,16 +364,16 @@ class _PlayerItemState extends State<PlayerItem>
       }
       // 历史记录相关
       if (playerController.playerPlaying && !videoPageController.loading) {
-        if (!WebDav().isHistorySyncing){
+        if (!WebDav().isHistorySyncing) {
           historyController.updateHistory(
-            videoPageController.currentEpisode,
-            videoPageController.currentRoad,
-            videoPageController.currentPlugin.name,
-            videoPageController.bangumiItem,
-            playerController.playerPosition,
-            videoPageController.src,
-            videoPageController.roadList[videoPageController.currentRoad]
-                .identifier[videoPageController.currentEpisode - 1]);
+              videoPageController.currentEpisode,
+              videoPageController.currentRoad,
+              videoPageController.currentPlugin.name,
+              videoPageController.bangumiItem,
+              playerController.playerPosition,
+              videoPageController.src,
+              videoPageController.roadList[videoPageController.currentRoad]
+                  .identifier[videoPageController.currentEpisode - 1]);
         }
       }
       // 自动播放下一集

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -722,7 +722,8 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                     ),
                                     MenuItemButton(
                                       onPressed: () {
-                                        widget.showSyncPlayEndPointSwitchDialog();
+                                        widget
+                                            .showSyncPlayEndPointSwitchDialog();
                                       },
                                       child: const Padding(
                                         padding:
@@ -928,7 +929,13 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                                 showModalBottomSheet(
                                                     isScrollControlled: true,
                                                     constraints: BoxConstraints(
-                                                        maxHeight: 280,
+                                                        maxHeight:
+                                                            MediaQuery.of(
+                                                                        context)
+                                                                    .size
+                                                                    .height *
+                                                                3 /
+                                                                4,
                                                         maxWidth: (Utils
                                                                     .isDesktop() ||
                                                                 Utils
@@ -991,7 +998,11 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                       showModalBottomSheet(
                                           isScrollControlled: true,
                                           constraints: BoxConstraints(
-                                              maxHeight: 280,
+                                              maxHeight: MediaQuery.of(context)
+                                                      .size
+                                                      .height *
+                                                  3 /
+                                                  4,
                                               maxWidth: (Utils.isDesktop() ||
                                                       Utils.isTablet())
                                                   ? MediaQuery.of(context)
@@ -1163,16 +1174,23 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                                   );
                                 },
                                 menuChildren: [
-                                  for (final entry in aspectRatioTypeMap.entries)
+                                  for (final entry
+                                      in aspectRatioTypeMap.entries)
                                     MenuItemButton(
-                                      onPressed: () => playerController.aspectRatioType = entry.key,
+                                      onPressed: () => playerController
+                                          .aspectRatioType = entry.key,
                                       child: Padding(
-                                        padding: const EdgeInsets.fromLTRB(0, 10, 10, 10),
+                                        padding: const EdgeInsets.fromLTRB(
+                                            0, 10, 10, 10),
                                         child: Text(
                                           entry.value,
                                           style: TextStyle(
-                                            color: entry.key == playerController.aspectRatioType
-                                                ? Theme.of(context).colorScheme.primary
+                                            color: entry.key ==
+                                                    playerController
+                                                        .aspectRatioType
+                                                ? Theme.of(context)
+                                                    .colorScheme
+                                                    .primary
                                                 : null,
                                           ),
                                         ),

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -590,7 +590,10 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                               showModalBottomSheet(
                                 isScrollControlled: true,
                                 constraints: BoxConstraints(
-                                    maxHeight: 280,
+                                    maxHeight:
+                                        MediaQuery.of(context).size.height *
+                                            3 /
+                                            4,
                                     maxWidth: (Utils.isDesktop() ||
                                             Utils.isTablet())
                                         ? MediaQuery.of(context).size.width *

--- a/lib/pages/settings/danmaku/danmaku_settings.dart
+++ b/lib/pages/settings/danmaku/danmaku_settings.dart
@@ -6,7 +6,6 @@ import 'package:hive/hive.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/pages/popular/popular_controller.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
-import 'package:kazumi/utils/constants.dart';
 import 'package:card_settings_ui/card_settings_ui.dart';
 
 class DanmakuSettingsPage extends StatefulWidget {
@@ -110,386 +109,192 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
       },
       child: Scaffold(
         appBar: const SysAppBar(title: Text('弹幕设置')),
-        body: Center(
-          child: SizedBox(
-            width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-            child: SettingsList(
-              sections: [
-                SettingsSection(
-                  title: const Text('弹幕'),
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuEnabledByDefault =
-                            value ?? !danmakuEnabledByDefault;
-                        await setting.put(SettingBoxKey.danmakuEnabledByDefault,
-                            danmakuEnabledByDefault);
-                        setState(() {});
-                      },
-                      title: const Text('默认开启'),
-                      description: const Text('默认是否随视频播放弹幕'),
-                      initialValue: danmakuEnabledByDefault,
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('弹幕来源'),
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuBiliBiliSource = value ?? !danmakuBiliBiliSource;
-                        await setting.put(SettingBoxKey.danmakuBiliBiliSource,
-                            danmakuBiliBiliSource);
-                        setState(() {});
-                      },
-                      title: const Text('BiliBili'),
-                      initialValue: danmakuBiliBiliSource,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuGamerSource = value ?? !danmakuGamerSource;
-                        await setting.put(SettingBoxKey.danmakuGamerSource,
-                            danmakuGamerSource);
-                        setState(() {});
-                      },
-                      title: const Text('Gamer'),
-                      initialValue: danmakuGamerSource,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuDanDanSource = value ?? !danmakuDanDanSource;
-                        await setting.put(SettingBoxKey.danmakuDanDanSource,
-                            danmakuDanDanSource);
-                        setState(() {});
-                      },
-                      title: const Text('DanDan'),
-                      initialValue: danmakuDanDanSource,
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('弹幕屏蔽'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        Modular.to.pushNamed('/settings/danmaku/shield');
-                      },
-                      title: const Text('关键词屏蔽'),
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('弹幕显示'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('弹幕区域'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              return Wrap(
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  for (final double i
-                                      in danAreaList) ...<Widget>[
-                                    if (i == defaultDanmakuArea) ...<Widget>[
-                                      FilledButton(
-                                        onPressed: () async {
-                                          updateDanmakuArea(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ] else ...[
-                                      FilledButton.tonal(
-                                        onPressed: () async {
-                                          updateDanmakuArea(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ]
-                                  ]
-                                ],
-                              );
-                            }),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDanmakuArea(1.0);
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('弹幕区域'),
-                      value: Text('占据 $defaultDanmakuArea 屏幕'),
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuTop = value ?? !danmakuTop;
-                        await setting.put(SettingBoxKey.danmakuTop, danmakuTop);
-                        setState(() {});
-                      },
-                      title: const Text('顶部弹幕'),
-                      initialValue: danmakuTop,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuBottom = value ?? !danmakuBottom;
-                        await setting.put(
-                            SettingBoxKey.danmakuBottom, danmakuBottom);
-                        setState(() {});
-                      },
-                      title: const Text('底部弹幕'),
-                      initialValue: danmakuBottom,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuScroll = value ?? !danmakuScroll;
-                        await setting.put(
-                            SettingBoxKey.danmakuScroll, danmakuScroll);
-                        setState(() {});
-                      },
-                      title: const Text('滚动弹幕'),
-                      initialValue: danmakuScroll,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuMassive = value ?? !danmakuMassive;
-                        await setting.put(
-                            SettingBoxKey.danmakuMassive, danmakuMassive);
-                        setState(() {});
-                      },
-                      title: const Text('海量弹幕'),
-                      description: const Text('弹幕过多时进行叠加绘制'),
-                      initialValue: danmakuMassive,
-                    ),
-                  ],
-                ),
-                SettingsSection(
-                  title: const Text('弹幕样式'),
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuBorder = value ?? !danmakuBorder;
-                        await setting.put(
-                            SettingBoxKey.danmakuBorder, danmakuBorder);
-                        setState(() {});
-                      },
-                      title: const Text('弹幕描边'),
-                      initialValue: danmakuBorder,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        danmakuColor = value ?? !danmakuColor;
-                        await setting.put(
-                            SettingBoxKey.danmakuColor, danmakuColor);
-                        setState(() {});
-                      },
-                      title: const Text('弹幕颜色'),
-                      initialValue: danmakuColor,
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('字体大小'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              return Wrap(
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  for (final double i
-                                      in danFontList) ...<Widget>[
-                                    if (i ==
-                                        defaultDanmakuFontSize) ...<Widget>[
-                                      FilledButton(
-                                        onPressed: () async {
-                                          updateDanmakuFontSize(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ] else ...[
-                                      FilledButton.tonal(
-                                        onPressed: () async {
-                                          updateDanmakuFontSize(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ]
-                                  ]
-                                ],
-                              );
-                            }),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDanmakuFontSize(
-                                      (Utils.isCompact()) ? 16.0 : 25.0);
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('字体大小'),
-                      value: Text('$defaultDanmakuFontSize'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('字体字重'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              return Wrap(
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  for (final int i
-                                      in danFontWeightList) ...<Widget>[
-                                    if (i ==
-                                        defaultDanmakuFontWeight) ...<Widget>[
-                                      FilledButton(
-                                        onPressed: () async {
-                                          updateDanmakuFontWeight(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ] else ...[
-                                      FilledButton.tonal(
-                                        onPressed: () async {
-                                          updateDanmakuFontWeight(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ]
-                                  ]
-                                ],
-                              );
-                            }),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDanmakuFontWeight(4);
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('字体字重'),
-                      value: Text('$defaultDanmakuFontWeight'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('弹幕不透明度'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              return Wrap(
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  for (final double i
-                                      in danOpacityList) ...<Widget>[
-                                    if (i == defaultDanmakuOpacity) ...<Widget>[
-                                      FilledButton(
-                                        onPressed: () async {
-                                          updateDanmakuOpacity(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ] else ...[
-                                      FilledButton.tonal(
-                                        onPressed: () async {
-                                          updateDanmakuOpacity(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ]
-                                  ]
-                                ],
-                              );
-                            }),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDanmakuOpacity(1.0);
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('弹幕不透明度'),
-                      value: Text('$defaultDanmakuOpacity'),
-                    ),
-                  ],
+        body: SettingsList(
+          maxWidth: 1000,
+          sections: [
+            SettingsSection(
+              title: const Text('弹幕'),
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuEnabledByDefault = value ?? !danmakuEnabledByDefault;
+                    await setting.put(SettingBoxKey.danmakuEnabledByDefault,
+                        danmakuEnabledByDefault);
+                    setState(() {});
+                  },
+                  title: const Text('默认开启'),
+                  description: const Text('默认是否随视频播放弹幕'),
+                  initialValue: danmakuEnabledByDefault,
                 ),
               ],
             ),
-          ),
+            SettingsSection(
+              title: const Text('弹幕来源'),
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuBiliBiliSource = value ?? !danmakuBiliBiliSource;
+                    await setting.put(SettingBoxKey.danmakuBiliBiliSource,
+                        danmakuBiliBiliSource);
+                    setState(() {});
+                  },
+                  title: const Text('BiliBili'),
+                  initialValue: danmakuBiliBiliSource,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuGamerSource = value ?? !danmakuGamerSource;
+                    await setting.put(
+                        SettingBoxKey.danmakuGamerSource, danmakuGamerSource);
+                    setState(() {});
+                  },
+                  title: const Text('Gamer'),
+                  initialValue: danmakuGamerSource,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuDanDanSource = value ?? !danmakuDanDanSource;
+                    await setting.put(
+                        SettingBoxKey.danmakuDanDanSource, danmakuDanDanSource);
+                    setState(() {});
+                  },
+                  title: const Text('DanDan'),
+                  initialValue: danmakuDanDanSource,
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: const Text('弹幕屏蔽'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    Modular.to.pushNamed('/settings/danmaku/shield');
+                  },
+                  title: const Text('关键词屏蔽'),
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: const Text('弹幕显示'),
+              tiles: [
+                SettingsTile(
+                  title: const Text('弹幕区域'),
+                  description: Slider(
+                    value: defaultDanmakuArea,
+                    min: 0,
+                    max: 1,
+                    divisions: 4,
+                    label: '${(defaultDanmakuArea * 100).round()}%',
+                    onChanged: (value) {
+                      updateDanmakuArea(value);
+                    },
+                  ),
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuTop = value ?? !danmakuTop;
+                    await setting.put(SettingBoxKey.danmakuTop, danmakuTop);
+                    setState(() {});
+                  },
+                  title: const Text('顶部弹幕'),
+                  initialValue: danmakuTop,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuBottom = value ?? !danmakuBottom;
+                    await setting.put(
+                        SettingBoxKey.danmakuBottom, danmakuBottom);
+                    setState(() {});
+                  },
+                  title: const Text('底部弹幕'),
+                  initialValue: danmakuBottom,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuScroll = value ?? !danmakuScroll;
+                    await setting.put(
+                        SettingBoxKey.danmakuScroll, danmakuScroll);
+                    setState(() {});
+                  },
+                  title: const Text('滚动弹幕'),
+                  initialValue: danmakuScroll,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuMassive = value ?? !danmakuMassive;
+                    await setting.put(
+                        SettingBoxKey.danmakuMassive, danmakuMassive);
+                    setState(() {});
+                  },
+                  title: const Text('海量弹幕'),
+                  description: const Text('弹幕过多时进行叠加绘制'),
+                  initialValue: danmakuMassive,
+                ),
+              ],
+            ),
+            SettingsSection(
+              title: const Text('弹幕样式'),
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuBorder = value ?? !danmakuBorder;
+                    await setting.put(
+                        SettingBoxKey.danmakuBorder, danmakuBorder);
+                    setState(() {});
+                  },
+                  title: const Text('弹幕描边'),
+                  initialValue: danmakuBorder,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    danmakuColor = value ?? !danmakuColor;
+                    await setting.put(SettingBoxKey.danmakuColor, danmakuColor);
+                    setState(() {});
+                  },
+                  title: const Text('弹幕颜色'),
+                  initialValue: danmakuColor,
+                ),
+                SettingsTile(
+                  title: const Text('字体大小'),
+                  description: Slider(
+                    value: defaultDanmakuFontSize,
+                    min: 10,
+                    max: Utils.isCompact() ? 32 : 48,
+                    label: '${defaultDanmakuFontSize.floorToDouble()}',
+                    onChanged: (value) {
+                      updateDanmakuFontSize(value.floorToDouble());
+                    },
+                  ),
+                ),
+                SettingsTile(
+                  title: const Text('字体字重'),
+                  description: Slider(
+                    value: defaultDanmakuFontWeight.toDouble(),
+                    min: 1,
+                    max: 9,
+                    divisions: 8,
+                    label: '$defaultDanmakuFontWeight',
+                    onChanged: (value) {
+                      updateDanmakuFontWeight(value.toInt());
+                    },
+                  ),
+                ),
+                SettingsTile(
+                  title: const Text('弹幕不透明度'),
+                  description: Slider(
+                    value: defaultDanmakuOpacity,
+                    min: 0.1,
+                    max: 1,
+                    label: '${(defaultDanmakuOpacity * 100).round()}%',
+                    onChanged: (value) {
+                      updateDanmakuOpacity(
+                          double.parse(value.toStringAsFixed(2)));
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
+++ b/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
@@ -4,9 +4,11 @@ import 'package:hive/hive.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/utils/utils.dart';
 import 'package:kazumi/pages/settings/danmaku/danmaku_shield_settings.dart';
+import 'package:card_settings_ui/card_settings_ui.dart';
 
 class DanmakuSettingsSheet extends StatefulWidget {
   final DanmakuController danmakuController;
+
   const DanmakuSettingsSheet({super.key, required this.danmakuController});
 
   @override
@@ -31,152 +33,128 @@ class _DanmakuSettingsSheetState extends State<DanmakuSettingsSheet> {
         });
   }
 
-  Widget get danmakuFontSettingsBody {
-    return ListView(
-      children: [
-        const Padding(
-          padding: EdgeInsets.fromLTRB(24, 10, 0, 0),
-          child: Text('弹幕字号'),
-        ),
-        Slider(
-          value: widget.danmakuController.option.fontSize,
-          min: 10,
-          max: Utils.isCompact() ? 32 : 48,
-          divisions: Utils.isCompact() ? 22 : 38,
-          label: widget.danmakuController.option.fontSize.toStringAsFixed(1),
-          onChanged: (value) {
-            setState(() => widget.danmakuController.updateOption(
-                  widget.danmakuController.option.copyWith(
-                    fontSize: value,
-                  ),
-                ));
-            setting.put(SettingBoxKey.danmakuFontSize, value);
-          },
-        ),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(24, 0, 0, 0),
-          child: Text('弹幕区域'),
-        ),
-        Slider(
-          value: widget.danmakuController.option.area,
-          min: 0,
-          max: 1,
-          divisions: 4,
-          label: '${(widget.danmakuController.option.area * 100).round()}%',
-          onChanged: (value) {
-            setState(() => widget.danmakuController.updateOption(
-                  widget.danmakuController.option.copyWith(
-                    area: value,
-                  ),
-                ));
-            setting.put(SettingBoxKey.danmakuArea, value);
-          },
-        ),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(24, 0, 0, 0),
-          child: Text('弹幕不透明度'),
-        ),
-        Slider(
-          value: widget.danmakuController.option.opacity,
-          min: 0.1,
-          max: 1,
-          divisions: 9,
-          label: '${(widget.danmakuController.option.opacity * 100).round()}%',
-          onChanged: (value) {
-            setState(() => widget.danmakuController.updateOption(
-                  widget.danmakuController.option.copyWith(
-                    opacity: value,
-                  ),
-                ));
-            setting.put(SettingBoxKey.danmakuOpacity,
-                double.parse(value.toStringAsFixed(1)));
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget get danmakuHideSettingsBody {
-    return ListView(
-      children: [
-        ListTile(
-          title: const Text('隐藏滚动弹幕'),
-          trailing: Switch(
-            value: widget.danmakuController.option.hideScroll,
-            onChanged: (value) {
-              setState(() => widget.danmakuController.updateOption(
-                    widget.danmakuController.option.copyWith(
-                      hideScroll: value,
-                    ),
-                  ));
-              setting.put(SettingBoxKey.danmakuScroll, !value);
-            },
-          ),
-        ),
-        ListTile(
-          title: const Text('隐藏顶部弹幕'),
-          trailing: Switch(
-            value: widget.danmakuController.option.hideTop,
-            onChanged: (value) {
-              setState(() => widget.danmakuController.updateOption(
-                    widget.danmakuController.option.copyWith(
-                      hideTop: value,
-                    ),
-                  ));
-              setting.put(SettingBoxKey.danmakuTop, !value);
-            },
-          ),
-        ),
-        ListTile(
-          title: const Text('隐藏底部弹幕'),
-          trailing: Switch(
-            value: widget.danmakuController.option.hideBottom,
-            onChanged: (value) {
-              setState(() => widget.danmakuController.updateOption(
-                    widget.danmakuController.option.copyWith(
-                      hideBottom: value,
-                    ),
-                  ));
-              setting.put(SettingBoxKey.danmakuBottom, !value);
-            },
-          ),
-        ),
-        ListTile(
-          title: const Text('关键词屏蔽'),
-          onTap: () {
-            showDanmakuShieldSheet();
-          },
-        ),
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        body: Column(
-          children: [
-            const PreferredSize(
-              preferredSize: Size.fromHeight(kToolbarHeight),
-              child: Material(
-                child: TabBar(
-                  tabs: [
-                    Tab(text: '字体设置'),
-                    Tab(text: '屏蔽设置'),
-                  ],
-                ),
+    return SettingsList(
+      sections: [
+        SettingsSection(
+          title: const Text('弹幕样式'),
+          tiles: [
+            SettingsTile(
+              title: const Text('字体大小'),
+              description: Slider(
+                value: widget.danmakuController.option.fontSize,
+                min: 10,
+                max: Utils.isCompact() ? 32 : 48,
+                label:
+                    '${widget.danmakuController.option.fontSize.floorToDouble()}',
+                onChanged: (value) {
+                  setState(() => widget.danmakuController.updateOption(
+                        widget.danmakuController.option.copyWith(
+                          fontSize: value.floorToDouble(),
+                        ),
+                      ));
+                  setting.put(
+                      SettingBoxKey.danmakuFontSize, value.floorToDouble());
+                },
               ),
             ),
-            Expanded(
-              child: TabBarView(
-                children: [danmakuFontSettingsBody, danmakuHideSettingsBody],
+            SettingsTile(
+              title: const Text('弹幕不透明度'),
+              description: Slider(
+                value: widget.danmakuController.option.opacity,
+                min: 0.1,
+                max: 1,
+                label:
+                    '${(widget.danmakuController.option.opacity * 100).round()}%',
+                onChanged: (value) {
+                  setState(() => widget.danmakuController.updateOption(
+                        widget.danmakuController.option.copyWith(
+                          opacity: value,
+                        ),
+                      ));
+                  setting.put(SettingBoxKey.danmakuOpacity,
+                      double.parse(value.toStringAsFixed(2)));
+                },
               ),
             ),
           ],
         ),
-      ),
+        SettingsSection(
+          title: const Text('弹幕显示'),
+          tiles: [
+            SettingsTile(
+              title: const Text('弹幕区域'),
+              description: Slider(
+                value: widget.danmakuController.option.area,
+                min: 0,
+                max: 1,
+                divisions: 4,
+                label:
+                    '${(widget.danmakuController.option.area * 100).round()}%',
+                onChanged: (value) {
+                  setState(() => widget.danmakuController.updateOption(
+                        widget.danmakuController.option.copyWith(
+                          area: value,
+                        ),
+                      ));
+                  setting.put(SettingBoxKey.danmakuArea, value);
+                },
+              ),
+            ),
+            SettingsTile.switchTile(
+              onToggle: (value) async {
+                bool show = value ?? widget.danmakuController.option.hideTop;
+                setState(() => widget.danmakuController.updateOption(
+                      widget.danmakuController.option.copyWith(
+                        hideTop: !show,
+                      ),
+                    ));
+                setting.put(SettingBoxKey.danmakuTop, show);
+              },
+              title: const Text('顶部弹幕'),
+              initialValue: !widget.danmakuController.option.hideTop,
+            ),
+            SettingsTile.switchTile(
+              onToggle: (value) async {
+                bool show = value ?? widget.danmakuController.option.hideBottom;
+                setState(() => widget.danmakuController.updateOption(
+                      widget.danmakuController.option.copyWith(
+                        hideBottom: !show,
+                      ),
+                    ));
+                setting.put(SettingBoxKey.danmakuBottom, show);
+              },
+              title: const Text('底部弹幕'),
+              initialValue: !widget.danmakuController.option.hideBottom,
+            ),
+            SettingsTile.switchTile(
+              onToggle: (value) async {
+                bool show = value ?? widget.danmakuController.option.hideScroll;
+                setState(() => widget.danmakuController.updateOption(
+                      widget.danmakuController.option.copyWith(
+                        hideScroll: !show,
+                      ),
+                    ));
+                setting.put(SettingBoxKey.danmakuScroll, show);
+              },
+              title: const Text('滚动弹幕'),
+              initialValue: !widget.danmakuController.option.hideScroll,
+            ),
+          ],
+        ),
+        SettingsSection(
+          title: const Text('弹幕屏蔽'),
+          tiles: [
+            SettingsTile.navigation(
+              onPressed: (_) {
+                showDanmakuShieldSheet();
+              },
+              title: const Text('关键词屏蔽'),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
+++ b/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
@@ -38,6 +38,17 @@ class _DanmakuSettingsSheetState extends State<DanmakuSettingsSheet> {
     return SettingsList(
       sections: [
         SettingsSection(
+          title: const Text('弹幕屏蔽'),
+          tiles: [
+            SettingsTile.navigation(
+              onPressed: (_) {
+                showDanmakuShieldSheet();
+              },
+              title: const Text('关键词屏蔽'),
+            ),
+          ],
+        ),
+        SettingsSection(
           title: const Text('弹幕样式'),
           tiles: [
             SettingsTile(
@@ -140,17 +151,6 @@ class _DanmakuSettingsSheetState extends State<DanmakuSettingsSheet> {
               },
               title: const Text('滚动弹幕'),
               initialValue: !widget.danmakuController.option.hideScroll,
-            ),
-          ],
-        ),
-        SettingsSection(
-          title: const Text('弹幕屏蔽'),
-          tiles: [
-            SettingsTile.navigation(
-              onPressed: (_) {
-                showDanmakuShieldSheet();
-              },
-              title: const Text('关键词屏蔽'),
             ),
           ],
         ),

--- a/lib/pages/settings/danmaku/danmaku_shield_settings.dart
+++ b/lib/pages/settings/danmaku/danmaku_shield_settings.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/pages/my/my_controller.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -17,7 +18,7 @@ class _DanmakuShieldSettingsState extends State<DanmakuShieldSettings> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
+      appBar: SysAppBar(
         title: const Text("弹幕屏蔽"),
       ),
       body: ListView(

--- a/lib/pages/settings/decoder_settings.dart
+++ b/lib/pages/settings/decoder_settings.dart
@@ -24,33 +24,29 @@ class _DecoderSettingsState extends State<DecoderSettings> {
       appBar: const SysAppBar(
         title: Text('硬件解码器'),
       ),
-      body: Center(
-        child: SizedBox(
-          width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-          child: SettingsList(
-            sections: [
-              SettingsSection(
-                title: const Text('选择不受支持的解码器将回退到软件解码'),
-                tiles: hardwareDecodersList.entries
-                    .map((e) => SettingsTile<String>.radioTile(
-                          title: Text(e.key),
-                          description: Text(e.value),
-                          radioValue: e.key,
-                          groupValue: decoder.value,
-                          onChanged: (String? value) {
-                            if (value != null) {
-                              setting.put(SettingBoxKey.hardwareDecoder, value);
-                              setState(() {
-                                decoder.value = value;
-                              });
-                            }
-                          },
-                        ))
-                    .toList(),
-              ),
-            ],
+      body: SettingsList(
+        maxWidth: 1000,
+        sections: [
+          SettingsSection(
+            title: const Text('选择不受支持的解码器将回退到软件解码'),
+            tiles: hardwareDecodersList.entries
+                .map((e) => SettingsTile<String>.radioTile(
+                      title: Text(e.key),
+                      description: Text(e.value),
+                      radioValue: e.key,
+                      groupValue: decoder.value,
+                      onChanged: (String? value) {
+                        if (value != null) {
+                          setting.put(SettingBoxKey.hardwareDecoder, value);
+                          setState(() {
+                            decoder.value = value;
+                          });
+                        }
+                      },
+                    ))
+                .toList(),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/pages/settings/displaymode_settings.dart
+++ b/lib/pages/settings/displaymode_settings.dart
@@ -64,37 +64,33 @@ class _SetDisplayModeState extends State<SetDisplayMode> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('屏幕帧率设置')),
-      body: Center(
-        child: SizedBox(
-          width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-          child: (modes.isEmpty)
-              ? const CircularProgressIndicator()
-              : SettingsList(
-                  sections: [
-                    SettingsSection(
-                      title: const Text('没有生效? 重启app试试'),
-                      tiles: modes
-                          .map((e) => SettingsTile<DisplayMode>.radioTile(
-                                radioValue: e,
-                                groupValue: preferred,
-                                onChanged: (DisplayMode? newMode) async {
-                                  await FlutterDisplayMode.setPreferredMode(
-                                      newMode!);
-                                  await Future<dynamic>.delayed(
-                                    const Duration(milliseconds: 100),
-                                  );
-                                  await fetchAll();
-                                },
-                                title: e == DisplayMode.auto
-                                    ? const Text('自动')
-                                    : Text('$e${e == active ? "  [系统]" : ""}'),
-                              ))
-                          .toList(),
-                    ),
-                  ],
+      body: (modes.isEmpty)
+          ? const CircularProgressIndicator()
+          : SettingsList(
+              maxWidth: 1000,
+              sections: [
+                SettingsSection(
+                  title: const Text('没有生效? 重启app试试'),
+                  tiles: modes
+                      .map((e) => SettingsTile<DisplayMode>.radioTile(
+                            radioValue: e,
+                            groupValue: preferred,
+                            onChanged: (DisplayMode? newMode) async {
+                              await FlutterDisplayMode.setPreferredMode(
+                                  newMode!);
+                              await Future<dynamic>.delayed(
+                                const Duration(milliseconds: 100),
+                              );
+                              await fetchAll();
+                            },
+                            title: e == DisplayMode.auto
+                                ? const Text('自动')
+                                : Text('$e${e == active ? "  [系统]" : ""}'),
+                          ))
+                      .toList(),
                 ),
-        ),
-      ),
+              ],
+            ),
     );
   }
 }

--- a/lib/pages/settings/player_settings.dart
+++ b/lib/pages/settings/player_settings.dart
@@ -79,242 +79,185 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
       },
       child: Scaffold(
         appBar: const SysAppBar(title: Text('播放设置')),
-        body: Center(
-          child: SizedBox(
-            width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-            child: SettingsList(
-              sections: [
-                SettingsSection(
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        hAenable = value ?? !hAenable;
-                        await setting.put(SettingBoxKey.hAenable, hAenable);
-                        setState(() {});
-                      },
-                      title: const Text('硬件解码'),
-                      initialValue: hAenable,
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (value) async {
-                        await Modular.to.pushNamed('/settings/player/decoder');
-                      },
-                      title: const Text('硬件解码器'),
-                      description: const Text('仅在硬件解码启用时生效'),
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        lowMemoryMode = value ?? !lowMemoryMode;
-                        await setting.put(
-                            SettingBoxKey.lowMemoryMode, lowMemoryMode);
-                        setState(() {});
-                      },
-                      title: const Text('低内存模式'),
-                      description: const Text('禁用高级缓存以减少内存占用'),
-                      initialValue: lowMemoryMode,
-                    ),
-                    if (Platform.isAndroid) ...[
-                      SettingsTile.switchTile(
-                        onToggle: (value) async {
-                          androidEnableOpenSLES =
-                              value ?? !androidEnableOpenSLES;
-                          await setting.put(SettingBoxKey.androidEnableOpenSLES,
-                              androidEnableOpenSLES);
-                          setState(() {});
-                        },
-                        title: const Text('低延迟音频'),
-                        description: const Text('启用OpenSLES音频输出以降低延时'),
-                        initialValue: androidEnableOpenSLES,
-                      ),
-                    ],
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        Modular.to.pushNamed('/settings/player/super');
-                      },
-                      title: const Text('超分辨率'),
-                    ),
-                  ],
+        body: SettingsList(
+          maxWidth: 1000,
+          sections: [
+            SettingsSection(
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    hAenable = value ?? !hAenable;
+                    await setting.put(SettingBoxKey.hAenable, hAenable);
+                    setState(() {});
+                  },
+                  title: const Text('硬件解码'),
+                  initialValue: hAenable,
                 ),
-                SettingsSection(
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        playResume = value ?? !playResume;
-                        await setting.put(SettingBoxKey.playResume, playResume);
-                        setState(() {});
-                      },
-                      title: const Text('自动跳转'),
-                      description: const Text('跳转到上次播放位置'),
-                      initialValue: playResume,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        showPlayerError = value ?? !showPlayerError;
-                        await setting.put(
-                            SettingBoxKey.showPlayerError, showPlayerError);
-                        setState(() {});
-                      },
-                      title: const Text('错误提示'),
-                      description: const Text('显示播放器内部错误提示'),
-                      initialValue: showPlayerError,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        playerDebugMode = value ?? !playerDebugMode;
-                        await setting.put(
-                            SettingBoxKey.playerDebugMode, playerDebugMode);
-                        setState(() {});
-                      },
-                      title: const Text('调试模式'),
-                      description: const Text('记录播放器内部日志'),
-                      initialValue: playerDebugMode,
-                    ),
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        privateMode = value ?? !privateMode;
-                        await setting.put(
-                            SettingBoxKey.privateMode, privateMode);
-                        setState(() {});
-                      },
-                      title: const Text('隐身模式'),
-                      description: const Text('不保留观看记录'),
-                      initialValue: privateMode,
-                    ),
-                  ],
+                SettingsTile.navigation(
+                  onPressed: (value) async {
+                    await Modular.to.pushNamed('/settings/player/decoder');
+                  },
+                  title: const Text('硬件解码器'),
+                  description: const Text('仅在硬件解码启用时生效'),
                 ),
-                SettingsSection(
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('默认倍速'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              final List<double> playSpeedList;
-                              playSpeedList = defaultPlaySpeedList;
-                              return Wrap(
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  for (final double i
-                                      in playSpeedList) ...<Widget>[
-                                    if (i == defaultPlaySpeed) ...<Widget>[
-                                      FilledButton(
-                                        onPressed: () async {
-                                          updateDefaultPlaySpeed(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ] else ...[
-                                      FilledButton.tonal(
-                                        onPressed: () async {
-                                          updateDefaultPlaySpeed(i);
-                                          KazumiDialog.dismiss();
-                                        },
-                                        child: Text(i.toString()),
-                                      ),
-                                    ]
-                                  ]
-                                ],
-                              );
-                            }),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDefaultPlaySpeed(1.0);
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('默认倍速'),
-                      value: Text('$defaultPlaySpeed'),
-                    ),
-                    SettingsTile.navigation(
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('默认视频比例'),
-                            content: StatefulBuilder(
-                              builder:
-                                  (BuildContext context, StateSetter setState) {
-                                return Wrap(
-                                  spacing: 8,
-                                  runSpacing: Utils.isDesktop() ? 8 : 0,
-                                  children: [
-                                    for (final entry in aspectRatioTypeMap
-                                        .entries) ...<Widget>[
-                                      if (entry.key ==
-                                          defaultAspectRatioType) ...<Widget>[
-                                        FilledButton(
-                                          onPressed: () async {
-                                            updateDefaultAspectRatioType(
-                                                entry.key);
-                                            KazumiDialog.dismiss();
-                                          },
-                                          child: Text(entry.value),
-                                        ),
-                                      ] else ...[
-                                        FilledButton.tonal(
-                                          onPressed: () async {
-                                            updateDefaultAspectRatioType(
-                                                entry.key);
-                                            KazumiDialog.dismiss();
-                                          },
-                                          child: Text(entry.value),
-                                        ),
-                                      ]
-                                    ]
-                                  ],
-                                );
-                              },
-                            ),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => KazumiDialog.dismiss(),
-                                child: Text(
-                                  '取消',
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .outline),
-                                ),
-                              ),
-                              TextButton(
-                                onPressed: () async {
-                                  updateDefaultAspectRatioType(1); // 默认恢复自动
-                                  KazumiDialog.dismiss();
-                                },
-                                child: const Text('默认设置'),
-                              ),
-                            ],
-                          );
-                        });
-                      },
-                      title: const Text('默认视频比例'),
-                      value: Text(
-                          aspectRatioTypeMap[defaultAspectRatioType] ?? '自动'),
-                    ),
-                  ],
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    lowMemoryMode = value ?? !lowMemoryMode;
+                    await setting.put(
+                        SettingBoxKey.lowMemoryMode, lowMemoryMode);
+                    setState(() {});
+                  },
+                  title: const Text('低内存模式'),
+                  description: const Text('禁用高级缓存以减少内存占用'),
+                  initialValue: lowMemoryMode,
+                ),
+                if (Platform.isAndroid) ...[
+                  SettingsTile.switchTile(
+                    onToggle: (value) async {
+                      androidEnableOpenSLES = value ?? !androidEnableOpenSLES;
+                      await setting.put(SettingBoxKey.androidEnableOpenSLES,
+                          androidEnableOpenSLES);
+                      setState(() {});
+                    },
+                    title: const Text('低延迟音频'),
+                    description: const Text('启用OpenSLES音频输出以降低延时'),
+                    initialValue: androidEnableOpenSLES,
+                  ),
+                ],
+                SettingsTile.navigation(
+                  onPressed: (_) async {
+                    Modular.to.pushNamed('/settings/player/super');
+                  },
+                  title: const Text('超分辨率'),
                 ),
               ],
             ),
-          ),
+            SettingsSection(
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    playResume = value ?? !playResume;
+                    await setting.put(SettingBoxKey.playResume, playResume);
+                    setState(() {});
+                  },
+                  title: const Text('自动跳转'),
+                  description: const Text('跳转到上次播放位置'),
+                  initialValue: playResume,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    showPlayerError = value ?? !showPlayerError;
+                    await setting.put(
+                        SettingBoxKey.showPlayerError, showPlayerError);
+                    setState(() {});
+                  },
+                  title: const Text('错误提示'),
+                  description: const Text('显示播放器内部错误提示'),
+                  initialValue: showPlayerError,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    playerDebugMode = value ?? !playerDebugMode;
+                    await setting.put(
+                        SettingBoxKey.playerDebugMode, playerDebugMode);
+                    setState(() {});
+                  },
+                  title: const Text('调试模式'),
+                  description: const Text('记录播放器内部日志'),
+                  initialValue: playerDebugMode,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    privateMode = value ?? !privateMode;
+                    await setting.put(SettingBoxKey.privateMode, privateMode);
+                    setState(() {});
+                  },
+                  title: const Text('隐身模式'),
+                  description: const Text('不保留观看记录'),
+                  initialValue: privateMode,
+                ),
+              ],
+            ),
+            SettingsSection(
+              tiles: [
+                SettingsTile(
+                  title: const Text('默认倍速'),
+                  description: Slider(
+                    value: defaultPlaySpeed,
+                    min: 0.25,
+                    max: 3,
+                    divisions: 11,
+                    label: '${defaultPlaySpeed}x',
+                    onChanged: (value) {
+                      updateDefaultPlaySpeed(
+                          double.parse(value.toStringAsFixed(2)));
+                    },
+                  ),
+                ),
+                SettingsTile.navigation(
+                  onPressed: (_) async {
+                    KazumiDialog.show(builder: (context) {
+                      return AlertDialog(
+                        title: const Text('默认视频比例'),
+                        content: StatefulBuilder(
+                          builder:
+                              (BuildContext context, StateSetter setState) {
+                            return Wrap(
+                              spacing: 8,
+                              runSpacing: Utils.isDesktop() ? 8 : 0,
+                              children: [
+                                for (final entry
+                                    in aspectRatioTypeMap.entries) ...<Widget>[
+                                  if (entry.key ==
+                                      defaultAspectRatioType) ...<Widget>[
+                                    FilledButton(
+                                      onPressed: () async {
+                                        updateDefaultAspectRatioType(entry.key);
+                                        KazumiDialog.dismiss();
+                                      },
+                                      child: Text(entry.value),
+                                    ),
+                                  ] else ...[
+                                    FilledButton.tonal(
+                                      onPressed: () async {
+                                        updateDefaultAspectRatioType(entry.key);
+                                        KazumiDialog.dismiss();
+                                      },
+                                      child: Text(entry.value),
+                                    ),
+                                  ]
+                                ]
+                              ],
+                            );
+                          },
+                        ),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () => KazumiDialog.dismiss(),
+                            child: Text(
+                              '取消',
+                              style: TextStyle(
+                                  color: Theme.of(context).colorScheme.outline),
+                            ),
+                          ),
+                          TextButton(
+                            onPressed: () async {
+                              updateDefaultAspectRatioType(1); // 默认恢复自动
+                              KazumiDialog.dismiss();
+                            },
+                            child: const Text('默认设置'),
+                          ),
+                        ],
+                      );
+                    });
+                  },
+                  title: const Text('默认视频比例'),
+                  value:
+                      Text(aspectRatioTypeMap[defaultAspectRatioType] ?? '自动'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/settings/super_resolution_settings.dart
+++ b/lib/pages/settings/super_resolution_settings.dart
@@ -26,64 +26,60 @@ class _SuperResolutionSettingsState extends State<SuperResolutionSettings> {
       appBar: const SysAppBar(
         title: Text('超分辨率'),
       ),
-      body: Center(
-        child: SizedBox(
-          width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-          child: SettingsList(
-            sections: [
-              SettingsSection(
-                  title: const Text(
-                      '超分辨率需要启用硬件解码, 若启用硬件解码后仍然不生效, 尝试切换硬件解码器为 auto-copy'),
-                  tiles: [
-                    SettingsTile<String>.radioTile(
-                      title: const Text("OFF"),
-                      description: const Text("默认禁用超分辨率"),
-                      radioValue: "1",
-                      groupValue: superResolutionType.value,
-                      onChanged: (String? value) {
-                        if (value != null) {
-                          setting.put(SettingBoxKey.defaultSuperResolutionType,
-                              int.tryParse(value) ?? 1);
-                          setState(() {
-                            superResolutionType.value = value;
-                          });
-                        }
-                      },
-                    ),
-                    SettingsTile<String>.radioTile(
-                      title: const Text("Efficiency"),
-                      description: const Text("默认启用基于Anime4K的超分辨率 (效率优先)"),
-                      radioValue: "2",
-                      groupValue: superResolutionType.value,
-                      onChanged: (String? value) {
-                        if (value != null) {
-                          setting.put(SettingBoxKey.defaultSuperResolutionType,
-                              int.tryParse(value) ?? 1);
-                          setState(() {
-                            superResolutionType.value = value;
-                          });
-                        }
-                      },
-                    ),
-                    SettingsTile<String>.radioTile(
-                      title: const Text("Quality"),
-                      description: const Text("默认启用基于Anime4K的超分辨率 (质量优先)"),
-                      radioValue: "3",
-                      groupValue: superResolutionType.value,
-                      onChanged: (String? value) {
-                        if (value != null) {
-                          setting.put(SettingBoxKey.defaultSuperResolutionType,
-                              int.tryParse(value) ?? 1);
-                          setState(() {
-                            superResolutionType.value = value;
-                          });
-                        }
-                      },
-                    )
-                  ]),
-            ],
-          ),
-        ),
+      body: SettingsList(
+        maxWidth: 1000,
+        sections: [
+          SettingsSection(
+              title: const Text(
+                  '超分辨率需要启用硬件解码, 若启用硬件解码后仍然不生效, 尝试切换硬件解码器为 auto-copy'),
+              tiles: [
+                SettingsTile<String>.radioTile(
+                  title: const Text("OFF"),
+                  description: const Text("默认禁用超分辨率"),
+                  radioValue: "1",
+                  groupValue: superResolutionType.value,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      setting.put(SettingBoxKey.defaultSuperResolutionType,
+                          int.tryParse(value) ?? 1);
+                      setState(() {
+                        superResolutionType.value = value;
+                      });
+                    }
+                  },
+                ),
+                SettingsTile<String>.radioTile(
+                  title: const Text("Efficiency"),
+                  description: const Text("默认启用基于Anime4K的超分辨率 (效率优先)"),
+                  radioValue: "2",
+                  groupValue: superResolutionType.value,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      setting.put(SettingBoxKey.defaultSuperResolutionType,
+                          int.tryParse(value) ?? 1);
+                      setState(() {
+                        superResolutionType.value = value;
+                      });
+                    }
+                  },
+                ),
+                SettingsTile<String>.radioTile(
+                  title: const Text("Quality"),
+                  description: const Text("默认启用基于Anime4K的超分辨率 (质量优先)"),
+                  radioValue: "3",
+                  groupValue: superResolutionType.value,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      setting.put(SettingBoxKey.defaultSuperResolutionType,
+                          int.tryParse(value) ?? 1);
+                      setState(() {
+                        superResolutionType.value = value;
+                      });
+                    }
+                  },
+                )
+              ]),
+        ],
       ),
     );
   }

--- a/lib/pages/settings/theme_settings_page.dart
+++ b/lib/pages/settings/theme_settings_page.dart
@@ -60,6 +60,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
         brightness: Brightness.dark,
         colorSchemeSeed: color,
         progressIndicatorTheme: progressIndicatorTheme2024,
+        sliderTheme: sliderTheme2024,
         pageTransitionsTheme: pageTransitionsTheme2024);
     var oledDarkTheme = Utils.oledDarkTheme(defaultDarkTheme);
     themeProvider.setTheme(
@@ -68,6 +69,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
           brightness: Brightness.light,
           colorSchemeSeed: color,
           progressIndicatorTheme: progressIndicatorTheme2024,
+          sliderTheme: sliderTheme2024,
           pageTransitionsTheme: pageTransitionsTheme2024),
       oledEnhance ? oledDarkTheme : defaultDarkTheme,
     );
@@ -81,6 +83,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
         brightness: Brightness.dark,
         colorSchemeSeed: Colors.green,
         progressIndicatorTheme: progressIndicatorTheme2024,
+        sliderTheme: sliderTheme2024,
         pageTransitionsTheme: pageTransitionsTheme2024);
     var oledDarkTheme = Utils.oledDarkTheme(defaultDarkTheme);
     themeProvider.setTheme(
@@ -89,6 +92,7 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
           brightness: Brightness.light,
           colorSchemeSeed: Colors.green,
           progressIndicatorTheme: progressIndicatorTheme2024,
+          sliderTheme: sliderTheme2024,
           pageTransitionsTheme: pageTransitionsTheme2024),
       oledEnhance ? oledDarkTheme : defaultDarkTheme,
     );
@@ -133,191 +137,185 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
       },
       child: Scaffold(
         appBar: const SysAppBar(title: Text('外观设置')),
-        body: Center(
-          child: SizedBox(
-            width: (MediaQuery.of(context).size.width > 1000) ? 1000 : null,
-            child: SettingsList(
-              sections: [
-                SettingsSection(
-                  title: const Text('外观'),
-                  tiles: [
-                    SettingsTile.navigation(
-                      onPressed: (_) {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('深色模式'),
-                            content: StatefulBuilder(
-                              builder:
-                                  (BuildContext context, StateSetter setState) {
-                                return Wrap(
-                                  spacing: 8,
-                                  runSpacing: Utils.isDesktop() ? 8 : 0,
-                                  children: [
-                                    defaultThemeMode == 'system'
-                                        ? FilledButton(
-                                            onPressed: () {
-                                              updateTheme('system');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("跟随系统"))
-                                        : FilledButton.tonal(
-                                            onPressed: () {
-                                              updateTheme('system');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("跟随系统")),
-                                    defaultThemeMode == 'light'
-                                        ? FilledButton(
-                                            onPressed: () {
-                                              updateTheme('light');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("浅色"))
-                                        : FilledButton.tonal(
-                                            onPressed: () {
-                                              updateTheme('light');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("浅色")),
-                                    defaultThemeMode == 'dark'
-                                        ? FilledButton(
-                                            onPressed: () {
-                                              updateTheme('dark');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("深色"))
-                                        : FilledButton.tonal(
-                                            onPressed: () {
-                                              updateTheme('dark');
-                                              KazumiDialog.dismiss();
-                                            },
-                                            child: const Text("深色")),
-                                  ],
-                                );
-                              },
-                            ),
-                          );
-                        });
-                      },
-                      title: const Text('深色模式'),
-                      value: Text(
-                        defaultThemeMode == 'light'
-                            ? '浅色'
-                            : (defaultThemeMode == 'dark' ? '深色' : '跟随系统'),
-                      ),
-                    ),
-                    SettingsTile.navigation(
-                      enabled: !useDynamicColor,
-                      onPressed: (_) async {
-                        KazumiDialog.show(builder: (context) {
-                          return AlertDialog(
-                            title: const Text('配色方案'),
-                            content: StatefulBuilder(builder:
-                                (BuildContext context, StateSetter setState) {
-                              final List<Map<String, dynamic>> colorThemes =
-                                  colorThemeTypes;
-                              return Wrap(
-                                alignment: WrapAlignment.center,
-                                spacing: 8,
-                                runSpacing: Utils.isDesktop() ? 8 : 0,
-                                children: [
-                                  ...colorThemes.map(
-                                    (e) {
-                                      final index = colorThemes.indexOf(e);
-                                      return GestureDetector(
-                                        onTap: () {
-                                          index == 0
-                                              ? resetTheme()
-                                              : setTheme(e['color']);
+        body: SettingsList(
+          maxWidth: 1000,
+          sections: [
+            SettingsSection(
+              title: const Text('外观'),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    KazumiDialog.show(builder: (context) {
+                      return AlertDialog(
+                        title: const Text('深色模式'),
+                        content: StatefulBuilder(
+                          builder:
+                              (BuildContext context, StateSetter setState) {
+                            return Wrap(
+                              spacing: 8,
+                              runSpacing: Utils.isDesktop() ? 8 : 0,
+                              children: [
+                                defaultThemeMode == 'system'
+                                    ? FilledButton(
+                                        onPressed: () {
+                                          updateTheme('system');
                                           KazumiDialog.dismiss();
                                         },
-                                        child: Column(
-                                          children: [
-                                            PaletteCard(
-                                              color: e['color'],
-                                              selected: (e['color']
-                                                          .value
-                                                          .toRadixString(16) ==
-                                                      defaultThemeColor ||
-                                                  (defaultThemeColor ==
-                                                          'default' &&
-                                                      index == 0)),
-                                            ),
-                                            Text(e['label']),
-                                          ],
-                                        ),
-                                      );
+                                        child: const Text("跟随系统"))
+                                    : FilledButton.tonal(
+                                        onPressed: () {
+                                          updateTheme('system');
+                                          KazumiDialog.dismiss();
+                                        },
+                                        child: const Text("跟随系统")),
+                                defaultThemeMode == 'light'
+                                    ? FilledButton(
+                                        onPressed: () {
+                                          updateTheme('light');
+                                          KazumiDialog.dismiss();
+                                        },
+                                        child: const Text("浅色"))
+                                    : FilledButton.tonal(
+                                        onPressed: () {
+                                          updateTheme('light');
+                                          KazumiDialog.dismiss();
+                                        },
+                                        child: const Text("浅色")),
+                                defaultThemeMode == 'dark'
+                                    ? FilledButton(
+                                        onPressed: () {
+                                          updateTheme('dark');
+                                          KazumiDialog.dismiss();
+                                        },
+                                        child: const Text("深色"))
+                                    : FilledButton.tonal(
+                                        onPressed: () {
+                                          updateTheme('dark');
+                                          KazumiDialog.dismiss();
+                                        },
+                                        child: const Text("深色")),
+                              ],
+                            );
+                          },
+                        ),
+                      );
+                    });
+                  },
+                  title: const Text('深色模式'),
+                  value: Text(
+                    defaultThemeMode == 'light'
+                        ? '浅色'
+                        : (defaultThemeMode == 'dark' ? '深色' : '跟随系统'),
+                  ),
+                ),
+                SettingsTile.navigation(
+                  enabled: !useDynamicColor,
+                  onPressed: (_) async {
+                    KazumiDialog.show(builder: (context) {
+                      return AlertDialog(
+                        title: const Text('配色方案'),
+                        content: StatefulBuilder(builder:
+                            (BuildContext context, StateSetter setState) {
+                          final List<Map<String, dynamic>> colorThemes =
+                              colorThemeTypes;
+                          return Wrap(
+                            alignment: WrapAlignment.center,
+                            spacing: 8,
+                            runSpacing: Utils.isDesktop() ? 8 : 0,
+                            children: [
+                              ...colorThemes.map(
+                                (e) {
+                                  final index = colorThemes.indexOf(e);
+                                  return GestureDetector(
+                                    onTap: () {
+                                      index == 0
+                                          ? resetTheme()
+                                          : setTheme(e['color']);
+                                      KazumiDialog.dismiss();
                                     },
-                                  )
-                                ],
-                              );
-                            }),
+                                    child: Column(
+                                      children: [
+                                        PaletteCard(
+                                          color: e['color'],
+                                          selected: (e['color']
+                                                      .value
+                                                      .toRadixString(16) ==
+                                                  defaultThemeColor ||
+                                              (defaultThemeColor == 'default' &&
+                                                  index == 0)),
+                                        ),
+                                        Text(e['label']),
+                                      ],
+                                    ),
+                                  );
+                                },
+                              )
+                            ],
                           );
-                        });
-                      },
-                      title: const Text('配色方案'),
-                    ),
-                    SettingsTile.switchTile(
-                      enabled: !Platform.isIOS,
-                      onToggle: (value) async {
-                        useDynamicColor = value ?? !useDynamicColor;
-                        await setting.put(
-                            SettingBoxKey.useDynamicColor, useDynamicColor);
-                        themeProvider.setDynamic(useDynamicColor);
-                        setState(() {});
-                      },
-                      title: const Text('动态配色'),
-                      initialValue: useDynamicColor,
-                    ),
-                  ],
-                  bottomInfo: const Text('动态配色仅支持安卓12及以上和桌面平台'),
+                        }),
+                      );
+                    });
+                  },
+                  title: const Text('配色方案'),
                 ),
-                SettingsSection(
-                  tiles: [
-                    SettingsTile.switchTile(
-                      onToggle: (value) async {
-                        oledEnhance = value ?? !oledEnhance;
-                        await setting.put(
-                            SettingBoxKey.oledEnhance, oledEnhance);
-                        updateOledEnhance();
-                        setState(() {});
-                      },
-                      title: const Text('OLED优化'),
-                      description: const Text('深色模式下使用纯黑背景'),
-                      initialValue: oledEnhance,
-                    ),
-                  ],
+                SettingsTile.switchTile(
+                  enabled: !Platform.isIOS,
+                  onToggle: (value) async {
+                    useDynamicColor = value ?? !useDynamicColor;
+                    await setting.put(
+                        SettingBoxKey.useDynamicColor, useDynamicColor);
+                    themeProvider.setDynamic(useDynamicColor);
+                    setState(() {});
+                  },
+                  title: const Text('动态配色'),
+                  initialValue: useDynamicColor,
                 ),
-                if (Utils.isDesktop())
-                  SettingsSection(
-                    tiles: [
-                      SettingsTile.switchTile(
-                        onToggle: (value) async {
-                          showWindowButton = value ?? !showWindowButton;
-                          await setting.put(
-                              SettingBoxKey.showWindowButton, showWindowButton);
-                          setState(() {});
-                        },
-                        title: const Text('使用系统标题栏'),
-                        description: const Text('重启应用生效'),
-                        initialValue: showWindowButton,
-                      ),
-                    ],
-                  ),
-                if (Platform.isAndroid)
-                  SettingsSection(
-                    tiles: [
-                      SettingsTile.navigation(
-                        onPressed: (_) async {
-                          Modular.to.pushNamed('/settings/theme/display');
-                        },
-                        title: const Text('屏幕帧率'),
-                      ),
-                    ],
-                  ),
+              ],
+              bottomInfo: const Text('动态配色仅支持安卓12及以上和桌面平台'),
+            ),
+            SettingsSection(
+              tiles: [
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    oledEnhance = value ?? !oledEnhance;
+                    await setting.put(SettingBoxKey.oledEnhance, oledEnhance);
+                    updateOledEnhance();
+                    setState(() {});
+                  },
+                  title: const Text('OLED优化'),
+                  description: const Text('深色模式下使用纯黑背景'),
+                  initialValue: oledEnhance,
+                ),
               ],
             ),
-          ),
+            if (Utils.isDesktop())
+              SettingsSection(
+                tiles: [
+                  SettingsTile.switchTile(
+                    onToggle: (value) async {
+                      showWindowButton = value ?? !showWindowButton;
+                      await setting.put(
+                          SettingBoxKey.showWindowButton, showWindowButton);
+                      setState(() {});
+                    },
+                    title: const Text('使用系统标题栏'),
+                    description: const Text('重启应用生效'),
+                    initialValue: showWindowButton,
+                  ),
+                ],
+              ),
+            if (Platform.isAndroid)
+              SettingsSection(
+                tiles: [
+                  SettingsTile.navigation(
+                    onPressed: (_) async {
+                      Modular.to.pushNamed('/settings/theme/display');
+                    },
+                    title: const Text('屏幕帧率'),
+                  ),
+                ],
+              ),
+          ],
         ),
       ),
     );

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -10,12 +10,18 @@ class StyleString {
   static const double aspectRatio = 16 / 10;
 }
 
+/// `year2023` flag is deprecated since 3.29 but not default to false yet. Keep
+/// it to false so we have the latest M3 style process indicator.
+/// ignore: deprecated_member_use
 const ProgressIndicatorThemeData progressIndicatorTheme2024 =
-    ProgressIndicatorThemeData(
-  // This flag is deprecated since 3.29 but not default to false yet. Keep
-  // it to false so we have the latest M3 style process indicator.
-  // ignore: deprecated_member_use
+    ProgressIndicatorThemeData(year2023: false);
+
+/// `year2023` flag is deprecated since 3.29 but not default to false yet. Keep
+/// it to false so we have the latest M3 style slider.
+/// ignore: deprecated_member_use
+const SliderThemeData sliderTheme2024 = SliderThemeData(
   year2023: false,
+  showValueIndicator: ShowValueIndicator.always,
 );
 
 /// The page transition method defined here is managed by flutter, and the native transition method of flutter is set here.
@@ -49,7 +55,7 @@ class LayoutBreakpoint {
   static const Map<String, double> medium = {'width': 840, 'height': 900};
 }
 
-// 随机UA列表
+/// 随机UA列表
 const List<String> userAgentsList = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36',
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
@@ -62,7 +68,7 @@ const List<String> userAgentsList = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0',
 ];
 
-// 默认 SyncPlay 服务器列表
+/// 默认 SyncPlay 服务器列表
 const List<String> defaultSyncPlayEndPoints = [
   'syncplay.pl:8995',
   'syncplay.pl:8996',
@@ -73,21 +79,21 @@ const List<String> defaultSyncPlayEndPoints = [
 
 const String defaultSyncPlayEndPoint = 'syncplay.pl:8996';
 
-// 随机HTTP请求头accept-language字段列表
+/// 随机HTTP请求头accept-language字段列表
 const List<String> acceptLanguageList = [
   'zh-CN,zh;q=0.9',
   'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',
   'zh-CN,zh-TW;q=0.9,zh;q=0.8,en-US;q=0.7,en;q=0.6',
 ];
 
-// Bangumi API 文档要求的UA格式
+/// Bangumi API 文档要求的UA格式
 Map<String, String> bangumiHTTPHeader = {
   'user-agent':
       'Predidit/Kazumi/${Api.version} (Android) (https://github.com/Predidit/Kazumi)',
   'referer': '',
 };
 
-// 可选硬件解码器
+/// 可选硬件解码器
 const Map<String, String> hardwareDecodersList = {
   'auto': '启用任意可用解码器',
   'auto-safe': '启用最佳解码器',
@@ -116,7 +122,7 @@ const Map<String, String> hardwareDecodersList = {
   'rkmpp': 'Rockchip MPP (仅部分Rockchip芯片)',
 };
 
-// 超分辨率滤镜
+/// 超分辨率滤镜
 const List<String> mpvAnime4KShaders = [
   'Anime4K_Clamp_Highlights.glsl',
   'Anime4K_Restore_CNN_VL.glsl',
@@ -126,7 +132,7 @@ const List<String> mpvAnime4KShaders = [
   'Anime4K_Upscale_CNN_x2_M.glsl'
 ];
 
-// 超分辨率滤镜 (轻量)
+/// 超分辨率滤镜 (轻量)
 const List<String> mpvAnime4KShadersLite = [
   'Anime4K_Clamp_Highlights.glsl',
   'Anime4K_Restore_CNN_M.glsl',
@@ -137,7 +143,7 @@ const List<String> mpvAnime4KShadersLite = [
   'Anime4K_Upscale_CNN_x2_S.glsl'
 ];
 
-// 可选播放倍速
+/// 可选播放倍速
 const List<double> defaultPlaySpeedList = [
   0.25,
   0.5,
@@ -153,86 +159,6 @@ const List<double> defaultPlaySpeedList = [
   3.0,
 ];
 
-// 可选弹幕透明度
-const List<double> danOpacityList = [
-  0.1,
-  0.2,
-  0.3,
-  0.4,
-  0.5,
-  0.6,
-  0.7,
-  0.8,
-  0.9,
-  1.0,
-];
-
-// 可选弹幕字体大小
-final List<double> danFontList = [
-  10.0,
-  11.0,
-  12.0,
-  13.0,
-  14.0,
-  15.0,
-  16.0,
-  17.0,
-  18.0,
-  19.0,
-  20.0,
-  21.0,
-  22.0,
-  23.0,
-  24.0,
-  25.0,
-  26.0,
-  27.0,
-  28.0,
-  29.0,
-  30.0,
-  31.0,
-  32.0,
-  if (!Utils.isCompact()) ...[
-    33.0,
-    34.0,
-    35.0,
-    36.0,
-    37.0,
-    38.0,
-    39.0,
-    40.0,
-    41.0,
-    42.0,
-    43.0,
-    44.0,
-    45.0,
-    46.0,
-    47.0,
-    48.0,
-  ]
-];
-
-// 可选弹幕字体字重
-final List<int> danFontWeightList = [
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-];
-
-// 可选弹幕区域
-const List<double> danAreaList = [
-  0.25,
-  0.5,
-  0.75,
-  1.0,
-];
-
 const String danmakuOnSvg = '''
     <svg xmlns="http://www.w3.org/2000/svg" data-pointer="none" viewBox="0 0 24 24">
       <path fill="#FFFFFF" fill-rule="evenodd" d="M11.989 4.828c-.47 0-.975.004-1.515.012l-1.71-2.566a1.008 1.008 0 0 0-1.678 1.118l.999 1.5c-.681.018-1.403.04-2.164.068a4.013 4.013 0 0 0-3.83 3.44c-.165 1.15-.245 2.545-.245 4.185 0 1.965.115 3.67.35 5.116a4.012 4.012 0 0 0 3.763 3.363l.906.046c1.205.063 1.808.095 3.607.095a.988.988 0 0 0 0-1.975c-1.758 0-2.339-.03-3.501-.092l-.915-.047a2.037 2.037 0 0 1-1.91-1.708c-.216-1.324-.325-2.924-.325-4.798 0-1.563.076-2.864.225-3.904.14-.977.96-1.713 1.945-1.747 2.444-.087 4.465-.13 6.063-.131 1.598 0 3.62.044 6.064.13.96.034 1.71.81 1.855 1.814.075.524.113 1.962.141 3.065v.002c.01.342.017.65.025.88a.987.987 0 1 0 1.974-.068c-.008-.226-.016-.523-.025-.856v-.027c-.03-1.118-.073-2.663-.16-3.276-.273-1.906-1.783-3.438-3.74-3.507-.9-.032-1.743-.058-2.531-.078l1.05-1.46a1.008 1.008 0 0 0-1.638-1.177l-1.862 2.59c-.38-.004-.744-.007-1.088-.007h-.13Zm.521 4.775h-1.32v4.631h2.222v.847h-2.618v1.078h2.618l.003.678c.36.026.714.163 1.01.407h.11v-1.085h2.694v-1.078h-2.695v-.847H16.8v-4.63h-1.276a8.59 8.59 0 0 0 .748-1.42L15.183 7.8a14.232 14.232 0 0 1-.814 1.804h-1.518l.693-.308a8.862 8.862 0 0 0-.814-1.408l-1.045.352c.297.396.572.847.825 1.364Zm-4.18 3.564.154-1.485h1.98V8.294h-3.2v.98H9.33v1.43H7.472l-.308 3.453h2.277c0 1.166-.044 1.925-.12 2.277-.078.352-.386.528-.936.528-.308 0-.616-.022-.902-.055l.297 1.067.062.005c.285.02.551.04.818.04 1.001-.067 1.562-.419 1.694-1.057.11-.638.176-1.903.176-3.795h-2.2Zm7.458.11v-.858h-1.254v.858h1.254Zm-2.376-.858v.858h-1.199v-.858h1.2Zm-1.199-.946h1.2v-.902h-1.2v.902Zm2.321 0v-.902h1.254v.902h-1.254Z" clip-rule="evenodd"/>
@@ -240,9 +166,9 @@ const String danmakuOnSvg = '''
     </svg>
     ''';
 
-//可选默认视频比例
+/// 可选默认视频比例
 const Map<int, String> aspectRatioTypeMap = {
-  1 : "自动",
-  2 : "裁切填充",
-  3 : "拉伸填充",
+  1: "自动",
+  2: "裁切填充",
+  3: "拉伸填充",
 };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,10 +186,10 @@ packages:
     dependency: "direct main"
     description:
       name: card_settings_ui
-      sha256: ee92c90366096c84e43a4e2942902b81d3ecd53e7c4643ab804d342d0469cb77
+      sha256: "69946704bf4e05830e4737645188f14420285063c8e15f82ef8f5708dba55df8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   cached_network_image: ^3.4.1
-  card_settings_ui: ^1.1.3
+  card_settings_ui: ^2.0.0
 
   # fvp: ^0.28.0
   # video_player: ^2.9.1


### PR DESCRIPTION
<img width="1557" height="1020" alt="截屏2025-08-15 15 55 24" src="https://github.com/user-attachments/assets/644736e9-5642-4e03-a231-a4ad764d2185" />

modalBottomSheet 的背景颜色和 card-settings-ui 的浅色一模一样，都是 surface container low，不过看着也还行（

<img width="3366" height="1718" alt="image_2025-08-15_15-16-05" src="https://github.com/user-attachments/assets/00b7e72f-4592-4730-a0b7-c0f7f4d72bfb" />

有的文件只是把最大宽度的设置方式改了，maxWidth 可以让滚动条显示在最右边

设置界面的默认倍速也改成了 Slider，不知道合不合适

<img width="1606" height="1080" alt="image" src="https://github.com/user-attachments/assets/1d8b8137-4987-4f6c-8d52-6cfdd102fd0a" />
