### PR TITLE
ui(player): add dynamic animations for speed/brightness and adaptive volume icons

### DIFF
--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -67,7 +68,7 @@ class SmallestPlayerItemPanel extends StatefulWidget {
       _SmallestPlayerItemPanelState();
 }
 
-class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
+class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> with TickerProviderStateMixin {
   Box setting = GStorage.setting;
   late bool haEnable;
   late Animation<Offset> topOffsetAnimation;
@@ -131,6 +132,8 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
     });
   }
 
+  late AnimationController _speedIconController;
+
   @override
   void initState() {
     super.initState();
@@ -157,8 +160,18 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
     ));
     haEnable = setting.get(SettingBoxKey.hAenable, defaultValue: true);
     cacheSvgIcons();
+    _speedIconController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
   }
-  
+
+  @override
+  void dispose() {
+    _speedIconController.dispose();
+    super.dispose();
+  }
+
   void cacheSvgIcons() {
     cachedDanmakuOffIcon = RepaintBoundary(
       child: SvgPicture.asset(
@@ -188,6 +201,30 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
     }
 
     return cachedDanmakuOnIcon!;
+  }
+
+  Widget _buildFlowingArrows() {
+    return AnimatedBuilder(
+      animation: _speedIconController,
+      builder: (context, child) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Opacity(
+              opacity: (math.sin(_speedIconController.value * 2 * math.pi) + 1) / 2 * 0.7 + 0.3,
+              child: const Icon(Icons.play_arrow_rounded, color: Colors.white, size: 18),
+            ),
+            Transform.translate(
+              offset: const Offset(-10, 0),
+              child: Opacity(
+                opacity: (math.sin((_speedIconController.value - 0.4) * 2 * math.pi) + 1) / 2 * 0.7 + 0.3,
+                child: const Icon(Icons.play_arrow_rounded, color: Colors.white, size: 18),
+              ),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Widget _buildDanmakuToggleButton(BuildContext context) {
@@ -360,30 +397,40 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
           Positioned(
               top: 25,
               child: playerController.showPlaySpeed
-                  ? Wrap(
-                      alignment: WrapAlignment.center,
-                      children: <Widget>[
-                        Container(
-                          padding: const EdgeInsets.all(8.0),
-                          decoration: BoxDecoration(
-                            color: Colors.black54,
-                            borderRadius: BorderRadius.circular(8.0), // 圆角
+                  ? Observer(builder: (context) {
+                if (!_speedIconController.isAnimating) {
+                  _speedIconController.repeat();
+                }
+                return Wrap(
+                  alignment: WrapAlignment.center,
+                  children: <Widget>[
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: Colors.black54,
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          _buildFlowingArrows(),
+                          Text(
+                            ' ${playerController.playerSpeed}x 倍速',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                          child: const Row(
-                            children: <Widget>[
-                              Icon(Icons.fast_forward, color: Colors.white),
-                              Text(
-                                ' 倍速播放',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    )
-                  : Container()),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              })
+                  : (() {
+                _speedIconController.stop();
+                return Container();
+              })()),
           // 亮度条
           Positioned(
               top: 25,
@@ -399,8 +446,11 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                             ),
                             child: Row(
                               children: <Widget>[
-                                const Icon(Icons.brightness_7,
-                                    color: Colors.white),
+                                Transform.rotate(
+                                  angle: playerController.brightness * 2 * math.pi,
+                                  child: const Icon(Icons.brightness_7, color: Colors.white),
+                                ),
+                                const SizedBox(width: 4),
                                 Text(
                                   ' ${(playerController.brightness * 100).toInt()} %',
                                   style: const TextStyle(
@@ -427,8 +477,18 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                             ),
                             child: Row(
                               children: <Widget>[
-                                const Icon(Icons.volume_down,
-                                    color: Colors.white),
+                                Icon(
+                                  playerController.volume <= 0
+                                      ? Icons.volume_off
+                                      : playerController.volume <= 33
+                                      ? Icons.volume_mute
+                                      : playerController.volume <= 66
+                                      ? Icons.volume_down
+                                      : Icons.volume_up,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                                const SizedBox(width: 6),
                                 Text(
                                   ' ${playerController.volume.toInt()}%',
                                   style: const TextStyle(


### PR DESCRIPTION
### 优化播放器控制面板交互视觉反馈

**起因：**
**交互反馈单一**：原播放器在调节音量和亮度以及长按进行倍速播放时，顶部提示框仅有静态图标，缺乏直观的动态反馈，视觉体验较为生硬。

**改进方案：**
1. **实现多级自适应音量图标**：
   - 弃用单一静态图标，根据 `playerController.volume` 百分比实时映射四种状态：静音 (`volume_off`)、低音量 (`volume_mute`)、中音量 (`volume_down`)、高音量 (`volume_up`)。
2. **引入亮度图标关联旋转动画**：
   - 使用 `Transform.rotate` 包装亮度图标，将 `brightness` 线性值（0.0 - 1.0）映射至旋转弧度（0 - 2π），实现图标随滑动实时旋转的物理感反馈。
3. **新增倍速动态流光效果**：
   - 实现 `_buildFlowingArrows` 动画组件，通过 `AnimationController` 驱动 `math.sin` 改变双箭头的透明度与位移，在倍速播放时提供持续的动效引导。