### PR TITLE
feat: Android 后台下载

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,12 +35,19 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- flutter_foreground_task service -->
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility?hl=en and

--- a/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
@@ -1,7 +1,8 @@
 package com.example.kazumi
 
 import android.content.Intent
-import android.os.Build;
+import android.os.Build
+import android.os.StatFs
 import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.NonNull
@@ -11,6 +12,7 @@ import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.predidit.kazumi/intent"
+    private val STORAGE_CHANNEL = "com.predidit.kazumi/storage"
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -34,6 +36,16 @@ class MainActivity: FlutterActivity() {
                 result.notImplemented()
             }
         }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, STORAGE_CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "getAvailableStorage") {
+                val path = call.argument<String>("path") ?: filesDir.absolutePath
+                val availableBytes = getAvailableStorage(path)
+                result.success(availableBytes)
+            } else {
+                result.notImplemented()
+            }
+        }
     }
 
     private fun openWithMime(url: String, mimeType: String) {
@@ -53,5 +65,14 @@ class MainActivity: FlutterActivity() {
 
     private fun getAndroidSdkVersion(): Int {
         return Build.VERSION.SDK_INT
+    }
+
+    private fun getAvailableStorage(path: String): Long {
+        return try {
+            val stat = StatFs(path)
+            stat.availableBlocksLong * stat.blockSizeLong
+        } catch (e: Exception) {
+            -1L
+        }
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -32,6 +32,29 @@ import AVKit
                 result(FlutterMethodNotImplemented)
             }
         }
+
+        let storageChannel = FlutterMethodChannel(
+            name: "com.predidit.kazumi/storage",
+            binaryMessenger: engineBridge.applicationRegistrar.messenger()
+        )
+        storageChannel.setMethodCallHandler { (call: FlutterMethodCall, result: @escaping FlutterResult) in
+            if call.method == "getAvailableStorage" {
+                do {
+                    let attrs = try FileManager.default.attributesOfFileSystem(
+                        forPath: NSHomeDirectory()
+                    )
+                    if let freeSize = attrs[.systemFreeSize] as? Int64 {
+                        result(freeSize)
+                    } else {
+                        result(-1)
+                    }
+                } catch {
+                    result(-1)
+                }
+            } else {
+                result(FlutterMethodNotImplemented)
+            }
+        }
     }
     
     // TODO: ADD VLC SUPPORT

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -76,14 +76,7 @@ abstract class _DownloadController with Store {
       if (action == 'button_pressed') {
         _backgroundService.handleNotificationAction(data['id'] as String);
       } else if (action == 'navigate_to_download') {
-        // Delay slightly to ensure app is in foreground and UI is ready
-        Future.delayed(const Duration(milliseconds: 300), () {
-          try {
-            Modular.to.pushNamed('/settings/download/');
-          } catch (e) {
-            KazumiLogger().w('DownloadController: failed to navigate to download page', error: e);
-          }
-        });
+        _backgroundService.handleNavigateToDownload();
       }
     }
   }

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -71,8 +71,20 @@ abstract class _DownloadController with Store {
 
   /// Handle data received from background task handler
   void _onTaskData(Object data) {
-    if (data is Map && data['action'] == 'button_pressed') {
-      _backgroundService.handleNotificationAction(data['id'] as String);
+    if (data is Map) {
+      final action = data['action'];
+      if (action == 'button_pressed') {
+        _backgroundService.handleNotificationAction(data['id'] as String);
+      } else if (action == 'navigate_to_download') {
+        // Delay slightly to ensure app is in foreground and UI is ready
+        Future.delayed(const Duration(milliseconds: 300), () {
+          try {
+            Modular.to.pushNamed('/settings/download/');
+          } catch (e) {
+            KazumiLogger().w('DownloadController: failed to navigate to download page', error: e);
+          }
+        });
+      }
     }
   }
 

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -152,15 +152,6 @@ abstract class _DownloadController with Store {
             episode.status == DownloadStatus.pending) {
           pendingCount++;
           totalCount++;
-          // pending/resolving treated as 0% progress
-        } else if (episode.status == DownloadStatus.paused ||
-            episode.status == DownloadStatus.failed) {
-          totalCount++;
-          totalProgress += episode.progressPercent;
-        } else if (episode.status == DownloadStatus.completed) {
-          // Completed tasks count as 100% progress
-          totalCount++;
-          totalProgress += 1.0;
         }
       }
     }
@@ -506,6 +497,7 @@ abstract class _DownloadController with Store {
         episode.status = DownloadStatus.paused;
         await _repository.updateEpisode(recordKey, episodeNumber, episode);
         refreshRecords();
+        _updateBackgroundNotification();
       }
     }
   }
@@ -605,6 +597,7 @@ abstract class _DownloadController with Store {
         bangumiId, pluginName, episodeNumber);
     await _repository.deleteEpisode(recordKey, episodeNumber);
     refreshRecords();
+    _updateBackgroundNotification();
   }
 
   Future<void> deleteRecord(int bangumiId, String pluginName) async {
@@ -620,6 +613,7 @@ abstract class _DownloadController with Store {
     await _downloadManager.deleteRecordFiles(bangumiId, pluginName);
     await _repository.deleteRecord(recordKey);
     refreshRecords();
+    _updateBackgroundNotification();
   }
 
   Future<void> deleteEpisode(
@@ -633,6 +627,7 @@ abstract class _DownloadController with Store {
         bangumiId, pluginName, episodeNumber);
     await _repository.deleteEpisode(recordKey, episodeNumber);
     refreshRecords();
+    _updateBackgroundNotification();
   }
 
   Future<void> priorityDownload({

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -170,11 +170,15 @@ abstract class _DownloadController with Store {
             episode.status == DownloadStatus.pending) {
           pendingCount++;
           totalCount++;
+          // pending/resolving treated as 0% progress
         } else if (episode.status == DownloadStatus.paused ||
             episode.status == DownloadStatus.failed) {
-          // Include paused/failed in total for context, but with 0 progress contribution
           totalCount++;
           totalProgress += episode.progressPercent;
+        } else if (episode.status == DownloadStatus.completed) {
+          // Completed tasks count as 100% progress
+          totalCount++;
+          totalProgress += 1.0;
         }
       }
     }

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -8,6 +8,7 @@ import 'package:kazumi/plugins/plugins_controller.dart';
 import 'package:kazumi/repositories/download_repository.dart';
 import 'package:kazumi/utils/background_download_service.dart';
 import 'package:kazumi/utils/download_manager.dart';
+import 'package:kazumi/utils/format_utils.dart';
 import 'package:kazumi/utils/logger.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/providers/providers.dart';
@@ -177,14 +178,7 @@ abstract class _DownloadController with Store {
     return _speeds[key] ?? 0.0;
   }
 
-  /// Format speed to human-readable string
-  String formatSpeed(double bytesPerSec) {
-    if (bytesPerSec < 1024) return '${bytesPerSec.toStringAsFixed(0)} B/s';
-    if (bytesPerSec < 1024 * 1024) {
-      return '${(bytesPerSec / 1024).toStringAsFixed(1)} KB/s';
-    }
-    return '${(bytesPerSec / 1024 / 1024).toStringAsFixed(1)} MB/s';
-  }
+
 
   @action
   void refreshRecords() {
@@ -737,14 +731,6 @@ abstract class _DownloadController with Store {
         .length;
   }
 
-  String formatBytes(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) {
-      return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
-    }
-    return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(1)} GB';
-  }
 }
 
 class _ResolveRequest {

--- a/lib/pages/download/download_page.dart
+++ b/lib/pages/download/download_page.dart
@@ -7,6 +7,7 @@ import 'package:kazumi/modules/download/download_module.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/pages/download/download_controller.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
+import 'package:kazumi/utils/format_utils.dart';
 
 class DownloadPage extends StatefulWidget {
   const DownloadPage({super.key});
@@ -210,14 +211,14 @@ class _DownloadPageState extends State<DownloadPage> {
   String _getStatusText(DownloadRecord record, DownloadEpisode episode) {
     switch (episode.status) {
       case DownloadStatus.completed:
-        return '已完成  ${downloadController.formatBytes(episode.totalBytes)}';
+        return '已完成  ${formatBytes(episode.totalBytes)}';
       case DownloadStatus.downloading:
         final speed = downloadController.getSpeed(
           record.bangumiId,
           record.pluginName,
           episode.episodeNumber,
         );
-        final speedText = speed > 0 ? ' · ${downloadController.formatSpeed(speed)}' : '';
+        final speedText = speed > 0 ? ' · ${formatSpeed(speed)}' : '';
         return '${(episode.progressPercent * 100).toStringAsFixed(0)}%  '
             '${episode.downloadedSegments}/${episode.totalSegments}$speedText';
       case DownloadStatus.failed:

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -59,14 +59,12 @@ class _InitPageState extends State<InitPage> {
     _update();
   }
 
-  /// Setup callbacks for background download service
   void _setupBackgroundDownloadNavigation() {
     final backgroundService = BackgroundDownloadService();
 
     backgroundService.onNavigateToDownloadRequested = () {
       Future.delayed(const Duration(milliseconds: 300), () {
         try {
-          // 检查当前是否已在下载页面，避免重复导航
           if (Modular.to.path.contains('/download')) return;
           Modular.to.pushNamed('/settings/download/');
         } catch (e) {
@@ -75,7 +73,6 @@ class _InitPageState extends State<InitPage> {
       });
     };
 
-    // 设置通知权限请求回调
     backgroundService.onNotificationPermissionRequired = () async {
       final result = await KazumiDialog.show<bool>(
         clickMaskDismiss: false,

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -59,9 +59,11 @@ class _InitPageState extends State<InitPage> {
     _update();
   }
 
-  /// Setup navigation callback for background download notification
+  /// Setup callbacks for background download service
   void _setupBackgroundDownloadNavigation() {
     final backgroundService = BackgroundDownloadService();
+
+    // 设置点击通知导航回调
     backgroundService.onNavigateToDownloadRequested = () {
       // Delay slightly to ensure app is in foreground and UI is ready
       Future.delayed(const Duration(milliseconds: 300), () {
@@ -71,6 +73,36 @@ class _InitPageState extends State<InitPage> {
           KazumiLogger().w('InitPage: failed to navigate to download page', error: e);
         }
       });
+    };
+
+    // 设置通知权限请求回调
+    backgroundService.onNotificationPermissionRequired = () async {
+      final result = await KazumiDialog.show<bool>(
+        clickMaskDismiss: false,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('需要通知权限'),
+            content: const Text(
+              '开启通知权限后，可以在后台下载时显示进度，并防止系统终止下载任务。\n\n'
+              '如果拒绝，下载功能仍可使用，但在后台时可能被系统中断。',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => KazumiDialog.dismiss(popWith: false),
+                child: Text(
+                  '稍后再说',
+                  style: TextStyle(color: Theme.of(context).colorScheme.outline),
+                ),
+              ),
+              TextButton(
+                onPressed: () => KazumiDialog.dismiss(popWith: true),
+                child: const Text('允许'),
+              ),
+            ],
+          );
+        },
+      );
+      return result ?? false;
     };
   }
 

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -63,11 +63,11 @@ class _InitPageState extends State<InitPage> {
   void _setupBackgroundDownloadNavigation() {
     final backgroundService = BackgroundDownloadService();
 
-    // 设置点击通知导航回调
     backgroundService.onNavigateToDownloadRequested = () {
-      // Delay slightly to ensure app is in foreground and UI is ready
       Future.delayed(const Duration(milliseconds: 300), () {
         try {
+          // 检查当前是否已在下载页面，避免重复导航
+          if (Modular.to.path.contains('/download')) return;
           Modular.to.pushNamed('/settings/download/');
         } catch (e) {
           KazumiLogger().w('InitPage: failed to navigate to download page', error: e);

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -15,6 +15,7 @@ import 'package:provider/provider.dart';
 import 'package:kazumi/bean/settings/theme_provider.dart';
 import 'package:kazumi/shaders/shaders_controller.dart';
 import 'package:kazumi/pages/download/download_controller.dart';
+import 'package:kazumi/utils/background_download_service.dart';
 
 class InitPage extends StatefulWidget {
   const InitPage({super.key});
@@ -46,6 +47,7 @@ class _InitPageState extends State<InitPage> {
     _webDavInit();
     try {
       downloadController.init();
+      _setupBackgroundDownloadNavigation();
     } catch (e) {
       KazumiLogger().e('InitPage: downloadController.init() failed', error: e);
     }
@@ -55,6 +57,21 @@ class _InitPageState extends State<InitPage> {
 
     _navigateToHome();
     _update();
+  }
+
+  /// Setup navigation callback for background download notification
+  void _setupBackgroundDownloadNavigation() {
+    final backgroundService = BackgroundDownloadService();
+    backgroundService.onNavigateToDownloadRequested = () {
+      // Delay slightly to ensure app is in foreground and UI is ready
+      Future.delayed(const Duration(milliseconds: 300), () {
+        try {
+          Modular.to.pushNamed('/settings/download/');
+        } catch (e) {
+          KazumiLogger().w('InitPage: failed to navigate to download page', error: e);
+        }
+      });
+    };
   }
 
   void _navigateToHome() {

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -22,6 +22,9 @@ class BackgroundDownloadService {
   void Function()? onPauseAll;
   void Function()? onCancelAll;
 
+  /// 点击通知栏时的导航回调（由 UI 层设置）
+  void Function()? onNavigateToDownloadRequested;
+
   /// 是否支持后台下载（仅 Android）
   bool get isSupported => Platform.isAndroid;
 
@@ -180,6 +183,11 @@ class BackgroundDownloadService {
         onCancelAll?.call();
         break;
     }
+  }
+
+  /// 处理点击通知栏请求导航到下载页
+  void handleNavigateToDownload() {
+    onNavigateToDownloadRequested?.call();
   }
 
   /// 添加任务数据回调（用于接收来自 TaskHandler 的消息）

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -18,24 +18,15 @@ class BackgroundDownloadService {
   bool _isInitialized = false;
   bool _isRunning = false;
 
-  /// 通知栏按钮回调
   void Function()? onPauseAll;
   void Function()? onCancelAll;
-
-  /// 点击通知栏时的导航回调（由 UI 层设置）
   void Function()? onNavigateToDownloadRequested;
 
-  /// 需要通知权限时的回调（由 UI 层设置，用于显示解释对话框）
   /// 返回 true 表示用户同意请求权限，false 表示用户拒绝
   Future<bool> Function()? onNotificationPermissionRequired;
 
-  /// 是否支持后台下载（仅 Android）
   bool get isSupported => Platform.isAndroid;
-
-  /// 服务是否正在运行
   bool get isRunning => _isRunning;
-
-  /// 初始化服务配置
   Future<void> init() async {
     if (!isSupported || _isInitialized) return;
 
@@ -60,28 +51,24 @@ class BackgroundDownloadService {
       ),
     );
 
-    // Initialize communication port for receiving data from task handler
     FlutterForegroundTask.initCommunicationPort();
 
     _isInitialized = true;
     KazumiLogger().i('BackgroundDownloadService: initialized');
   }
 
-  /// 检查是否需要请求通知权限
   Future<bool> needsNotificationPermission() async {
     if (!isSupported) return false;
     final permission = await FlutterForegroundTask.checkNotificationPermission();
     return permission != NotificationPermission.granted;
   }
 
-  /// 请求通知权限（由 UI 层在用户确认后调用）
   Future<bool> requestNotificationPermission() async {
     if (!isSupported) return true;
     final result = await FlutterForegroundTask.requestNotificationPermission();
     return result == NotificationPermission.granted;
   }
 
-  /// 启动后台下载服务
   Future<bool> startService() async {
     if (!isSupported) return false;
     if (_isRunning) return true;
@@ -135,7 +122,6 @@ class BackgroundDownloadService {
     }
   }
 
-  /// 停止后台下载服务
   Future<void> stopService() async {
     if (!isSupported || !_isRunning) return;
 
@@ -148,7 +134,6 @@ class BackgroundDownloadService {
     }
   }
 
-  /// 更新通知栏内容
   Future<void> updateNotification({
     required String title,
     required String text,
@@ -165,7 +150,6 @@ class BackgroundDownloadService {
     }
   }
 
-  /// 更新下载进度通知
   Future<void> updateProgress({
     required int activeCount,
     required int totalCount,
@@ -189,7 +173,6 @@ class BackgroundDownloadService {
     await updateNotification(title: title, text: text);
   }
 
-  /// 显示下载完成通知
   Future<void> showCompletedNotification({
     required int completedCount,
   }) async {
@@ -198,7 +181,6 @@ class BackgroundDownloadService {
     // TODO: 显示普通通知告知用户下载完成（需要额外的通知插件）
   }
 
-  /// 处理通知栏按钮点击
   void handleNotificationAction(String buttonId) {
     switch (buttonId) {
       case 'pause_all':
@@ -210,17 +192,14 @@ class BackgroundDownloadService {
     }
   }
 
-  /// 处理点击通知栏请求导航到下载页
   void handleNavigateToDownload() {
     onNavigateToDownloadRequested?.call();
   }
 
-  /// 添加任务数据回调（用于接收来自 TaskHandler 的消息）
   void addTaskDataCallback(void Function(Object) callback) {
     FlutterForegroundTask.addTaskDataCallback(callback);
   }
 
-  /// 移除任务数据回调
   void removeTaskDataCallback(void Function(Object) callback) {
     FlutterForegroundTask.removeTaskDataCallback(callback);
   }

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -243,8 +243,8 @@ class _DownloadTaskHandler extends TaskHandler {
   }
 
   @override
-  Future<void> onDestroy(DateTime timestamp) async {
-    debugPrint('BackgroundDownloadService: task handler destroyed');
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    debugPrint('BackgroundDownloadService: task handler destroyed (isTimeout: $isTimeout)');
   }
 
   @override

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -224,7 +224,8 @@ class _DownloadTaskHandler extends TaskHandler {
 
   @override
   void onNotificationPressed() {
-    // 点击通知本身，打开 app
+    // 点击通知本身，发送导航消息到主 Isolate，然后打开 app
+    FlutterForegroundTask.sendDataToMain({'action': 'navigate_to_download'});
     FlutterForegroundTask.launchApp();
   }
 

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -1,0 +1,247 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:kazumi/utils/logger.dart';
+
+/// Android 后台下载服务
+///
+/// 使用 Foreground Service 保持 app 进程存活，防止系统在后台时杀死下载进程。
+/// 下载逻辑仍在主 Isolate 运行，此服务仅负责：
+/// 1. 显示通知栏进度
+/// 2. 保持进程存活
+/// 3. 提供通知栏交互（暂停/取消）
+class BackgroundDownloadService {
+  static final BackgroundDownloadService _instance = BackgroundDownloadService._internal();
+  factory BackgroundDownloadService() => _instance;
+  BackgroundDownloadService._internal();
+
+  bool _isInitialized = false;
+  bool _isRunning = false;
+
+  /// 通知栏按钮回调
+  void Function()? onPauseAll;
+  void Function()? onCancelAll;
+
+  /// 是否支持后台下载（仅 Android）
+  bool get isSupported => Platform.isAndroid;
+
+  /// 服务是否正在运行
+  bool get isRunning => _isRunning;
+
+  /// 初始化服务配置
+  Future<void> init() async {
+    if (!isSupported || _isInitialized) return;
+
+    FlutterForegroundTask.init(
+      androidNotificationOptions: AndroidNotificationOptions(
+        channelId: 'kazumi_download_channel',
+        channelName: '下载服务',
+        channelDescription: '视频下载后台服务',
+        channelImportance: NotificationChannelImportance.LOW,
+        priority: NotificationPriority.LOW,
+        onlyAlertOnce: true,
+      ),
+      iosNotificationOptions: const IOSNotificationOptions(
+        showNotification: false,
+      ),
+      foregroundTaskOptions: ForegroundTaskOptions(
+        eventAction: ForegroundTaskEventAction.nothing(),
+        autoRunOnBoot: false,
+        autoRunOnMyPackageReplaced: false,
+        allowWakeLock: true,
+        allowWifiLock: true,
+      ),
+    );
+
+    // Initialize communication port for receiving data from task handler
+    FlutterForegroundTask.initCommunicationPort();
+
+    _isInitialized = true;
+    KazumiLogger().i('BackgroundDownloadService: initialized');
+  }
+
+  /// 启动后台下载服务
+  Future<bool> startService() async {
+    if (!isSupported) return false;
+    if (_isRunning) return true;
+
+    if (!_isInitialized) {
+      await init();
+    }
+
+    // 检查通知权限 (Android 13+)
+    final notificationPermission = await FlutterForegroundTask.checkNotificationPermission();
+    if (notificationPermission != NotificationPermission.granted) {
+      final result = await FlutterForegroundTask.requestNotificationPermission();
+      if (result != NotificationPermission.granted) {
+        KazumiLogger().w('BackgroundDownloadService: notification permission denied');
+        // 权限被拒绝时仍然尝试启动服务，只是通知可能不显示
+      }
+    }
+
+    try {
+      final result = await FlutterForegroundTask.startService(
+        notificationTitle: '正在下载',
+        notificationText: '准备中...',
+        notificationButtons: [
+          const NotificationButton(id: 'pause_all', text: '暂停全部'),
+        ],
+        callback: _backgroundCallback,
+      );
+
+      _isRunning = result is ServiceRequestSuccess;
+
+      if (_isRunning) {
+        KazumiLogger().i('BackgroundDownloadService: service started');
+      } else {
+        KazumiLogger().w('BackgroundDownloadService: service start returned non-success: $result');
+      }
+      return _isRunning;
+    } catch (e) {
+      KazumiLogger().e('BackgroundDownloadService: failed to start service', error: e);
+      return false;
+    }
+  }
+
+  /// 停止后台下载服务
+  Future<void> stopService() async {
+    if (!isSupported || !_isRunning) return;
+
+    try {
+      await FlutterForegroundTask.stopService();
+      _isRunning = false;
+      KazumiLogger().i('BackgroundDownloadService: service stopped');
+    } catch (e) {
+      KazumiLogger().e('BackgroundDownloadService: failed to stop service', error: e);
+    }
+  }
+
+  /// 更新通知栏内容
+  Future<void> updateNotification({
+    required String title,
+    required String text,
+  }) async {
+    if (!isSupported || !_isRunning) return;
+
+    try {
+      await FlutterForegroundTask.updateService(
+        notificationTitle: title,
+        notificationText: text,
+      );
+    } catch (e) {
+      // 忽略更新失败，不影响下载
+    }
+  }
+
+  /// 更新下载进度通知
+  Future<void> updateProgress({
+    required int activeCount,
+    required int totalCount,
+    required double overallProgress,
+    required String speedText,
+  }) async {
+    if (!isSupported || !_isRunning) return;
+
+    String title;
+    String text;
+
+    if (activeCount == 0) {
+      title = '下载已暂停';
+      text = '共 $totalCount 个任务';
+    } else {
+      final percent = (overallProgress * 100).toInt();
+      title = '正在下载 ($activeCount/$totalCount)';
+      text = '$percent% · $speedText';
+    }
+
+    await updateNotification(title: title, text: text);
+  }
+
+  /// 显示下载完成通知
+  Future<void> showCompletedNotification({
+    required int completedCount,
+  }) async {
+    if (!isSupported) return;
+
+    // 停止前台服务
+    await stopService();
+
+    // 可选：显示一个普通通知告知用户下载完成
+    // 这里暂时不实现，因为需要额外的通知插件
+  }
+
+  /// 处理通知栏按钮点击
+  void handleNotificationAction(String buttonId) {
+    switch (buttonId) {
+      case 'pause_all':
+        onPauseAll?.call();
+        break;
+      case 'cancel_all':
+        onCancelAll?.call();
+        break;
+    }
+  }
+
+  /// 添加任务数据回调（用于接收来自 TaskHandler 的消息）
+  void addTaskDataCallback(void Function(Object) callback) {
+    FlutterForegroundTask.addTaskDataCallback(callback);
+  }
+
+  /// 移除任务数据回调
+  void removeTaskDataCallback(void Function(Object) callback) {
+    FlutterForegroundTask.removeTaskDataCallback(callback);
+  }
+}
+
+/// 后台任务回调（在独立 Isolate 中运行）
+///
+/// 注意：此回调主要用于保持服务存活和处理通知交互。
+/// 实际下载逻辑在主 Isolate 中运行。
+@pragma('vm:entry-point')
+void _backgroundCallback() {
+  FlutterForegroundTask.setTaskHandler(_DownloadTaskHandler());
+}
+
+class _DownloadTaskHandler extends TaskHandler {
+  @override
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
+    // 服务启动时的初始化
+    debugPrint('BackgroundDownloadService: task handler started');
+  }
+
+  @override
+  void onRepeatEvent(DateTime timestamp) {
+    // 周期性事件（已配置为 nothing，不会触发）
+  }
+
+  @override
+  void onNotificationButtonPressed(String id) {
+    // 通知栏按钮点击
+    debugPrint('BackgroundDownloadService: notification button pressed: $id');
+    // 发送消息到主 Isolate
+    FlutterForegroundTask.sendDataToMain({'action': 'button_pressed', 'id': id});
+  }
+
+  @override
+  void onNotificationPressed() {
+    // 点击通知本身，打开 app
+    FlutterForegroundTask.launchApp();
+  }
+
+  @override
+  void onNotificationDismissed() {
+    // 通知被划掉（前台服务通知通常不可划掉）
+  }
+
+  @override
+  Future<void> onDestroy(DateTime timestamp) async {
+    // 服务销毁时的清理
+    debugPrint('BackgroundDownloadService: task handler destroyed');
+  }
+
+  @override
+  void onReceiveData(Object data) {
+    // 接收来自主 Isolate 的数据
+    debugPrint('BackgroundDownloadService: received data: $data');
+  }
+}

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -90,10 +90,8 @@ class BackgroundDownloadService {
       await init();
     }
 
-    // 检查通知权限 (Android 13+)
     final needsPermission = await needsNotificationPermission();
     if (needsPermission) {
-      // 如果设置了回调，让 UI 层显示解释对话框
       if (onNotificationPermissionRequired != null) {
         final userAgreed = await onNotificationPermissionRequired!();
         if (userAgreed) {
@@ -196,12 +194,8 @@ class BackgroundDownloadService {
     required int completedCount,
   }) async {
     if (!isSupported) return;
-
-    // 停止前台服务
     await stopService();
-
-    // 可选：显示一个普通通知告知用户下载完成
-    // 这里暂时不实现，因为需要额外的通知插件
+    // TODO: 显示普通通知告知用户下载完成（需要额外的通知插件）
   }
 
   /// 处理通知栏按钮点击
@@ -244,44 +238,38 @@ void _backgroundCallback() {
 class _DownloadTaskHandler extends TaskHandler {
   @override
   Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
-    // 服务启动时的初始化
     debugPrint('BackgroundDownloadService: task handler started');
   }
 
   @override
   void onRepeatEvent(DateTime timestamp) {
-    // 周期性事件（已配置为 nothing，不会触发）
+    // eventAction 配置为 nothing，不会触发
   }
 
   @override
   void onNotificationButtonPressed(String id) {
-    // 通知栏按钮点击
     debugPrint('BackgroundDownloadService: notification button pressed: $id');
-    // 发送消息到主 Isolate
     FlutterForegroundTask.sendDataToMain({'action': 'button_pressed', 'id': id});
   }
 
   @override
   void onNotificationPressed() {
-    // 点击通知本身，发送导航消息到主 Isolate，然后打开 app
     FlutterForegroundTask.sendDataToMain({'action': 'navigate_to_download'});
     FlutterForegroundTask.launchApp();
   }
 
   @override
   void onNotificationDismissed() {
-    // 通知被划掉（前台服务通知通常不可划掉）
+    // 前台服务通知通常不可划掉
   }
 
   @override
   Future<void> onDestroy(DateTime timestamp) async {
-    // 服务销毁时的清理
     debugPrint('BackgroundDownloadService: task handler destroyed');
   }
 
   @override
   void onReceiveData(Object data) {
-    // 接收来自主 Isolate 的数据
     debugPrint('BackgroundDownloadService: received data: $data');
   }
 }

--- a/lib/utils/download_manager.dart
+++ b/lib/utils/download_manager.dart
@@ -139,50 +139,21 @@ class DownloadManager implements IDownloadManager {
     );
   }
 
-  /// Check available storage space on the device
+  /// Check available storage space on the device via platform MethodChannel
   /// Returns available bytes, or -1 if unable to determine
   Future<int> _getAvailableStorage(String path) async {
     try {
-      if (Platform.isAndroid || Platform.isIOS) {
-        final result = await _storageChannel.invokeMethod<int>(
-          'getAvailableStorage',
-          {'path': path},
-        );
-        return result ?? -1;
-      } else if (Platform.isMacOS || Platform.isLinux) {
-        return _getAvailableStorageUnix(path);
-      } else if (Platform.isWindows) {
-        return _getAvailableStorageWindows(path);
-      }
+      final result = await _storageChannel.invokeMethod<int>(
+        'getAvailableStorage',
+        {'path': path},
+      );
+      return result ?? -1;
     } on MissingPluginException {
       return -1;
     } catch (e) {
       KazumiLogger().w('DownloadManager: failed to get storage info', error: e);
+      return -1;
     }
-    return -1;
-  }
-
-  Future<int> _getAvailableStorageUnix(String path) async {
-    final result = await Process.run('df', ['-k', path]);
-    if (result.exitCode != 0) return -1;
-    final lines = (result.stdout as String).split('\n');
-    if (lines.length < 2) return -1;
-    final parts = lines[1].split(RegExp(r'\s+'));
-    // df -k output: Filesystem 1K-blocks Used Available ...
-    if (parts.length < 4) return -1;
-    final availableKB = int.tryParse(parts[3]);
-    return availableKB != null ? availableKB * 1024 : -1;
-  }
-
-  Future<int> _getAvailableStorageWindows(String path) async {
-    final driveLetter = path.substring(0, 1).toUpperCase();
-    final result = await Process.run('wmic', [
-      'logicaldisk', 'where', "DeviceID='$driveLetter:'",
-      'get', 'FreeSpace', '/value',
-    ]);
-    if (result.exitCode != 0) return -1;
-    final match = RegExp(r'FreeSpace=(\d+)').firstMatch(result.stdout as String);
-    return match != null ? (int.tryParse(match.group(1)!) ?? -1) : -1;
   }
 
   /// Check if there's enough storage space before downloading

--- a/lib/utils/format_utils.dart
+++ b/lib/utils/format_utils.dart
@@ -1,0 +1,16 @@
+String formatBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / 1024 / 1024 / 1024).toStringAsFixed(1)} GB';
+}
+
+String formatSpeed(double bytesPerSec) {
+  if (bytesPerSec < 1024) return '${bytesPerSec.toStringAsFixed(0)} B/s';
+  if (bytesPerSec < 1024 * 1024) {
+    return '${(bytesPerSec / 1024).toStringAsFixed(1)} KB/s';
+  }
+  return '${(bytesPerSec / 1024 / 1024).toStringAsFixed(1)} MB/s';
+}

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -39,6 +39,27 @@ class AppDelegate: FlutterAppDelegate {
                 result(FlutterMethodNotImplemented)
             }
         });
+
+        let storageChannel = FlutterMethodChannel.init(name: "com.predidit.kazumi/storage", binaryMessenger: controller.engine.binaryMessenger)
+        storageChannel.setMethodCallHandler({
+            (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+            if call.method == "getAvailableStorage" {
+                do {
+                    let attrs = try FileManager.default.attributesOfFileSystem(
+                        forPath: NSHomeDirectory()
+                    )
+                    if let freeSize = attrs[.systemFreeSize] as? Int64 {
+                        result(freeSize)
+                    } else {
+                        result(-1)
+                    }
+                } catch {
+                    result(-1)
+                }
+            } else {
+                result(FlutterMethodNotImplemented)
+            }
+        });
         self.menuChannel?.setMethodCallHandler({call,result in
             switch call.method {
             case "setMenuEnabled":

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -407,6 +407,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  flutter_foreground_task:
+    dependency: "direct main"
+    description:
+      name: flutter_foreground_task
+      sha256: "206017ee1bf864f34b8d7bce664a172717caa21af8da23f55866470dfe316644"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.17.0"
   flutter_inappwebview_android:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -411,10 +411,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_foreground_task
-      sha256: "206017ee1bf864f34b8d7bce664a172717caa21af8da23f55866470dfe316644"
+      sha256: "48ea45056155a99fb30b15f14f4039a044d925bc85f381ed0b2d3b00a60b99de"
       url: "https://pub.dev"
     source: hosted
-    version: "8.17.0"
+    version: "9.2.0"
   flutter_inappwebview_android:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
   flutter_svg: ^2.2.3
   antlr4: ^4.13.2
   fl_chart: ^1.1.1
-  flutter_foreground_task: ^8.11.0
+  flutter_foreground_task: ^9.0.0
   skeletonizer: ^2.1.2
   flutter_inappwebview_platform_interface: ^1.3.0+1
   flutter_inappwebview_ios: ^1.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   flutter_svg: ^2.2.3
   antlr4: ^4.13.2
   fl_chart: ^1.1.1
+  flutter_foreground_task: ^8.11.0
   skeletonizer: ^2.1.2
   flutter_inappwebview_platform_interface: ^1.3.0+1
   flutter_inappwebview_ios: ^1.1.2

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -31,6 +31,9 @@ class FlutterWindow : public Win32Window {
 
   // Register Intent MethodChannel
   void RegisterIntentChannel();
+
+  // Register Storage MethodChannel
+  void RegisterStorageChannel();
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_


### PR DESCRIPTION
为 Android 平台实现后台下载功能，使用 Foreground Service 保持应用进程在后台下载时不被系统杀死。
  - 后台下载服务：使用 flutter_foreground_task 实现 Android 前台服务
  - 通知栏进度显示：实时显示下载进度、速度和任务数量
  - 通知栏交互：支持"暂停全部"按钮，点击通知跳转到下载管理页
  - 修复 ANR 问题：对下载进度 UI 更新添加 500ms 节流，防止高频回调导致应用无响应

我在本地使用Pixel 4 + Android 10测试完毕