### PR TITLE
fix: auto_updater _revealInFileManager

### DIFF
--- a/lib/utils/auto_updater.dart
+++ b/lib/utils/auto_updater.dart
@@ -687,6 +687,9 @@ class AutoUpdater {
     try {
       final type = await FileSystemEntity.type(filePath);
       String targetDirOrFile;
+
+      // 如果传入的本来就是目录则打开这个目录
+      // 如果是文件则打开包含它的目录
       if (type == FileSystemEntityType.notFound) {
         KazumiDialog.showToast(message: '文件或目录不存在');
         return;
@@ -710,6 +713,7 @@ class AutoUpdater {
           await Process.start('open', [targetDirOrFile]);
         }
       } else if (Platform.isLinux) {
+        // 尝试打开包含文件的文件夹
         await Process.start('xdg-open', [targetDirOrFile]);
       } else {
         KazumiDialog.showToast(message: '此平台不支持通过此方法打开文件管理器');
@@ -719,6 +723,7 @@ class AutoUpdater {
       KazumiLogger().w('Update: reveal in file manager failed', error: e);
     } finally {
       try {
+        // 确保对话框被关闭
         KazumiDialog.dismiss();
       } catch (_) {}
     }


### PR DESCRIPTION
修复 #1655 的问题
增加了更多检查防止出现更多问题
现在在Windows上能够正常打开包含新版本的目录并选中
在Windows中explorer的参数解析规则是：explorer.exe "/select,C:\path\file" 而不是 explorer.exe "/select," "C:\path\file"

https://github.com/user-attachments/assets/d220378a-7c57-4420-8afa-ee54e335177c


