### PR TITLE
去掉代理配置页面中的 HTTP Proxy 身份认证的样式

### DIFF
--- a/lib/pages/settings/proxy/proxy_editor_page.dart
+++ b/lib/pages/settings/proxy/proxy_editor_page.dart
@@ -19,26 +19,17 @@ class _ProxyEditorPageState extends State<ProxyEditorPage> {
   Box setting = GStorage.setting;
   final _formKey = GlobalKey<FormState>();
   final TextEditingController urlController = TextEditingController();
-  final TextEditingController usernameController = TextEditingController();
-  final TextEditingController passwordController = TextEditingController();
-  bool passwordVisible = false;
 
   @override
   void initState() {
     super.initState();
     urlController.text =
         setting.get(SettingBoxKey.proxyUrl, defaultValue: '');
-    usernameController.text =
-        setting.get(SettingBoxKey.proxyUsername, defaultValue: '');
-    passwordController.text =
-        setting.get(SettingBoxKey.proxyPassword, defaultValue: '');
   }
 
   @override
   void dispose() {
     urlController.dispose();
-    usernameController.dispose();
-    passwordController.dispose();
     super.dispose();
   }
 
@@ -54,8 +45,6 @@ class _ProxyEditorPageState extends State<ProxyEditorPage> {
     }
 
     await setting.put(SettingBoxKey.proxyUrl, url);
-    await setting.put(SettingBoxKey.proxyUsername, usernameController.text);
-    await setting.put(SettingBoxKey.proxyPassword, passwordController.text);
     // 重置配置状态，等待测试结果
     await setting.put(SettingBoxKey.proxyConfigured, false);
 
@@ -116,33 +105,6 @@ class _ProxyEditorPageState extends State<ProxyEditorPage> {
                       }
                       return null;
                     },
-                  ),
-                  const SizedBox(height: 20),
-                  TextFormField(
-                    controller: usernameController,
-                    decoration: const InputDecoration(
-                      labelText: '用户名（可选）',
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 20),
-                  TextFormField(
-                    controller: passwordController,
-                    obscureText: !passwordVisible,
-                    decoration: InputDecoration(
-                      labelText: '密码（可选）',
-                      border: const OutlineInputBorder(),
-                      suffixIcon: IconButton(
-                        onPressed: () {
-                          setState(() {
-                            passwordVisible = !passwordVisible;
-                          });
-                        },
-                        icon: Icon(passwordVisible
-                            ? Icons.visibility_rounded
-                            : Icons.visibility_off_rounded),
-                      ),
-                    ),
                   ),
                 ],
               ),

--- a/lib/request/request.dart
+++ b/lib/request/request.dart
@@ -43,10 +43,6 @@ class Request {
 
     final String proxyUrl =
         setting.get(SettingBoxKey.proxyUrl, defaultValue: '');
-    final String proxyUsername =
-        setting.get(SettingBoxKey.proxyUsername, defaultValue: '');
-    final String proxyPassword =
-        setting.get(SettingBoxKey.proxyPassword, defaultValue: '');
 
     final parsed = ProxyUtils.parseProxyUrl(proxyUrl);
     if (parsed == null) {
@@ -62,15 +58,6 @@ class Request {
         client.findProxy = (Uri uri) {
           return 'PROXY $proxyHost:$proxyPort';
         };
-        // 处理代理认证
-        if (proxyUsername.isNotEmpty && proxyPassword.isNotEmpty) {
-          client.addProxyCredentials(
-            proxyHost,
-            proxyPort,
-            'Basic',
-            HttpClientBasicCredentials(proxyUsername, proxyPassword),
-          );
-        }
         // 忽略证书验证
         client.badCertificateCallback =
             (X509Certificate cert, String host, int port) => true;

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -270,7 +270,5 @@ class SettingBoxKey {
       forceAdBlocker = 'forceAdBlocker',
       proxyEnable = 'proxyEnable',
       proxyConfigured = 'proxyConfigured',
-      proxyUrl = 'proxyUrl',
-      proxyUsername = 'proxyUsername',
-      proxyPassword = 'proxyPassword';
+      proxyUrl = 'proxyUrl';
 }


### PR DESCRIPTION
libmpv and Windows WebView2 do not support HTTP proxy authentication, so this feature is removed to avoid confusion.