### PR TITLE
允许Linux使用系统标题栏而非GTK自定义标题栏

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -19,9 +19,10 @@ static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
-
+  
+  // If have GTK_CSD in env and it is equal to 1 then add the gtk header bar
+  // to always use client side decorations
   const char* GTK_CSD = getenv("GTK_CSD");
-
   if (GTK_CSD && strcmp(GTK_CSD, "1") == 0) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
@@ -102,6 +103,10 @@ static void my_application_class_init(MyApplicationClass* klass) {
 static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
   g_set_prgname(APPLICATION_ID);
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,


### PR DESCRIPTION
允许Linux使用系统标题栏而非GTK标题栏
参考了Localsend代码，读取相同的环境变量 GTK_CSD=0 来启用系统标题栏。
解决了对非GNOME桌面用户来说GTK标题栏过粗和阴影闪烁的问题。