### PR TITLE
fix: #858

### DIFF
--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -208,6 +208,14 @@ Win32Window::MessageHandler(HWND hwnd,
     }
 
     case WM_ACTIVATE:
+      if (LOWORD(wparam) == WA_ACTIVE || LOWORD(wparam) == WA_CLICKACTIVE) {
+        if (child_content_ != nullptr) {
+          SetFocus(child_content_);
+        }
+      }
+      return 0;
+
+    case WM_SETFOCUS:
       if (child_content_ != nullptr) {
         SetFocus(child_content_);
       }


### PR DESCRIPTION
如题，通过在```MessageHandler```添加对```WM_SETFOCUS```消息的处理可修复