### PR TITLE
feat(ios): 适配 UISceneDelegate 生命周期

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,52 +3,63 @@ import Flutter
 import AVKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
-        let channel = FlutterMethodChannel(name: "com.predidit.kazumi/intent",
-                                           binaryMessenger: controller.binaryMessenger)
-        channel.setMethodCallHandler({
-            (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+        let channel = FlutterMethodChannel(
+            name: "com.predidit.kazumi/intent",
+            binaryMessenger: engineBridge.applicationRegistrar.messenger()
+        )
+        channel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
             if call.method == "openWithReferer" {
                 guard let args = call.arguments else { return }
                 if let myArgs = args as? [String: Any],
                    let url = myArgs["url"] as? String,
                    let referer = myArgs["referer"] as? String {
-                    self.openVideoWithReferer(url: url, referer: referer)
+                    self?.openVideoWithReferer(url: url, referer: referer)
                 }
                 result(nil)
             } else {
                 result(FlutterMethodNotImplemented)
             }
-        })
-        GeneratedPluginRegistrant.register(with: self)
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+        }
     }
     
     // TODO: ADD VLC SUPPORT
     // VLC can be downloaded from iOS App Store, but don't know how to build selectable app lists, while checking if it is installled.
     // VLC supports more video formats than AVPlayer but does not support referer while AVPlayer does
     private func openVideoWithReferer(url: String, referer: String) {
-        if let videoUrl = URL(string: url) {
-            let headers: [String: String] = [
-                "Referer": referer,
-            ]
-            let asset = AVURLAsset(url: videoUrl, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
-            let playerItem = AVPlayerItem(asset: asset)
-            let player = AVPlayer(playerItem: playerItem)
-            let playerViewController = AVPlayerViewController()
-            playerViewController.player = player
-            playerViewController.videoGravity = AVLayerVideoGravity.resizeAspect
-            
-            UIApplication.shared.keyWindow?.rootViewController?.present(playerViewController, animated: true, completion: {
-                playerViewController.player!.play()
-            })
+        guard let videoUrl = URL(string: url) else { return }
+
+        let headers: [String: String] = [
+            "Referer": referer,
+        ]
+        let asset = AVURLAsset(url: videoUrl, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+        let playerItem = AVPlayerItem(asset: asset)
+        let player = AVPlayer(playerItem: playerItem)
+        let playerViewController = AVPlayerViewController()
+        playerViewController.player = player
+        playerViewController.videoGravity = AVLayerVideoGravity.resizeAspect
+
+        // Use UIScene API instead of deprecated keyWindow
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let rootViewController = windowScene.windows.first?.rootViewController else {
+            return
         }
-        
+
+        rootViewController.present(playerViewController, animated: true) {
+            playerViewController.player?.play()
+        }
+
 //        guard let appURL = URL(string: "vlc-x-callback://x-callback-url/stream?url=" + url) else {
 //            return
 //        }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,6 +43,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
我已经在本地使用ipad测试，以及在mac下使用iphone17 pro模拟测试，功能正常

## 改动：
- 为 AppDelegate 添加 FlutterImplicitEngineDelegate 协议
- 将插件注册和 Method Channel 设置移至 didInitializeImplicitFlutterEngine
- 使用 UIScene API 替代已弃用的 keyWindow
- 在 Info.plist 中添加 UIApplicationSceneManifest
- 添加 CocoaPods 依赖管理的 Podfile

此迁移是 Apple 对 iOS 26+ 兼容性的要求
参考: https://docs.flutter.dev/release/breaking-changes/uiscenedelegate