### PR TITLE
fix: use HeadlessWebview.dispose() instead of disposeEnvironment()

### DIFF
--- a/lib/webview/webview_controller_impel/webview_windows_controller_impel.dart
+++ b/lib/webview/webview_controller_impel/webview_windows_controller_impel.dart
@@ -102,11 +102,8 @@ class WebviewWindowsItemControllerImpel
       } catch (_) {}
     });
     subscriptions.clear();
-    // disposeEnvironment() 内部已通过 headless_instances_.clear() 销毁所有 headless 实例，
-    // 不要额外调用 headlessWebview.dispose()，否则两个异步方法通道调用可能产生竞争，
-    // 导致 disposeEnvironment 先到达原生侧清除实例后，disposeHeadless 找不到条目抛出异常。
+    headlessWebview?.dispose();
     headlessWebview = null;
-    WebviewController.disposeEnvironment();
   }
 
   // The webview_windows package does not have a method to unload the current page.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1615,8 +1615,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "9962cb9416f867d9ce9f409ccd6784e78c5f72ca"
-      resolved-ref: "9962cb9416f867d9ce9f409ccd6784e78c5f72ca"
+      ref: b23719a4bbf3517eda7e7e42ec932b39ce5ce1e3
+      resolved-ref: b23719a4bbf3517eda7e7e42ec932b39ce5ce1e3
       url: "https://github.com/Predidit/flutter-webview-windows.git"
     source: git
     version: "0.4.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,7 +92,7 @@ dependencies:
   webview_windows:
     git:
       url: https://github.com/Predidit/flutter-webview-windows.git
-      ref: 9962cb9416f867d9ce9f409ccd6784e78c5f72ca
+      ref: b23719a4bbf3517eda7e7e42ec932b39ce5ce1e3
   desktop_webview_window:
     git:
       url: https://github.com/Predidit/linux_webview_window.git


### PR DESCRIPTION
  修改 webview_windows_controller_impel.dart：
  - dispose() 从直接调用 WebviewController.disposeEnvironment() 改为调用 headlessWebview?.dispose()
  - 环境生命周期交由 webview_windows 包内部的引用计数管理

  ---
  解决的问题：
  - 并发场景（边播放边下载）一个实例 dispose 不再摧毁另一个实例的环境，消除 MissingPluginException
  - 所有实例释放后环境正确重置，代理热切换能力保留
  - 重复调用 initializeEnvironment() 不再产生误导性错误日志