### PR TITLE
Fix/custom proxy test url

### DIFF
--- a/lib/request/bangumi.dart
+++ b/lib/request/bangumi.dart
@@ -1,9 +1,4 @@
-import 'package:dio/dio.dart';
-import 'package:hive_ce/hive.dart';
 import 'package:kazumi/utils/logger.dart';
-import 'package:kazumi/utils/storage.dart';
-import 'package:kazumi/utils/proxy_manager.dart';
-import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/request/api.dart';
 import 'package:kazumi/request/request.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
@@ -14,43 +9,13 @@ import 'package:kazumi/modules/character/character_full_item.dart';
 import 'package:kazumi/modules/staff/staff_response.dart';
 
 class BangumiHTTP {
-  static final Box _setting = GStorage.setting;
-
-  static bool _isConnectionError(DioException e) {
-    return e.type == DioExceptionType.connectionTimeout ||
-        e.type == DioExceptionType.sendTimeout ||
-        e.type == DioExceptionType.receiveTimeout ||
-        e.type == DioExceptionType.connectionError;
-  }
-
-  static Future<Response> _requestWithProxyRetry(
-    Future<Response> Function() request,
-  ) async {
-    try {
-      return await request();
-    } on DioException catch (e) {
-      final proxyEnabled =
-          _setting.get(SettingBoxKey.proxyEnable, defaultValue: false);
-      if (proxyEnabled && _isConnectionError(e)) {
-        await _setting.put(SettingBoxKey.proxyEnable, false);
-        ProxyManager.clearProxy();
-        KazumiLogger().w('Proxy: 代理连接失败，已自动禁用');
-        KazumiDialog.showToast(message: '代理连接失败，已自动禁用');
-        return await request();
-      }
-      rethrow;
-    }
-  }
   // why the api havn't been replaced by getCalendarBySearch?
   // Because getCalendarBySearch is not stable, it will miss some bangumi items.
   static Future<List<List<BangumiItem>>> getCalendar() async {
     List<List<BangumiItem>> bangumiCalendar = [];
     try {
-      var res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.bangumiAPINextDomain + Api.bangumiCalendar,
-          shouldRethrow: true,
-        ),
+      var res = await Request().get(
+        Api.bangumiAPINextDomain + Api.bangumiCalendar,
       );
       final jsonData = res.data;
       for (int i = 1; i <= 7; i++) {
@@ -92,12 +57,9 @@ class BangumiHTTP {
     try {
       final url = Api.formatUrl(
           Api.bangumiAPIDomain + Api.bangumiRankSearch, [limit, offset]);
-      final res = await _requestWithProxyRetry(
-        () => Request().post(
-          url,
-          data: params,
-          shouldRethrow: true,
-        ),
+      final res = await Request().post(
+        url,
+        data: params,
       );
       final jsonData = res.data;
       final jsonList = jsonData['data'];
@@ -154,12 +116,9 @@ class BangumiHTTP {
       };
     }
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().post(
-          Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiRankSearch, [100, 0]),
-          data: params,
-          shouldRethrow: true,
-        ),
+      final res = await Request().post(
+        Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiRankSearch, [100, 0]),
+        data: params,
       );
       final jsonData = res.data;
       final jsonList = jsonData['data'];
@@ -184,12 +143,9 @@ class BangumiHTTP {
       'offset': offset,
     };
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.bangumiAPINextDomain + Api.bangumiTrendsNext,
-          data: params,
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.bangumiAPINextDomain + Api.bangumiTrendsNext,
+        data: params,
       );
       final jsonData = res.data;
       final jsonList = jsonData['data'];
@@ -222,13 +178,10 @@ class BangumiHTTP {
     };
 
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().post(
-          Api.formatUrl(
-              Api.bangumiAPIDomain + Api.bangumiRankSearch, [20, offset]),
-          data: params,
-          shouldRethrow: true,
-        ),
+      final res = await Request().post(
+        Api.formatUrl(
+            Api.bangumiAPIDomain + Api.bangumiRankSearch, [20, offset]),
+        data: params,
       );
       final jsonData = res.data;
       final jsonList = jsonData['data'];
@@ -252,11 +205,8 @@ class BangumiHTTP {
 
   static Future<BangumiItem?> getBangumiInfoByID(int id) async {
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiInfoByID, [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiInfoByID, [id]),
       );
       return BangumiItem.fromJson(res.data);
     } catch (e) {
@@ -273,12 +223,9 @@ class BangumiHTTP {
       'limit': 1
     };
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.bangumiAPIDomain + Api.bangumiEpisodeByID,
-          data: params,
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.bangumiAPIDomain + Api.bangumiEpisodeByID,
+        data: params,
       );
       final jsonData = res.data['data'][0];
       episodeInfo = EpisodeInfo.fromJson(jsonData);
@@ -292,12 +239,9 @@ class BangumiHTTP {
       {int offset = 0}) async {
     CommentResponse commentResponse = CommentResponse.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(Api.bangumiAPINextDomain + Api.bangumiCommentsByIDNext,
-              [id, 20, offset]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(Api.bangumiAPINextDomain + Api.bangumiCommentsByIDNext,
+            [id, 20, offset]),
       );
       final jsonData = res.data;
       commentResponse = CommentResponse.fromJson(jsonData);
@@ -312,13 +256,10 @@ class BangumiHTTP {
     EpisodeCommentResponse commentResponse =
         EpisodeCommentResponse.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(
-              Api.bangumiAPINextDomain + Api.bangumiEpisodeCommentsByIDNext,
-              [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(
+            Api.bangumiAPINextDomain + Api.bangumiEpisodeCommentsByIDNext,
+            [id]),
       );
       final jsonData = res.data;
       commentResponse = EpisodeCommentResponse.fromJson(jsonData);
@@ -333,13 +274,10 @@ class BangumiHTTP {
     CharacterCommentResponse commentResponse =
         CharacterCommentResponse.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(
-              Api.bangumiAPINextDomain + Api.bangumiCharacterCommentsByIDNext,
-              [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(
+            Api.bangumiAPINextDomain + Api.bangumiCharacterCommentsByIDNext,
+            [id]),
       );
       final jsonData = res.data;
       commentResponse = CharacterCommentResponse.fromJson(jsonData);
@@ -352,12 +290,9 @@ class BangumiHTTP {
   static Future<StaffResponse> getBangumiStaffByID(int id) async {
     StaffResponse staffResponse = StaffResponse.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(
-              Api.bangumiAPINextDomain + Api.bangumiStaffByIDNext, [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(
+            Api.bangumiAPINextDomain + Api.bangumiStaffByIDNext, [id]),
       );
       final jsonData = res.data;
       staffResponse = StaffResponse.fromJson(jsonData);
@@ -370,11 +305,8 @@ class BangumiHTTP {
   static Future<CharactersResponse> getCharatersByBangumiID(int id) async {
     CharactersResponse charactersResponse = CharactersResponse.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiCharacterByID, [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(Api.bangumiAPIDomain + Api.bangumiCharacterByID, [id]),
       );
       final jsonData = res.data;
       charactersResponse = CharactersResponse.fromJson(jsonData);
@@ -387,14 +319,11 @@ class BangumiHTTP {
   static Future<CharacterFullItem> getCharacterByCharacterID(int id) async {
     CharacterFullItem characterFullItem = CharacterFullItem.fromTemplate();
     try {
-      final res = await _requestWithProxyRetry(
-        () => Request().get(
-          Api.formatUrl(
-              Api.bangumiAPINextDomain +
-                  Api.bangumiCharacterInfoByCharacterIDNext,
-              [id]),
-          shouldRethrow: true,
-        ),
+      final res = await Request().get(
+        Api.formatUrl(
+            Api.bangumiAPINextDomain +
+                Api.bangumiCharacterInfoByCharacterIDNext,
+            [id]),
       );
       final jsonData = res.data;
       characterFullItem = CharacterFullItem.fromJson(jsonData);

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -331,6 +331,7 @@ class SettingBoxKey {
       proxyEnable = 'proxyEnable',
       proxyConfigured = 'proxyConfigured',
       proxyUrl = 'proxyUrl',
+      proxyTestUrl = 'proxyTestUrl',
       showRating = 'showRating',
       downloadParallelEpisodes = 'downloadParallelEpisodes',
       downloadParallelSegments = 'downloadParallelSegments',


### PR DESCRIPTION
这个改动修复了一处此前并没有测试到的问题。

当用户已经配置代理，同时代理失效以后，无法正确回退的问题。

同时，考虑到可能某些用户的代理也存在无法访问gogle的情况，这个改动允许用户自定义测试通信的url，默认值仍然是google，但是