### PR TITLE
feat: add timed shutdown setting (issue #1586)

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -44,6 +44,7 @@ class PlayerItem extends StatefulWidget {
     required this.keyboardFocus,
     required this.sendDanmaku,
     required this.showDanmakuDestinationPickerAndSend,
+    required this.pauseForTimedShutdown,
     this.disableAnimations = false,
   });
 
@@ -56,6 +57,7 @@ class PlayerItem extends StatefulWidget {
   final FocusNode keyboardFocus;
   final bool disableAnimations;
   final void Function(String) showDanmakuDestinationPickerAndSend;
+  final VoidCallback pauseForTimedShutdown;
 
   @override
   State<PlayerItem> createState() => _PlayerItemState();
@@ -1514,6 +1516,7 @@ class _PlayerItemState extends State<PlayerItem>
                             showSyncPlayEndPointSwitchDialog:
                                 showSyncPlayEndPointSwitchDialog,
                             showDanmakuDestinationPickerAndSend: widget.showDanmakuDestinationPickerAndSend,
+                            pauseForTimedShutdown: widget.pauseForTimedShutdown,
                             disableAnimations: widget.disableAnimations,
                             handleScreenShot: handleScreenshot,
                             skipOP: skipOP,
@@ -1539,6 +1542,7 @@ class _PlayerItemState extends State<PlayerItem>
                                 showSyncPlayRoomCreateDialog,
                             showSyncPlayEndPointSwitchDialog:
                                 showSyncPlayEndPointSwitchDialog,
+                            pauseForTimedShutdown: widget.pauseForTimedShutdown,
                             disableAnimations: widget.disableAnimations,
                             skipOP: skipOP,
                           ),

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -43,6 +43,7 @@ class PlayerItemPanel extends StatefulWidget {
     required this.showSyncPlayRoomCreateDialog,
     required this.showSyncPlayEndPointSwitchDialog,
     required this.showDanmakuDestinationPickerAndSend,
+    required this.pauseForTimedShutdown,
     this.disableAnimations = false,
   });
 
@@ -68,6 +69,7 @@ class PlayerItemPanel extends StatefulWidget {
   final void Function() showSyncPlayRoomCreateDialog;
   final void Function() showSyncPlayEndPointSwitchDialog;
   final void Function(String) showDanmakuDestinationPickerAndSend;
+  final VoidCallback pauseForTimedShutdown;
   final bool disableAnimations;
 
   @override
@@ -1241,7 +1243,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                           for (final int minutes in [15, 30, 60])
                             MenuItemButton(
                               onPressed: () {
-                                TimedShutdownService().start(minutes);
+                                TimedShutdownService().start(minutes, onExpired: widget.pauseForTimedShutdown);
                                 KazumiDialog.showToast(message: '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
                               },
                               child: Container(
@@ -1262,7 +1264,9 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                             ),
                           MenuItemButton(
                             onPressed: () {
-                              TimedShutdownService.showCustomTimerDialog();
+                              TimedShutdownService.showCustomTimerDialog(
+                                onExpired: widget.pauseForTimedShutdown,
+                              );
                             },
                             child: Container(
                               height: 48,

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -38,6 +38,7 @@ class SmallestPlayerItemPanel extends StatefulWidget {
     required this.showVideoInfo,
     required this.showSyncPlayRoomCreateDialog,
     required this.showSyncPlayEndPointSwitchDialog,
+    required this.pauseForTimedShutdown,
     this.disableAnimations = false,
   });
 
@@ -58,6 +59,7 @@ class SmallestPlayerItemPanel extends StatefulWidget {
   final void Function() showVideoInfo;
   final void Function() showSyncPlayRoomCreateDialog;
   final void Function() showSyncPlayEndPointSwitchDialog;
+  final VoidCallback pauseForTimedShutdown;
   final bool disableAnimations;
 
   @override
@@ -906,7 +908,7 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                     for (final int minutes in [15, 30, 60])
                       MenuItemButton(
                         onPressed: () {
-                          TimedShutdownService().start(minutes);
+                          TimedShutdownService().start(minutes, onExpired: widget.pauseForTimedShutdown);
                           KazumiDialog.showToast(message: '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
                         },
                         child: Container(
@@ -927,7 +929,9 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                       ),
                     MenuItemButton(
                       onPressed: () {
-                        TimedShutdownService.showCustomTimerDialog();
+                        TimedShutdownService.showCustomTimerDialog(
+                          onExpired: widget.pauseForTimedShutdown,
+                        );
                       },
                       child: Container(
                         height: 48,

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -320,6 +320,13 @@ class _VideoPageState extends State<VideoPage>
     Navigator.of(context).pop();
   }
 
+  /// Callback for timed shutdown - pauses video when timer expires
+  void pauseForTimedShutdown() {
+    if (playerController.playing) {
+      playerController.pause();
+    }
+  }
+
   /// 发送弹幕 由于接口限制, 暂时未提交云端
   void sendDanmaku(String msg) async {
     keyboardFocus.requestFocus();
@@ -762,6 +769,7 @@ class _VideoPageState extends State<VideoPage>
                   sendDanmaku: sendDanmaku,
                   disableAnimations: disableAnimations,
                   showDanmakuDestinationPickerAndSend: showDanmakuDestinationPickerAndSend,
+                  pauseForTimedShutdown: pauseForTimedShutdown,
                 ),
         ),
 


### PR DESCRIPTION
在设置页面新增「定时关闭」功能。

支持选择预设关闭时间或自定义关闭时长；
设置完成后，可在定时关闭页面顶部随时取消已设定的定时任务；
当到达预定关闭时间时，会弹出确认提示，用户可选择立即关闭或取消关闭；
若在 30 秒内未进行任何操作，应用将自动关闭。

目前已在 Windows 和 Android 平台完成测试并验证功能正常，iOS 平台暂未测试。