### PR TITLE
Refactor: switch to native download notification

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         android:extractNativeLibs="true">
         <meta-data
              android:name="io.flutter.embedding.android.EnableImpeller"
-             android:value="false" 
+             android:value="false"
         />
         <activity
             android:name=".MainActivity"
@@ -35,11 +35,13 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <!-- flutter_foreground_task service -->
         <service
-            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
-            android:foregroundServiceType="dataSync"
-            android:exported="false" />
+                android:name=".DownloadForegroundService"
+                android:foregroundServiceType="dataSync"
+                android:exported="false" />
+        <receiver
+                android:name=".DownloadNotificationActionReceiver"
+                android:exported="false" />
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/android/app/src/main/kotlin/com/example/kazumi/DownloadForegroundService.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/DownloadForegroundService.kt
@@ -1,0 +1,144 @@
+package com.example.kazumi
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+
+class DownloadForegroundService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "kazumi_download_channel"
+        const val CHANNEL_NAME = "下载服务"
+        const val NOTIFICATION_ID = 10086
+
+        const val ACTION_START = "kazumi.action.DOWNLOAD_START"
+        const val ACTION_UPDATE = "kazumi.action.DOWNLOAD_UPDATE"
+        const val ACTION_STOP = "kazumi.action.DOWNLOAD_STOP"
+
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_TEXT = "text"
+        const val EXTRA_PROGRESS = "progress"
+        const val EXTRA_INDETERMINATE = "indeterminate"
+
+        fun start(context: Context, title: String, text: String) {
+            val i = Intent(context, DownloadForegroundService::class.java).apply {
+                action = ACTION_START
+                putExtra(EXTRA_TITLE, title)
+                putExtra(EXTRA_TEXT, text)
+                putExtra(EXTRA_PROGRESS, 0)
+                putExtra(EXTRA_INDETERMINATE, true)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) context.startForegroundService(i)
+            else context.startService(i)
+        }
+
+        fun update(context: Context, title: String, text: String, progress: Int, indeterminate: Boolean = false) {
+            val i = Intent(context, DownloadForegroundService::class.java).apply {
+                action = ACTION_UPDATE
+                putExtra(EXTRA_TITLE, title)
+                putExtra(EXTRA_TEXT, text)
+                putExtra(EXTRA_PROGRESS, progress.coerceIn(0, 100))
+                putExtra(EXTRA_INDETERMINATE, indeterminate)
+            }
+            context.startService(i)
+        }
+
+        fun stop(context: Context) {
+            val i = Intent(context, DownloadForegroundService::class.java).apply { action = ACTION_STOP }
+            context.startService(i)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureChannel()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                val title = intent.getStringExtra(EXTRA_TITLE) ?: "正在下载"
+                val text = intent.getStringExtra(EXTRA_TEXT) ?: "准备中..."
+                val progress = intent.getIntExtra(EXTRA_PROGRESS, 0)
+                val indeterminate = intent.getBooleanExtra(EXTRA_INDETERMINATE, true)
+                startForeground(NOTIFICATION_ID, buildNotification(title, text, progress, indeterminate))
+            }
+
+            ACTION_UPDATE -> {
+                val title = intent.getStringExtra(EXTRA_TITLE) ?: "正在下载"
+                val text = intent.getStringExtra(EXTRA_TEXT) ?: ""
+                val progress = intent.getIntExtra(EXTRA_PROGRESS, 0)
+                val indeterminate = intent.getBooleanExtra(EXTRA_INDETERMINATE, false)
+                val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+                nm.notify(NOTIFICATION_ID, buildNotification(title, text, progress, indeterminate))
+            }
+
+            ACTION_STOP -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) stopForeground(STOP_FOREGROUND_REMOVE)
+                else {
+                    @Suppress("DEPRECATION")
+                    stopForeground(true)
+                }
+                stopSelf()
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun buildNotification(title: String, text: String, progress: Int, indeterminate: Boolean): Notification {
+        val openIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            action = MainActivity.ACTION_OPEN_DOWNLOAD_MANAGER
+        }
+
+        val pendingFlags =
+            PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+
+        val openPendingIntent = PendingIntent.getActivity(this, 0, openIntent, pendingFlags)
+
+        val pauseIntent = Intent(this, DownloadNotificationActionReceiver::class.java).apply {
+            action = DownloadNotificationActionReceiver.ACTION_PAUSE_ALL
+        }
+        val pausePending = PendingIntent.getBroadcast(this, 1, pauseIntent, pendingFlags)
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setContentIntent(openPendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setProgress(100, progress.coerceIn(0, 100), indeterminate)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .addAction(0, "暂停全部", pausePending)
+
+        // Android 12+：更及时显示
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            builder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+        }
+
+        return builder.build()
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            val ch = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW).apply {
+                description = "视频下载后台服务"
+                setSound(null, null)
+                enableVibration(false)
+            }
+            nm.createNotificationChannel(ch)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/example/kazumi/DownloadNotificationActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/DownloadNotificationActionReceiver.kt
@@ -1,0 +1,22 @@
+package com.example.kazumi
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class DownloadNotificationActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+
+        // 先落地，避免 Flutter 不在时丢事件
+        val sp = context.getSharedPreferences("kazumi_download", Context.MODE_PRIVATE)
+        sp.edit().putString("pending_action", action).apply()
+
+        MainActivity.dispatchDownloadActionToFlutter(action)
+    }
+
+    companion object {
+        const val ACTION_PAUSE_ALL = "kazumi.action.PAUSE_ALL"
+    }
+}

--- a/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
@@ -1,66 +1,178 @@
 package com.example.kazumi
 
+import android.Manifest
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.StatFs
-import android.net.Uri
-import android.os.Bundle
 import androidx.annotation.NonNull
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.predidit.kazumi/intent"
     private val STORAGE_CHANNEL = "com.predidit.kazumi/storage"
 
+    private val DOWNLOAD_FG_CHANNEL = "kazumi/download_fg"
+    private val NOTIF_PERMISSION_CHANNEL = "kazumi/notification_permission"
+    private val DOWNLOAD_ACTIONS_CHANNEL = "kazumi/download_actions"
+
+    private val REQ_POST_NOTIFICATIONS = 10001
+    private var pendingPermissionResult: MethodChannel.Result? = null
+
+    companion object {
+        const val ACTION_OPEN_DOWNLOAD_MANAGER = "kazumi.action.OPEN_DOWNLOAD_MANAGER"
+        private var downloadActionsChannel: MethodChannel? = null
+
+        fun dispatchDownloadActionToFlutter(action: String) {
+            val id = when (action) {
+                DownloadNotificationActionReceiver.ACTION_PAUSE_ALL -> "pause_all"
+                else -> action
+            }
+            downloadActionsChannel?.invokeMethod("onAction", mapOf("id" to id))
+        }
+    }
+
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
-            if (call.method == "openWithMime") {
-                val url = call.argument<String>("url")
-                val mimeType = call.argument<String>("mimeType")
-                if (url != null && mimeType != null) {
-                    openWithMime(url, mimeType)
-                    result.success(null)
-                } else {
-                    result.error("INVALID_ARGUMENT", "URL and MIME type required", null)
+            when (call.method) {
+                "openWithMime" -> {
+                    val url = call.argument<String>("url")
+                    val mimeType = call.argument<String>("mimeType")
+                    if (url != null && mimeType != null) {
+                        openWithMime(url, mimeType)
+                        result.success(null)
+                    } else {
+                        result.error("INVALID_ARGUMENT", "URL and MIME type required", null)
+                    }
                 }
-            } else if (call.method == "checkIfInMultiWindowMode") {
-                val isInMultiWindow = checkIfInMultiWindowMode()
-                result.success(isInMultiWindow)
-            } else if (call.method == "getAndroidSdkVersion") {
-                val sdkVersion = getAndroidSdkVersion()
-                result.success(sdkVersion)
-            } else {
-                result.notImplemented()
+                "checkIfInMultiWindowMode" -> result.success(checkIfInMultiWindowMode())
+                "getAndroidSdkVersion" -> result.success(getAndroidSdkVersion())
+                else -> result.notImplemented()
             }
         }
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, STORAGE_CHANNEL).setMethodCallHandler { call, result ->
-            if (call.method == "getAvailableStorage") {
-                val path = call.argument<String>("path") ?: filesDir.absolutePath
-                val availableBytes = getAvailableStorage(path)
-                result.success(availableBytes)
-            } else {
-                result.notImplemented()
+            when (call.method) {
+                "getAvailableStorage" -> {
+                    val path = call.argument<String>("path") ?: filesDir.absolutePath
+                    result.success(getAvailableStorage(path))
+                }
+                else -> result.notImplemented()
             }
+        }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, DOWNLOAD_FG_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "start" -> {
+                    val title = call.argument<String>("title") ?: "正在下载"
+                    val text = call.argument<String>("text") ?: "准备中..."
+                    DownloadForegroundService.start(this, title, text)
+                    result.success(true)
+                }
+                "update" -> {
+                    val title = call.argument<String>("title") ?: "正在下载"
+                    val text = call.argument<String>("text") ?: ""
+                    val progress = call.argument<Int>("progress") ?: 0
+                    val indeterminate = call.argument<Boolean>("indeterminate") ?: false
+                    DownloadForegroundService.update(this, title, text, progress, indeterminate)
+                    result.success(true)
+                }
+                "stop" -> {
+                    DownloadForegroundService.stop(this)
+                    result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // 通知权限
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, NOTIF_PERMISSION_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "check" -> result.success(isNotificationPermissionGranted())
+                "request" -> {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        result.success(true)
+                        return@setMethodCallHandler
+                    }
+                    if (isNotificationPermissionGranted()) {
+                        result.success(true)
+                        return@setMethodCallHandler
+                    }
+                    if (pendingPermissionResult != null) {
+                        result.error("IN_PROGRESS", "Permission request already in progress", null)
+                        return@setMethodCallHandler
+                    }
+                    pendingPermissionResult = result
+                    ActivityCompat.requestPermissions(
+                        this,
+                        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                        REQ_POST_NOTIFICATIONS
+                    )
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        downloadActionsChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, DOWNLOAD_ACTIONS_CHANNEL)
+        handleIntentForDownloadManager(intent)
+        flushPendingDownloadAction()
+    }
+
+    private fun flushPendingDownloadAction() {
+        val sp = getSharedPreferences("kazumi_download", Context.MODE_PRIVATE)
+        val pending = sp.getString("pending_action", null) ?: return
+        sp.edit().remove("pending_action").apply()
+        dispatchDownloadActionToFlutter(pending)
+    }
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntentForDownloadManager(intent)
+    }
+
+    private fun handleIntentForDownloadManager(intent: Intent?) {
+        if (intent?.action == ACTION_OPEN_DOWNLOAD_MANAGER) {
+            dispatchDownloadActionToFlutter(ACTION_OPEN_DOWNLOAD_MANAGER)
+            // 防止同一 intent 在某些机型/系统行为下重复触发
+            intent.action = null
         }
     }
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQ_POST_NOTIFICATIONS) {
+            val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+            pendingPermissionResult?.success(granted)
+            pendingPermissionResult = null
+        }
+    }
+
+    private fun isNotificationPermissionGranted(): Boolean {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) true
+        else ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+    }
+
     private fun openWithMime(url: String, mimeType: String) {
-        val intent = Intent()
-        intent.action = Intent.ACTION_VIEW
-        intent.setDataAndType(Uri.parse(url), mimeType)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(Uri.parse(url), mimeType)
+        }
         startActivity(intent)
     }
 
     private fun checkIfInMultiWindowMode(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            this.isInMultiWindowMode 
-        } else {
-            false 
-        }
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && this.isInMultiWindowMode
     }
 
     private fun getAndroidSdkVersion(): Int {

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -63,19 +63,7 @@ abstract class _DownloadController with Store {
 
     await _backgroundService.init();
     _backgroundService.onPauseAll = pauseAllDownloads;
-    _backgroundService.addTaskDataCallback(_onTaskData);
     _isBackgroundServiceInitialized = true;
-  }
-
-  void _onTaskData(Object data) {
-    if (data is Map) {
-      final action = data['action'];
-      if (action == 'button_pressed') {
-        _backgroundService.handleNotificationAction(data['id'] as String);
-      } else if (action == 'navigate_to_download') {
-        _backgroundService.handleNavigateToDownload();
-      }
-    }
   }
 
   final Map<String, double> _speeds = {};

--- a/lib/utils/background_download_service.dart
+++ b/lib/utils/background_download_service.dart
@@ -1,72 +1,77 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter/services.dart';
 import 'package:kazumi/utils/logger.dart';
 
-/// Android 后台下载服务
+/// Android 后台下载服务（原生前台服务 + 原生通知进度条 + 通知按钮回传）
 ///
-/// 使用 Foreground Service 保持 app 进程存活，防止系统在后台时杀死下载进程。
-/// 下载逻辑仍在主 Isolate 运行，此服务仅负责：
-/// 1. 显示通知栏进度
-/// 2. 保持进程存活
-/// 3. 提供通知栏交互（暂停/取消）
+/// 说明：
+/// - 下载逻辑仍在 Flutter 主 Isolate 运行
+/// - Android 侧通过 ForegroundService + NotificationCompat.setProgress 显示进度条通知
+/// - Flutter 通过 MethodChannel 控制：start/update/stop
+/// - 通知按钮（暂停全部）通过 BroadcastReceiver -> MainActivity -> MethodChannel 回传 Flutter
 class BackgroundDownloadService {
-  static final BackgroundDownloadService _instance = BackgroundDownloadService._internal();
+  static final BackgroundDownloadService _instance =
+  BackgroundDownloadService._internal();
   factory BackgroundDownloadService() => _instance;
   BackgroundDownloadService._internal();
+
+  static const MethodChannel _downloadChannel =
+  MethodChannel('kazumi/download_fg');
+
+  static const MethodChannel _permissionChannel =
+  MethodChannel('kazumi/notification_permission');
+
+  static const MethodChannel _actionsChannel =
+  MethodChannel('kazumi/download_actions');
 
   bool _isInitialized = false;
   bool _isRunning = false;
 
   void Function()? onPauseAll;
-  void Function()? onCancelAll;
   void Function()? onNavigateToDownloadRequested;
 
-  /// 返回 true 表示用户同意请求权限，false 表示用户拒绝
   Future<bool> Function()? onNotificationPermissionRequired;
 
   bool get isSupported => Platform.isAndroid;
   bool get isRunning => _isRunning;
+
   Future<void> init() async {
     if (!isSupported || _isInitialized) return;
 
-    FlutterForegroundTask.init(
-      androidNotificationOptions: AndroidNotificationOptions(
-        channelId: 'kazumi_download_channel',
-        channelName: '下载服务',
-        channelDescription: '视频下载后台服务',
-        channelImportance: NotificationChannelImportance.LOW,
-        priority: NotificationPriority.LOW,
-        onlyAlertOnce: true,
-      ),
-      iosNotificationOptions: const IOSNotificationOptions(
-        showNotification: false,
-      ),
-      foregroundTaskOptions: ForegroundTaskOptions(
-        eventAction: ForegroundTaskEventAction.nothing(),
-        autoRunOnBoot: false,
-        autoRunOnMyPackageReplaced: false,
-        allowWakeLock: true,
-        allowWifiLock: true,
-      ),
-    );
+    // 监听原生通知按钮回传
+    _actionsChannel.setMethodCallHandler((call) async {
+      if (call.method == 'onAction') {
+        final args = (call.arguments as Map?) ?? const {};
+        final id = args['id'] as String?;
 
-    FlutterForegroundTask.initCommunicationPort();
+        if (id == null) return;
+
+        handleNotificationAction(id);
+      }
+    });
 
     _isInitialized = true;
-    KazumiLogger().i('BackgroundDownloadService: initialized');
+    KazumiLogger().i('BackgroundDownloadService(native): initialized');
   }
 
   Future<bool> needsNotificationPermission() async {
     if (!isSupported) return false;
-    final permission = await FlutterForegroundTask.checkNotificationPermission();
-    return permission != NotificationPermission.granted;
+    try {
+      final granted = await _permissionChannel.invokeMethod<bool>('check');
+      return granted != true;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<bool> requestNotificationPermission() async {
     if (!isSupported) return true;
-    final result = await FlutterForegroundTask.requestNotificationPermission();
-    return result == NotificationPermission.granted;
+    try {
+      final granted = await _permissionChannel.invokeMethod<bool>('request');
+      return granted == true;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<bool> startService() async {
@@ -77,6 +82,7 @@ class BackgroundDownloadService {
       await init();
     }
 
+    // 通知权限
     final needsPermission = await needsNotificationPermission();
     if (needsPermission) {
       if (onNotificationPermissionRequired != null) {
@@ -84,68 +90,85 @@ class BackgroundDownloadService {
         if (userAgreed) {
           final granted = await requestNotificationPermission();
           if (!granted) {
-            KazumiLogger().w('BackgroundDownloadService: notification permission denied by user');
+            KazumiLogger().w(
+                'BackgroundDownloadService(native): notification permission denied by user');
           }
         } else {
-          KazumiLogger().i('BackgroundDownloadService: user declined permission dialog');
+          KazumiLogger().i(
+              'BackgroundDownloadService(native): user declined permission dialog');
         }
       } else {
-        // 没有设置回调，直接请求权限（兼容旧行为）
         final granted = await requestNotificationPermission();
         if (!granted) {
-          KazumiLogger().w('BackgroundDownloadService: notification permission denied');
+          KazumiLogger().w(
+              'BackgroundDownloadService(native): notification permission denied');
         }
       }
     }
 
     try {
-      final result = await FlutterForegroundTask.startService(
-        notificationTitle: '正在下载',
-        notificationText: '准备中...',
-        notificationButtons: [
-          const NotificationButton(id: 'pause_all', text: '暂停全部'),
-        ],
-        callback: _backgroundCallback,
-      );
+      // 启动原生前台服务：先用不确定进度（indeterminate=true）
+      await _downloadChannel.invokeMethod('start', {
+        'title': '正在下载',
+        'text': '准备中...',
+      });
 
-      _isRunning = result is ServiceRequestSuccess;
+      // 立即更新一次：显示 0% 的确定进度条
+      await _downloadChannel.invokeMethod('update', {
+        'title': '正在下载',
+        'text': '0% · 准备中...',
+        'progress': 0,
+        'indeterminate': false,
+      });
 
-      if (_isRunning) {
-        KazumiLogger().i('BackgroundDownloadService: service started');
-      } else {
-        KazumiLogger().w('BackgroundDownloadService: service start returned non-success: $result');
-      }
-      return _isRunning;
+      _isRunning = true;
+      KazumiLogger().i('BackgroundDownloadService(native): service started');
+      return true;
     } catch (e) {
-      KazumiLogger().e('BackgroundDownloadService: failed to start service', error: e);
+      _isRunning = false;
+      KazumiLogger()
+          .e('BackgroundDownloadService(native): failed to start', error: e);
       return false;
     }
   }
 
   Future<void> stopService() async {
     if (!isSupported || !_isRunning) return;
-
     try {
-      await FlutterForegroundTask.stopService();
+      await _downloadChannel.invokeMethod('stop');
       _isRunning = false;
-      KazumiLogger().i('BackgroundDownloadService: service stopped');
+      KazumiLogger().i('BackgroundDownloadService(native): service stopped');
     } catch (e) {
-      KazumiLogger().e('BackgroundDownloadService: failed to stop service', error: e);
+      KazumiLogger()
+          .e('BackgroundDownloadService(native): failed to stop', error: e);
     }
   }
 
   Future<void> updateNotification({
     required String title,
     required String text,
+    int? progress,
   }) async {
     if (!isSupported || !_isRunning) return;
 
     try {
-      await FlutterForegroundTask.updateService(
-        notificationTitle: title,
-        notificationText: text,
-      );
-    } catch (e) {
+      if (progress == null) {
+        await _downloadChannel.invokeMethod('update', {
+          'title': title,
+          'text': text,
+          'progress': 0,
+          'indeterminate': true,
+        });
+      } else {
+        final p = progress.clamp(0, 100);
+        await _downloadChannel.invokeMethod('update', {
+          'title': title,
+          'text': text,
+          'progress': p,
+          'indeterminate': false,
+        });
+      }
+    } catch (_) {
       // 忽略更新失败，不影响下载
     }
   }
@@ -158,19 +181,18 @@ class BackgroundDownloadService {
   }) async {
     if (!isSupported || !_isRunning) return;
 
-    String title;
-    String text;
-
     if (activeCount == 0) {
-      title = '下载已暂停';
-      text = '共 $totalCount 个任务';
-    } else {
-      final percent = (overallProgress * 100).toInt();
-      title = '正在下载 ($activeCount/$totalCount)';
-      text = '$percent% · $speedText';
+      final title = '下载已暂停';
+      final text = '共 $totalCount 个任务';
+      await updateNotification(title: title, text: text, progress: null);
+      return;
     }
 
-    await updateNotification(title: title, text: text);
+    final percent = (overallProgress * 100).clamp(0, 100).toInt();
+    final title = '正在下载 ($activeCount/$totalCount)';
+    final text = '$percent% · $speedText';
+
+    await updateNotification(title: title, text: text, progress: percent);
   }
 
   Future<void> showCompletedNotification({
@@ -178,77 +200,27 @@ class BackgroundDownloadService {
   }) async {
     if (!isSupported) return;
     await stopService();
-    // TODO: 显示普通通知告知用户下载完成（需要额外的通知插件）
   }
 
-  void handleNotificationAction(String buttonId) {
+  void handleNotificationAction(String buttonId) async {
+    KazumiLogger().i('BackgroundDownloadService(native): action=$buttonId');
+
     switch (buttonId) {
       case 'pause_all':
         onPauseAll?.call();
         break;
-      case 'cancel_all':
-        onCancelAll?.call();
+
+      case 'kazumi.action.OPEN_DOWNLOAD_MANAGER':
+        handleNavigateToDownload();
+        break;
+
+      default:
         break;
     }
   }
 
+
   void handleNavigateToDownload() {
     onNavigateToDownloadRequested?.call();
-  }
-
-  void addTaskDataCallback(void Function(Object) callback) {
-    FlutterForegroundTask.addTaskDataCallback(callback);
-  }
-
-  void removeTaskDataCallback(void Function(Object) callback) {
-    FlutterForegroundTask.removeTaskDataCallback(callback);
-  }
-}
-
-/// 后台任务回调（在独立 Isolate 中运行）
-///
-/// 注意：此回调主要用于保持服务存活和处理通知交互。
-/// 实际下载逻辑在主 Isolate 中运行。
-@pragma('vm:entry-point')
-void _backgroundCallback() {
-  FlutterForegroundTask.setTaskHandler(_DownloadTaskHandler());
-}
-
-class _DownloadTaskHandler extends TaskHandler {
-  @override
-  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
-    debugPrint('BackgroundDownloadService: task handler started');
-  }
-
-  @override
-  void onRepeatEvent(DateTime timestamp) {
-    // eventAction 配置为 nothing，不会触发
-  }
-
-  @override
-  void onNotificationButtonPressed(String id) {
-    debugPrint('BackgroundDownloadService: notification button pressed: $id');
-    FlutterForegroundTask.sendDataToMain({'action': 'button_pressed', 'id': id});
-  }
-
-  @override
-  void onNotificationPressed() {
-    FlutterForegroundTask.sendDataToMain({'action': 'navigate_to_download'});
-    FlutterForegroundTask.launchApp();
-  }
-
-  @override
-  void onNotificationDismissed() {
-    // 前台服务通知通常不可划掉
-  }
-
-  @override
-  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
-    debugPrint('BackgroundDownloadService: task handler destroyed (isTimeout: $isTimeout)');
-  }
-
-  @override
-  void onReceiveData(Object data) {
-    debugPrint('BackgroundDownloadService: received data: $data');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,6 @@ dependencies:
   flutter_svg: ^2.2.3
   antlr4: ^4.13.2
   fl_chart: ^1.1.1
-  flutter_foreground_task: ^9.0.0
   skeletonizer: ^2.1.2
   flutter_inappwebview_platform_interface: ^1.3.0+1
   flutter_inappwebview_ios: ^1.1.2


### PR DESCRIPTION
**起因：**
1. **后台冻结问题**：目前 Android 端部分用户使用 NoActive、Thanox 等墓碑管理工具。之前的 Flutter 通知插件生成的通知标记不规范，导致应用进入后台后无法被这些工具准确识别为“正在下载”，从而导致进程被冻结，下载中断。
2. **功能限制**：原有插件方案在实现动态进度条更新时逻辑较复杂，且在部分机型上 UI 刷新频率和展示效果不理想。

**改进方案：**
将下载通知模块从第三方插件迁移至原生 Android 实现：
* **原生前台服务**：手动实现 `DownloadForegroundService` 并声明 `dataSync` 类型。
* **标准通知 API**：使用 `NotificationCompat.Builder` 及其 `setProgress` 方法实现系统级进度条。
* **双向通信**：通过 `MethodChannel` 处理 Flutter 进度下发及原生通知动作（如暂停、跳转）的回传。

**重构优势：**
1. **提升后台稳定性**：原生前台服务能更有效地触发系统及 NoActive 等第三方工具的豁免规则，降低应用在后台下载时被冻结或杀掉的概率。
2. **优化 UI 表现**：使用系统原生进度条，UI 刷新更平滑，且符合 Android 通知栏设计规范。
3. **精简依赖**：移除了 `flutter_foreground_task` 插件及相关冗余代码，减少了应用体积和内存占用。
4. **增强交互**：优化了通知栏按钮的响应逻辑，以及点击通知跳转至下载管理页面的可靠性。