### PR TITLE
fix getDownloadUrlForType

### DIFF
--- a/lib/utils/auto_updater.dart
+++ b/lib/utils/auto_updater.dart
@@ -705,21 +705,19 @@ class AutoUpdater {
   /// 根据安装类型获取下载链接
   Future<String> _getDownloadUrlForType(
       List<dynamic> assets, InstallationType type) async {
-    final patterns = _getFilePatterns(type);
+    final patterns = _getFilePatterns(type).map((p) => p.toLowerCase()).toList();
 
-    for (final asset in assets) {
-      final name = asset['name'] as String? ?? '';
-      final downloadUrl = asset['browser_download_url'] as String? ?? '';
-
-      for (final pattern in patterns) {
-        if (patterns.every((pattern) => name.toLowerCase().contains(pattern.toLowerCase())) &&
-            downloadUrl.isNotEmpty) {
-          return downloadUrl;
-        }
-      }
+    try {
+      final asset = assets.cast<Map<String, dynamic>>().firstWhere((asset) {
+        final name = (asset['name'] as String?)?.toLowerCase() ?? '';
+        final downloadUrl = (asset['browser_download_url'] as String?) ?? '';
+        return downloadUrl.isNotEmpty &&
+              patterns.every((pattern) => name.contains(pattern));
+      });
+      return (asset['browser_download_url'] as String?) ?? '';
+    } catch (e) {
+      return '';
     }
-
-    return '';
   }
 
   /// 获取合适的下载链接


### PR DESCRIPTION
Bug: auto_updater.dart:715

此处判断存在问题，按照原先的代码会导致即使用户选择了zip格式的安装包，下载的仍然是msix格式的安装包

我已经在分支中修复了此问题，这应该不会导致其他判断异常
<img width="508" height="199" alt="505964B2CA92F5F16AD5C27A01D0F2C5" src="https://github.com/user-attachments/assets/970c2044-56b5-44e6-abe6-caaf2600abfe" />
