### PR TITLE
跳过广告

### DIFF
--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -290,6 +290,9 @@ abstract class _PlayerController with Store {
         setting.get(SettingBoxKey.lowMemoryMode, defaultValue: false);
     playerDebugMode =
         setting.get(SettingBoxKey.playerDebugMode, defaultValue: false);
+    bool forceAdBlocker =
+        setting.get(SettingBoxKey.forceAdBlocker, defaultValue: false);
+    bool adBlockerEnabled = forceAdBlocker || videoPageController.currentPlugin.adBlocker;
     if (videoPageController.currentPlugin.userAgent == '') {
       userAgent = Utils.getRandomUA();
     } else {
@@ -306,6 +309,7 @@ abstract class _PlayerController with Store {
         bufferSize: lowMemoryMode ? 15 * 1024 * 1024 : 1500 * 1024 * 1024,
         osc: false,
         logLevel: MPVLogLevel.values[playerLogLevel],
+        adBlocker: adBlockerEnabled,
       ),
     );
 

--- a/lib/pages/plugin_editor/plugin_editor_page.dart
+++ b/lib/pages/plugin_editor/plugin_editor_page.dart
@@ -33,6 +33,7 @@ class _PluginEditorPageState extends State<PluginEditorPage> {
   bool useNativePlayer = true;
   bool usePost = false;
   bool useLegacyParser = false;
+  bool adBlocker = false;
 
   @override
   void initState() {
@@ -56,6 +57,7 @@ class _PluginEditorPageState extends State<PluginEditorPage> {
     useNativePlayer = plugin.useNativePlayer;
     usePost = plugin.usePost;
     useLegacyParser = plugin.useLegacyParser;
+    adBlocker = plugin.adBlocker;
   }
 
   @override
@@ -161,6 +163,16 @@ class _PluginEditorPageState extends State<PluginEditorPage> {
                         });
                       },
                     ),
+                    SwitchListTile(
+                      title: const Text('广告过滤'),
+                      subtitle: const Text('启用HLS广告过滤'),
+                      value: adBlocker,
+                      onChanged: (bool value) {
+                        setState(() {
+                          adBlocker = value;
+                        });
+                      },
+                    ),
                     const SizedBox(height: 20),
                     TextField(
                       controller: userAgentController,
@@ -197,6 +209,7 @@ class _PluginEditorPageState extends State<PluginEditorPage> {
                   useNativePlayer: useNativePlayer,
                   usePost: usePost,
                   useLegacyParser: useLegacyParser,
+                  adBlocker: adBlocker,
                   userAgent: userAgentController.text,
                   baseUrl: baseURLController.text,
                   searchURL: searchURLController.text,
@@ -231,6 +244,7 @@ class _PluginEditorPageState extends State<PluginEditorPage> {
               plugin.useNativePlayer = useNativePlayer;
               plugin.usePost = usePost;
               plugin.useLegacyParser = useLegacyParser;
+              plugin.adBlocker = adBlocker;
               plugin.referer = refererController.text;
               pluginsController.updatePlugin(plugin);
               Navigator.of(context).pop();

--- a/lib/pages/settings/player_settings.dart
+++ b/lib/pages/settings/player_settings.dart
@@ -28,6 +28,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
   late bool privateMode;
   late bool playerDebugMode;
   late bool playerDisableAnimations;
+  late bool forceAdBlocker;
   late int playerButtonSkipTime;
   late int playerArrowKeySkipTime;
   late int playerLogLevel;
@@ -54,6 +55,8 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         setting.get(SettingBoxKey.playerDebugMode, defaultValue: false);
     playerDisableAnimations =
         setting.get(SettingBoxKey.playerDisableAnimations, defaultValue: false);
+    forceAdBlocker =
+        setting.get(SettingBoxKey.forceAdBlocker, defaultValue: false);
     playerLogLevel = setting.get(SettingBoxKey.playerLogLevel, defaultValue: 2);
 
     playerButtonSkipTime =
@@ -231,6 +234,16 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                   title: Text('自动跳转', style: TextStyle(fontFamily: fontFamily)),
                   description: Text('跳转到上次播放位置', style: TextStyle(fontFamily: fontFamily)),
                   initialValue: playResume,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    forceAdBlocker = value ?? !forceAdBlocker;
+                    await setting.put(SettingBoxKey.forceAdBlocker, forceAdBlocker);
+                    setState(() {});
+                  },
+                  title: Text('广告过滤', style: TextStyle(fontFamily: fontFamily)),
+                  description: Text('强制启用HLS广告过滤，忽略规则设置', style: TextStyle(fontFamily: fontFamily)),
+                  initialValue: forceAdBlocker,
                 ),
                 SettingsTile.switchTile(
                   onToggle: (value) async {

--- a/lib/plugins/plugins.dart
+++ b/lib/plugins/plugins.dart
@@ -18,6 +18,7 @@ class Plugin {
   bool useNativePlayer;
   bool usePost;
   bool useLegacyParser;
+  bool adBlocker;
   String userAgent;
   String baseUrl;
   String searchURL;
@@ -38,6 +39,7 @@ class Plugin {
     required this.useNativePlayer,
     required this.usePost,
     required this.useLegacyParser,
+    required this.adBlocker,
     required this.userAgent,
     required this.baseUrl,
     required this.searchURL,
@@ -60,6 +62,7 @@ class Plugin {
         useNativePlayer: json['useNativePlayer'],
         usePost: json['usePost'] ?? false,
         useLegacyParser: json['useLegacyParser'] ?? false,
+        adBlocker: json['adBlocker'] ?? false,
         userAgent: json['userAgent'],
         baseUrl: json['baseURL'],
         searchURL: json['searchURL'],
@@ -82,6 +85,7 @@ class Plugin {
         useNativePlayer: true,
         usePost: false,
         useLegacyParser: false,
+        adBlocker: false,
         userAgent: '',
         baseUrl: '',
         searchURL: '',
@@ -104,6 +108,7 @@ class Plugin {
     data['useNativePlayer'] = useNativePlayer;
     data['usePost'] = usePost;
     data['useLegacyParser'] = useLegacyParser;
+    data['adBlocker'] = adBlocker;
     data['userAgent'] = userAgent;
     data['baseURL'] = baseUrl;
     data['searchURL'] = searchURL;

--- a/lib/request/api.dart
+++ b/lib/request/api.dart
@@ -2,7 +2,7 @@ class Api {
   /// 当前版本
   static const String version = '1.9.2';
   /// 规则API级别
-  static const int apiLevel = 4;
+  static const int apiLevel = 5;
   /// 项目主页
   static const String projectUrl = "https://kazumi.app/";
   /// Github 项目主页

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -265,5 +265,6 @@ class SettingBoxKey {
       searchNotShowAbandonedBangumis = 'searchNotShowAbandonedBangumis',
       timelineNotShowAbandonedBangumis = 'timelineNotShowAbandonedBangumis',
       timelineNotShowWatchedBangumis = 'timelineNotShowWatchedBangumis',
-      useSystemFont = 'useSystemFont';
+      useSystemFont = 'useSystemFont',
+      forceAdBlocker = 'forceAdBlocker';
 }


### PR DESCRIPTION
fixed #1524

完成了如下更新：

  - 插件API版本升级: 4 → 5
  - Plugin类添加adBlocker字段支持按规则控制广告过滤
  - 播放设置添加"广告过滤"全局开关(强制启用时忽略规则设置)
  - 规则编辑器添加广告过滤开关
  - 播放器集成adBlocker参数到PlayerConfiguration

此前的PR的实现与我们最终实际实现的代码并不相符，所以我干脆删除了我自己的skip-ad分支，重新创建了一个干净的分支来实现这些功能。

我已经自行测试，现在已经可以完美跳过广告了。

