### PR TITLE
将搜索设置、时间线设置改为弹出对话框，并移除TabBar

### DIFF
--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -19,7 +19,7 @@ class SearchPage extends StatefulWidget {
 
 class _SearchPageState extends State<SearchPage> {
   final SearchController searchController = SearchController();
-  String _currentSort = 'match';
+  String _currentSort = '';
 
   /// Don't use modular singleton here. We may have multiple search pages.
   /// Use a new instance of SearchPageController for each search page.
@@ -88,7 +88,7 @@ class _SearchPageState extends State<SearchPage> {
                     ),
                     ButtonSegment(
                       value: 'match',
-                      label: Text('匹配'),
+                      label: Text('准确'),
                       icon: Icon(Icons.search),
                     ),
                   ],
@@ -167,19 +167,14 @@ class _SearchPageState extends State<SearchPage> {
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () async {
-          showDialog(
+          showModalBottomSheet(
+            isScrollControlled: true,
+            useSafeArea: true,
+            clipBehavior: Clip.antiAlias,
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             context: context,
-            barrierDismissible: true,
             builder: (context) {
-              return Dialog(
-                insetPadding: const EdgeInsets.symmetric(horizontal: 10),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    maxWidth: 300,
-                  ),
-                  child: showSearchOptionsDialog(),
-                ),
-              );
+              return showSearchOptionsDialog();
             },
           );
         },

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -54,7 +54,7 @@ class _TimelinePageState extends State<TimelinePage>
     navigationBarState.updateSelectedIndex(0);
     Modular.to.navigate('/tab/popular/');
   }
-  String _currentSort = 'match';
+  String _currentSort = 'time';
   DateTime generateDateTime(int year, String season) {
     switch (season) {
       case '冬':
@@ -363,18 +363,13 @@ class _TimelinePageState extends State<TimelinePage>
                   selected: {_currentSort},
                   onSelectionChanged: (Set<String> value) {
                     final sort = value.first;
-
-                    setInnerState(() {
-                      _currentSort = sort;
-                    });
-
+                    setInnerState(() {_currentSort = sort;});
                     int type;
                     sort == 'heat'
                       ? type = 3
                       : sort == 'rank'
                         ? type = 2
                         : type = 1;
-
                     timelineController.changeSortType(type);
                   },
                 ),
@@ -451,20 +446,18 @@ class _TimelinePageState extends State<TimelinePage>
         ),
         floatingActionButton: FloatingActionButton(
           onPressed: () async {
-            showDialog(
+            KazumiDialog.showBottomSheet(
+              backgroundColor: Theme.of(context).colorScheme.surface,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+              ),
+              isScrollControlled: true,
+              useSafeArea: true,
+              clipBehavior: Clip.antiAlias,
               context: context,
-              barrierDismissible: true,
               builder: (context) {
-                return Dialog(
-                  insetPadding: const EdgeInsets.symmetric(horizontal: 10),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(
-                      maxWidth: 300,
-                    ),
-                    child: showTimelineOptionsDialog(),
-                  ),
-                );
-              },
+                return showTimelineOptionsDialog();
+              }
             );
           },
           child: const Icon(Icons.tune),


### PR DESCRIPTION
1. 将搜索设置、时间线设置改为弹出对话框，以规避问题#1571
2. 排序方式改为使用SegmentedButton来选择
3. 移除了TabBar，直接在一页内显示

如图所示
<img width="320" height="727" alt="image" src="https://github.com/user-attachments/assets/38cae0f9-013c-4689-a2fb-60b4cbf40dbe" />
<img width="942" height="648" alt="image" src="https://github.com/user-attachments/assets/81879d1c-90e7-4690-80cf-f8a8fa34e59c" />
