### PR TITLE
fix: bangumi_card maxLines

### DIFF
--- a/lib/bean/card/bangumi_card.dart
+++ b/lib/bean/card/bangumi_card.dart
@@ -78,6 +78,9 @@ class BangumiContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final ts = MediaQuery.textScalerOf(context);
 
+    final int maxTextLines = Utils.isDesktop() ? 3 
+      : (Utils.isTablet() && MediaQuery.of(context).orientation == Orientation.landscape) ? 3 : 2;
+
     return Expanded(
       child: Padding(
         // 多列
@@ -92,7 +95,7 @@ class BangumiContent extends StatelessWidget {
             letterSpacing: 0.3,
           ),
           textScaler: ts.clamp(maxScaleFactor: 1.1),
-          maxLines: Utils.isDesktop() || Utils.isTablet() ? 3 : 2,
+          maxLines: maxTextLines,
           overflow: TextOverflow.ellipsis,
         ),
       ),


### PR DESCRIPTION
用于修复 #1609 
我的方案是在平板环境下 竖屏显示2行 横屏显示3行 这样看起来是比较美观的
我也尝试过直接平板竖屏显示3行 看起来有点奇怪而且字贴到卡片框底了 看起来很紧凑 横屏三行则显示正常
PC显示3行 手机显示2行 逻辑不变

如果平板下竖屏显3行 看起来很奇怪：
<img width="299" height="543" alt="84e84314-07ce-4afd-bfae-fd1e0790f44f" src="https://github.com/user-attachments/assets/5a1ac421-9828-4513-88f0-3228314db102" />

我的方案 平板下竖屏显2行 横屏显3行：
<img width="2160" height="1620" alt="5BE3C52103DAB7451C76DB25CF1DACFF" src="https://github.com/user-attachments/assets/114136a6-5dc9-406e-935e-77479dcef3ac" />
<img width="1620" height="2160" alt="43788896D89EC01F78428DB33B72C981" src="https://github.com/user-attachments/assets/0795693c-9d14-4c4d-b910-247f9191500e" />
