### PR TITLE
fix: add safearea for danmaku_settings_sheet

### DIFF
--- a/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
+++ b/lib/pages/settings/danmaku/danmaku_settings_sheet.dart
@@ -34,180 +34,186 @@ class _DanmakuSettingsSheetState extends State<DanmakuSettingsSheet> {
         clipBehavior: Clip.antiAlias,
         context: context,
         builder: (context) {
-          return DanmakuShieldSettings();
+          return SafeArea(
+            bottom: false,
+            child: DanmakuShieldSettings(),
+          );
         });
   }
 
   @override
   Widget build(BuildContext context) {
     final fontFamily = Theme.of(context).textTheme.bodyMedium?.fontFamily;
-    return SettingsList(
-      sections: [
-        SettingsSection(
-          title: Text('弹幕屏蔽', style: TextStyle(fontFamily: fontFamily)),
-          tiles: [
-            SettingsTile.navigation(
-              onPressed: (_) {
-                showDanmakuShieldSheet();
-              },
-              title: Text('关键词屏蔽', style: TextStyle(fontFamily: fontFamily)),
-            ),
-          ],
-        ),
-        SettingsSection(
-          title: Text('弹幕样式', style: TextStyle(fontFamily: fontFamily)),
-          tiles: [
-            SettingsTile(
-              title: Text('字体大小', style: TextStyle(fontFamily: fontFamily)),
-              description: Slider(
-                value: widget.danmakuController.option.fontSize,
-                min: 10,
-                max: Utils.isCompact() ? 32 : 48,
-                label:
-                    '${widget.danmakuController.option.fontSize.floorToDouble()}',
-                onChanged: (value) {
+    return SafeArea(
+      bottom: false,
+      child: SettingsList(
+        sections: [
+          SettingsSection(
+            title: Text('弹幕屏蔽', style: TextStyle(fontFamily: fontFamily)),
+            tiles: [
+              SettingsTile.navigation(
+                onPressed: (_) {
+                  showDanmakuShieldSheet();
+                },
+                title: Text('关键词屏蔽', style: TextStyle(fontFamily: fontFamily)),
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text('弹幕样式', style: TextStyle(fontFamily: fontFamily)),
+            tiles: [
+              SettingsTile(
+                title: Text('字体大小', style: TextStyle(fontFamily: fontFamily)),
+                description: Slider(
+                  value: widget.danmakuController.option.fontSize,
+                  min: 10,
+                  max: Utils.isCompact() ? 32 : 48,
+                  label:
+                      '${widget.danmakuController.option.fontSize.floorToDouble()}',
+                  onChanged: (value) {
+                    setState(() => widget.danmakuController.updateOption(
+                          widget.danmakuController.option.copyWith(
+                            fontSize: value.floorToDouble(),
+                          ),
+                        ));
+                    setting.put(
+                        SettingBoxKey.danmakuFontSize, value.floorToDouble());
+                  },
+                ),
+              ),
+              SettingsTile(
+                title: Text('弹幕不透明度', style: TextStyle(fontFamily: fontFamily)),
+                description: Slider(
+                  value: widget.danmakuController.option.opacity,
+                  min: 0.1,
+                  max: 1,
+                  label:
+                      '${(widget.danmakuController.option.opacity * 100).round()}%',
+                  onChanged: (value) {
+                    setState(() => widget.danmakuController.updateOption(
+                          widget.danmakuController.option.copyWith(
+                            opacity: value,
+                          ),
+                        ));
+                    setting.put(SettingBoxKey.danmakuOpacity,
+                        double.parse(value.toStringAsFixed(2)));
+                  },
+                ),
+              ),
+            ],
+          ),
+          SettingsSection(
+            title: Text('弹幕显示', style: TextStyle(fontFamily: fontFamily)),
+            tiles: [
+              SettingsTile(
+                title: Text('弹幕区域', style: TextStyle(fontFamily: fontFamily)),
+                description: Slider(
+                  value: widget.danmakuController.option.area,
+                  min: 0,
+                  max: 1,
+                  divisions: 8,
+                  label:
+                      '${(widget.danmakuController.option.area * 100).round()}%',
+                  onChanged: (value) {
+                    setState(() => widget.danmakuController.updateOption(
+                          widget.danmakuController.option.copyWith(
+                            area: value,
+                          ),
+                        ));
+                    setting.put(SettingBoxKey.danmakuArea, value);
+                  },
+                ),
+              ),
+              SettingsTile(title: Text('持续时间', style: TextStyle(fontFamily: fontFamily)),
+                description: Slider(
+                  value: widget.danmakuController.option.duration.toDouble(),
+                  min: 2,
+                  max: 16,
+                  divisions: 14,
+                  label:
+                      '${widget.danmakuController.option.duration.round()}',
+                  onChanged: (value) {
+                    setState(() => widget.danmakuController.updateOption(
+                          widget.danmakuController.option.copyWith(
+                            duration: value,
+                          ),
+                        ));
+                    setting.put(SettingBoxKey.danmakuDuration, value.round().toDouble());
+                  },
+                ),
+              ),
+              SettingsTile(
+                title: Text('行高', style: TextStyle(fontFamily: fontFamily)),
+                description: Slider(
+                  value: widget.danmakuController.option.lineHeight,
+                  min: 0,
+                  max: 3,
+                  divisions: 30,
+                  label: widget.danmakuController.option.lineHeight.toStringAsFixed(1),
+                  onChanged: (value) {
+                    setState(() => widget.danmakuController.updateOption(
+                          widget.danmakuController.option.copyWith(
+                            lineHeight: double.parse(value.toStringAsFixed(1)),
+                          ),
+                        ));
+                    setting.put(SettingBoxKey.danmakuLineHeight, double.parse(value.toStringAsFixed(1)));
+                  },
+                ),
+              ),
+              SettingsTile.switchTile(
+                onToggle: (value) async {
+                  bool show = value ?? widget.danmakuController.option.hideTop;
                   setState(() => widget.danmakuController.updateOption(
                         widget.danmakuController.option.copyWith(
-                          fontSize: value.floorToDouble(),
+                          hideTop: !show,
                         ),
                       ));
-                  setting.put(
-                      SettingBoxKey.danmakuFontSize, value.floorToDouble());
+                  setting.put(SettingBoxKey.danmakuTop, show);
                 },
+                title: Text('顶部弹幕', style: TextStyle(fontFamily: fontFamily)),
+                initialValue: !widget.danmakuController.option.hideTop,
               ),
-            ),
-            SettingsTile(
-              title: Text('弹幕不透明度', style: TextStyle(fontFamily: fontFamily)),
-              description: Slider(
-                value: widget.danmakuController.option.opacity,
-                min: 0.1,
-                max: 1,
-                label:
-                    '${(widget.danmakuController.option.opacity * 100).round()}%',
-                onChanged: (value) {
+              SettingsTile.switchTile(
+                onToggle: (value) async {
+                  bool show = value ?? widget.danmakuController.option.hideBottom;
                   setState(() => widget.danmakuController.updateOption(
                         widget.danmakuController.option.copyWith(
-                          opacity: value,
+                          hideBottom: !show,
                         ),
                       ));
-                  setting.put(SettingBoxKey.danmakuOpacity,
-                      double.parse(value.toStringAsFixed(2)));
+                  setting.put(SettingBoxKey.danmakuBottom, show);
                 },
+                title: Text('底部弹幕', style: TextStyle(fontFamily: fontFamily)),
+                initialValue: !widget.danmakuController.option.hideBottom,
               ),
-            ),
-          ],
-        ),
-        SettingsSection(
-          title: Text('弹幕显示', style: TextStyle(fontFamily: fontFamily)),
-          tiles: [
-            SettingsTile(
-              title: Text('弹幕区域', style: TextStyle(fontFamily: fontFamily)),
-              description: Slider(
-                value: widget.danmakuController.option.area,
-                min: 0,
-                max: 1,
-                divisions: 8,
-                label:
-                    '${(widget.danmakuController.option.area * 100).round()}%',
-                onChanged: (value) {
+              SettingsTile.switchTile(
+                onToggle: (value) async {
+                  bool show = value ?? widget.danmakuController.option.hideScroll;
                   setState(() => widget.danmakuController.updateOption(
                         widget.danmakuController.option.copyWith(
-                          area: value,
+                          hideScroll: !show,
                         ),
                       ));
-                  setting.put(SettingBoxKey.danmakuArea, value);
+                  setting.put(SettingBoxKey.danmakuScroll, show);
                 },
+                title: Text('滚动弹幕', style: TextStyle(fontFamily: fontFamily)),
+                initialValue: !widget.danmakuController.option.hideScroll,
               ),
-            ),
-            SettingsTile(title: Text('持续时间', style: TextStyle(fontFamily: fontFamily)),
-              description: Slider(
-                value: widget.danmakuController.option.duration.toDouble(),
-                min: 2,
-                max: 16,
-                divisions: 14,
-                label:
-                    '${widget.danmakuController.option.duration.round()}',
-                onChanged: (value) {
-                  setState(() => widget.danmakuController.updateOption(
-                        widget.danmakuController.option.copyWith(
-                          duration: value,
-                        ),
-                      ));
-                  setting.put(SettingBoxKey.danmakuDuration, value.round().toDouble());
+              SettingsTile.switchTile(
+                onToggle: (value) async {
+                  bool followSpeed = value ?? !setting.get(SettingBoxKey.danmakuFollowSpeed, defaultValue: true);
+                  setting.put(SettingBoxKey.danmakuFollowSpeed, followSpeed);
+                  widget.onUpdateDanmakuSpeed?.call();
+                  setState(() {});
                 },
+                title: Text('跟随视频倍速', style: TextStyle(fontFamily: fontFamily)),
+                description: Text('弹幕速度随视频倍速变化', style: TextStyle(fontFamily: fontFamily)),
+                initialValue: setting.get(SettingBoxKey.danmakuFollowSpeed, defaultValue: true),
               ),
-            ),
-            SettingsTile(
-              title: Text('行高', style: TextStyle(fontFamily: fontFamily)),
-              description: Slider(
-                value: widget.danmakuController.option.lineHeight,
-                min: 0,
-                max: 3,
-                divisions: 30,
-                label: widget.danmakuController.option.lineHeight.toStringAsFixed(1),
-                onChanged: (value) {
-                  setState(() => widget.danmakuController.updateOption(
-                        widget.danmakuController.option.copyWith(
-                          lineHeight: double.parse(value.toStringAsFixed(1)),
-                        ),
-                      ));
-                  setting.put(SettingBoxKey.danmakuLineHeight, double.parse(value.toStringAsFixed(1)));
-                },
-              ),
-            ),
-            SettingsTile.switchTile(
-              onToggle: (value) async {
-                bool show = value ?? widget.danmakuController.option.hideTop;
-                setState(() => widget.danmakuController.updateOption(
-                      widget.danmakuController.option.copyWith(
-                        hideTop: !show,
-                      ),
-                    ));
-                setting.put(SettingBoxKey.danmakuTop, show);
-              },
-              title: Text('顶部弹幕', style: TextStyle(fontFamily: fontFamily)),
-              initialValue: !widget.danmakuController.option.hideTop,
-            ),
-            SettingsTile.switchTile(
-              onToggle: (value) async {
-                bool show = value ?? widget.danmakuController.option.hideBottom;
-                setState(() => widget.danmakuController.updateOption(
-                      widget.danmakuController.option.copyWith(
-                        hideBottom: !show,
-                      ),
-                    ));
-                setting.put(SettingBoxKey.danmakuBottom, show);
-              },
-              title: Text('底部弹幕', style: TextStyle(fontFamily: fontFamily)),
-              initialValue: !widget.danmakuController.option.hideBottom,
-            ),
-            SettingsTile.switchTile(
-              onToggle: (value) async {
-                bool show = value ?? widget.danmakuController.option.hideScroll;
-                setState(() => widget.danmakuController.updateOption(
-                      widget.danmakuController.option.copyWith(
-                        hideScroll: !show,
-                      ),
-                    ));
-                setting.put(SettingBoxKey.danmakuScroll, show);
-              },
-              title: Text('滚动弹幕', style: TextStyle(fontFamily: fontFamily)),
-              initialValue: !widget.danmakuController.option.hideScroll,
-            ),
-            SettingsTile.switchTile(
-              onToggle: (value) async {
-                bool followSpeed = value ?? !setting.get(SettingBoxKey.danmakuFollowSpeed, defaultValue: true);
-                setting.put(SettingBoxKey.danmakuFollowSpeed, followSpeed);
-                widget.onUpdateDanmakuSpeed?.call();
-                setState(() {});
-              },
-              title: Text('跟随视频倍速', style: TextStyle(fontFamily: fontFamily)),
-              description: Text('弹幕速度随视频倍速变化', style: TextStyle(fontFamily: fontFamily)),
-              initialValue: setting.get(SettingBoxKey.danmakuFollowSpeed, defaultValue: true),
-            ),
-          ],
-        ),
-      ],
+            ],
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
手机的额头摄像头区域挡住了页面（截图截不到额头区域，例图）：
<img width="2532" height="1170" alt="31EC1DC3CC66C629AC90FBA3B97CC2A6" src="https://github.com/user-attachments/assets/408a77a2-e8d5-4452-a557-8f5b31b56fd3" />
添加了安全区域来修复此问题：
<img width="2532" height="1170" alt="7E32EFF988D1E988B44DB320E4DC5AC4" src="https://github.com/user-attachments/assets/f30d99df-c97c-4bde-8c05-e2d3d551b766" />

<img width="1469" height="376" alt="d95b2a9a-8b32-4254-9a79-0cf922562414" src="https://github.com/user-attachments/assets/f811a080-016f-424d-b4f9-0c5547be8a9c" />
