### PR TITLE
fix: 修复安卓下鼠标操作后最外层出现绿色边框的问题

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,6 +6,8 @@
              the Flutter engine draws its first frame -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -16,5 +18,7 @@
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">shortEdges</item>
+
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 </resources>


### PR DESCRIPTION
安卓下用鼠标操作后最外层出现一道绿色边框，设置android:defaultFocusHighlightEnabled为false后安卓下就不会这样了