### PR TITLE
feat: use create-dmg to generate prettier dmg

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,10 +247,9 @@
           - run: flutter build macos --release
           - name: Create DMG
             run: |
-              mkdir -p build/dist
-              cp -a build/macos/Build/Products/Release/Kazumi.app build/dist/
-              ln -s /Applications build/dist/Applications
-              hdiutil create -format UDZO -srcfolder build/dist -volname Kazumi Kazumi_macos_canary.dmg
+              npm install --global create-dmg
+              create-dmg build/macos/Build/Products/Release/Kazumi.app --no-version-in-filename
+              mv Kazumi.dmg Kazumi_macos_canary.dmg
           - name: Upload MacOS build
             uses: actions/upload-artifact@v4
             with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -248,10 +248,10 @@
           - name: Create DMG
             run: |
               npm install --global create-dmg
-              create-dmg build/macos/Build/Products/Release/Kazumi.app --no-version-in-filename
+              create-dmg build/macos/Build/Products/Release/Kazumi.app
             continue-on-error: true
           - name: Rename DMG
-            run: mv Kazumi.dmg Kazumi_macos_canary.dmg
+            run: mv Kazumi*.dmg Kazumi_macos_canary.dmg
           - name: Upload MacOS build
             uses: actions/upload-artifact@v4
             with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -249,7 +249,9 @@
             run: |
               npm install --global create-dmg
               create-dmg build/macos/Build/Products/Release/Kazumi.app --no-version-in-filename
-              mv Kazumi.dmg Kazumi_macos_canary.dmg
+            continue-on-error: true
+          - name: Rename DMG
+            run: mv Kazumi.dmg Kazumi_macos_canary.dmg
           - name: Upload MacOS build
             uses: actions/upload-artifact@v4
             with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -325,10 +325,11 @@
           - run: flutter build macos --release
           - name: Create DMG
             run: |
-              mkdir -p build/dist
-              cp -a build/macos/Build/Products/Release/Kazumi.app build/dist/
-              ln -s /Applications build/dist/Applications
-              hdiutil create -format UDZO -srcfolder build/dist -volname Kazumi Kazumi_macos_${{ env.tag }}.dmg
+              npm install --global create-dmg
+              create-dmg build/macos/Build/Products/Release/Kazumi.app
+            continue-on-error: true
+          - name: Rename DMG
+            run: mv Kazumi*.dmg Kazumi_macos_${{ env.tag }}.dmg
           - name: Upload MacOS build
             uses: actions/upload-artifact@v4
             with:


### PR DESCRIPTION
更新 dmg 外观。由于没有签名会报错所以需要使用 `continue-on-error: true`，但是 dmg 仍然可以成功创建

| 新 | 旧 |
| --- | --- |
|<img width="660" height="422" alt="image" src="https://github.com/user-attachments/assets/067b188c-d2f5-46b0-a64d-1ebafdc3968f" />|<img width="920" height="464" alt="image" src="https://github.com/user-attachments/assets/720ab24a-b60b-47f0-9936-b134ef825928" />|
