### PR TITLE
chore: sync pubspec with ohos

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -780,7 +780,7 @@ packages:
     source: git
     version: "1.1.4"
   media_kit_libs_ohos:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "libs/ohos/media_kit_libs_ohos"
       ref: "7d1e3f8116abce740bdf83dc5e85f37e89436db5"
@@ -1116,6 +1116,14 @@ packages:
     description:
       name: screen_brightness_ios
       sha256: "2493953340ecfe8f4f13f61db50ce72533a55b0bbd58ba1402893feecf3727f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  screen_brightness_ohos:
+    dependency: "direct main"
+    description:
+      name: screen_brightness_ohos
+      sha256: a93a263dcd39b5c56e589eb495bcd001ce65cdd96ff12ab1350683559d5c5bb7
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   saver_gallery: ^4.1.0
   screen_brightness_android: ^2.1.3
   screen_brightness_ios: ^2.1.2
+  screen_brightness_ohos: ^2.1.2
   screen_brightness_platform_interface: ^2.1.0
   synchronized: any
   flutter_svg: ^2.2.3
@@ -139,6 +140,11 @@ dependency_overrides:
       url: https://github.com/Predidit/media-kit.git
       ref: 7d1e3f8116abce740bdf83dc5e85f37e89436db5
       path: ./libs/macos/media_kit_libs_macos_video
+  media_kit_libs_ohos:
+    git:
+      url: https://github.com/Predidit/media-kit.git
+      ref: 7d1e3f8116abce740bdf83dc5e85f37e89436db5
+      path: ./libs/ohos/media_kit_libs_ohos
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
flutter_inappwebview_ohos 因为没有 pub.dev 管理的包所以无法做到与 ohos 仓库完全同步

好像 dependency overrides 是不需要的，我全部删除后 pubspec.lock 只是从 direct overridden 变成了 transitive。