### PR TITLE
Linux标题栏修复

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "kazumi")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.kazumi")
+set(APPLICATION_ID "io.github.Predidit.Kazumi")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.


### PR DESCRIPTION
修复了Wayland下窗口管理器识别不到Kazumi图标的问题。
现在设置里的系统标题栏选项能够正常运作，开启时使用原生标题栏，不需要GTK_CSD=0环境变量；关闭时使用GTK标题栏，再通过windowManager隐藏GTK标题栏。