### PR TITLE
调整了对旧版本Android的降级处理

### DIFF
--- a/lib/webview/webview_controller_impel/webview_controller_impel.dart
+++ b/lib/webview/webview_controller_impel/webview_controller_impel.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 import 'package:kazumi/utils/utils.dart';
 import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/utils/proxy_utils.dart';
@@ -20,17 +21,12 @@ class WebviewItemControllerImpel
     await _setupProxy();
     headlessWebView ??= PlatformHeadlessInAppWebView(
       PlatformHeadlessInAppWebViewCreationParams(
+        initialSize: const Size(360, 640),
         initialSettings: InAppWebViewSettings(
           userAgent: Utils.getRandomUA(),
           mediaPlaybackRequiresUserGesture: true,
-          cacheEnabled: false,
-          blockNetworkImage: true,
-          loadsImagesAutomatically: false,
           upgradeKnownHostsToHTTPS: false,
-          safeBrowsingEnabled: false,
           mixedContentMode: MixedContentMode.MIXED_CONTENT_COMPATIBILITY_MODE,
-          geolocationEnabled: false,
-          useShouldInterceptRequest: true,
         ),
         onWebViewCreated: (controller) {
           print('[WebView] Created (legacy fallback)');
@@ -62,6 +58,14 @@ class WebviewItemControllerImpel
           if (url.toString() != 'about:blank') {
             await _onLoadStop();
           }
+        },
+        onConsoleMessage: (controller, consoleMessage) {
+          logEventController.add(
+              'Console [${consoleMessage.messageLevel}]: ${consoleMessage.message}');
+        },
+        onReceivedError: (controller, request, error) {
+          logEventController.add(
+              'Error: ${error.description} - ${request.url}');
         },
       ),
     );


### PR DESCRIPTION
fix #1726

在本地测试中，我使用此前提到的修改 WebviewItemControllerFactory ，使其为所有 android 设备返WebviewItemControllerImpel方案进行测试有效，目前可以正常播放流。

这个实现是迫降处理，可能会增加页面加载延迟。老 Android 不支持 AT_DOCUMENT_START，无法在页面 JS 执行前注入 hookshouldInterceptRequest是唯一能在原生层可靠拦截视频请求的机制，平台通道开销是为此付出的代价。