### PR TITLE
fix(android): 防止在安卓夜间模式下使用键鼠交互后最外层出现绿色边框

### DIFF
--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -6,6 +6,9 @@
              the Flutter engine draws its first frame -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -16,5 +19,8 @@
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">shortEdges</item>
+
+        <item name="android:defaultFocusHighlightEnabled">false</item>
+
     </style>
 </resources>


### PR DESCRIPTION
之前漏掉夜间模式的xml文件了，这次补上