### PR TITLE
feat: add comments sort button

### DIFF
--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -40,7 +40,7 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   /// episode input by [showEpisodeSelection]
   int ep = 0;
 
-  bool isAscending = true;
+  bool isAscending = false;
 
   @override
   void initState() {

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -92,6 +92,9 @@ abstract class _VideoPageController with Store {
         .then((value) {
       episodeCommentsList.addAll(value.commentList);
     });
+    episodeCommentsList.sort(
+      (a, b) => b.comment.createdAt.compareTo(a.comment.createdAt),
+    );
     KazumiLogger().i('VideoPageController: loaded comments list length ${episodeCommentsList.length}');
   }
 


### PR DESCRIPTION
实现 #1633 的功能
用于评论正序倒序的按钮
效果如图，已在 Win/iOS 测试
<img width="1367" height="915" alt="2ea87ceba990378d1faa53d25528cb8f" src="https://github.com/user-attachments/assets/dab2d779-15a6-4ced-bcdb-eddcf272d8ba" />
<img width="1367" height="915" alt="f89f60381c79f41e49d01fa0a1be5685" src="https://github.com/user-attachments/assets/c8c11a44-59fe-4089-8ce8-597ec0438ea4" />
<img width="1620" height="2160" alt="47B9C3AD858640C93921C4A28ACE12A6" src="https://github.com/user-attachments/assets/e82728ff-59d0-416e-8524-42a65f8b5858" />
