### PR TITLE
fix: migrate danmaku data from Hive to standalone files to prevent OOM

### DIFF
--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -58,7 +58,7 @@ abstract class _DownloadController with Store {
     await _migrateDanmakuDataToFiles();
 
     _downloadManager.onProgress = _onDownloadProgress;
-    _initBackgroundService();
+    await _initBackgroundService();
   }
 
   /// 启动时将所有旧 Hive danmakuData 迁移到独立文件并清空 Hive 字段

--- a/lib/pages/init_page.dart
+++ b/lib/pages/init_page.dart
@@ -47,7 +47,7 @@ class _InitPageState extends State<InitPage> {
     _loadDanmakuShield();
     _webDavInit();
     try {
-      downloadController.init();
+      await downloadController.init();
       _setupBackgroundDownloadNavigation();
     } catch (e) {
       KazumiLogger().e('InitPage: downloadController.init() failed', error: e);

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -650,7 +650,7 @@ abstract class _PlayerController with Store {
     try {
       danDanmakus.clear();
       final downloadController = Modular.get<DownloadController>();
-      final cachedDanmakus = downloadController.getCachedDanmakus(
+      final cachedDanmakus = await downloadController.getCachedDanmakus(
         bangumiId,
         pluginName,
         episode,


### PR DESCRIPTION
**目前我测试下载了同样数十集动漫，直到我的存储空间10g，并没有出现这个问题。**

fix #1772 

改动如下：

弹幕数据（每集约1MB，JSON格式）存储于Hive DownloadRecord中，导致50多集的记录膨胀至60-128MB。在Hive自动压缩过程中，BufferedFileReader.loadBytes分配了同等大小的缓冲区，引发内存不足、数据块损坏及数据丢失。

现改为每集将弹幕数据写入{下载目录}/danmaku.json。Hive的danmakuData字段保持空置，旧数据在首次读取时延迟迁移。