### PR TITLE
feat: 下载系统按 road 分离存储，解决多系列集数冲突

### DIFF
--- a/lib/modules/download/download_module.dart
+++ b/lib/modules/download/download_module.dart
@@ -24,6 +24,11 @@ class DownloadRecord {
 
   String get key => '${pluginName}_$bangumiId';
 
+  /// 生成复合 key: road * 100000 + episodeNumber
+  /// 用于在 episodes map 中区分不同 road 的同号集数
+  static int episodeKey(int road, int episodeNumber) =>
+      road * 100000 + episodeNumber;
+
   DownloadRecord(
     this.bangumiId,
     this.bangumiName,
@@ -87,6 +92,14 @@ class DownloadEpisode {
   @HiveField(15, defaultValue: 0)
   int danDanBangumiID;
 
+  /// 视频源详情页 URL (如 /voddetail/25443.html)，用于下载管理页分组显示
+  @HiveField(16, defaultValue: '')
+  String sourceDetailUrl;
+
+  /// 视频源详情页标题 (如 "JOJO的奇妙冒险 石之海")，用于下载管理页分组标题
+  @HiveField(17, defaultValue: '')
+  String sourceTitle;
+
   DownloadEpisode(
     this.episodeNumber,
     this.episodeName,
@@ -104,6 +117,8 @@ class DownloadEpisode {
     this.episodePageUrl, {
     this.danmakuData = '',
     this.danDanBangumiID = 0,
+    this.sourceDetailUrl = '',
+    this.sourceTitle = '',
   });
 }
 

--- a/lib/modules/download/download_module.g.dart
+++ b/lib/modules/download/download_module.g.dart
@@ -82,13 +82,15 @@ class DownloadEpisodeAdapter extends TypeAdapter<DownloadEpisode> {
       fields[13] == null ? '' : fields[13] as String,
       danmakuData: fields[14] == null ? '' : fields[14] as String,
       danDanBangumiID: fields[15] == null ? 0 : (fields[15] as num).toInt(),
+      sourceDetailUrl: fields[16] == null ? '' : fields[16] as String,
+      sourceTitle: fields[17] == null ? '' : fields[17] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, DownloadEpisode obj) {
     writer
-      ..writeByte(16)
+      ..writeByte(18)
       ..writeByte(0)
       ..write(obj.episodeNumber)
       ..writeByte(1)
@@ -120,7 +122,11 @@ class DownloadEpisodeAdapter extends TypeAdapter<DownloadEpisode> {
       ..writeByte(14)
       ..write(obj.danmakuData)
       ..writeByte(15)
-      ..write(obj.danDanBangumiID);
+      ..write(obj.danDanBangumiID)
+      ..writeByte(16)
+      ..write(obj.sourceDetailUrl)
+      ..writeByte(17)
+      ..write(obj.sourceTitle);
   }
 
   @override

--- a/lib/pages/download/download_episode_sheet.dart
+++ b/lib/pages/download/download_episode_sheet.dart
@@ -35,9 +35,8 @@ class _DownloadEpisodeSheetState extends State<DownloadEpisodeSheet> {
     final downloadedUrls = <String>{};
     if (record != null) {
       for (final entry in record.episodes.entries) {
-        if (entry.value.status == DownloadStatus.completed ||
-            entry.value.status == DownloadStatus.downloading ||
-            entry.value.status == DownloadStatus.pending) {
+        if (entry.value.road == widget.road &&
+            entry.value.status != DownloadStatus.failed) {
           if (entry.value.episodePageUrl.isNotEmpty) {
             downloadedUrls.add(entry.value.episodePageUrl);
           }
@@ -247,6 +246,8 @@ class _DownloadEpisodeSheetState extends State<DownloadEpisodeSheet> {
         episodeName: identifier,
         road: widget.road,
         episodePageUrl: episodePageUrl,
+        sourceDetailUrl: videoPageController.src,
+        sourceTitle: videoPageController.title,
       );
     }
 

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -266,7 +266,7 @@ abstract class _PlayerController with Store {
     if (episodeFromTitle == 0) {
       episodeFromTitle = params.episode;
     }
-    _loadDanmaku(params.bangumiId, params.pluginName, episodeFromTitle);
+    _loadDanmaku(params.bangumiId, params.pluginName, params.currentRoad, episodeFromTitle);
     mediaPlayer ??= await createVideoController(
       params.httpHeaders,
       params.adBlockerEnabled,
@@ -629,16 +629,16 @@ abstract class _PlayerController with Store {
 
   /// 加载弹幕 (离线模式优先从缓存加载，无缓存时尝试在线获取)
   Future<void> _loadDanmaku(
-      int bangumiId, String pluginName, int episode) async {
+      int bangumiId, String pluginName, int road, int episode) async {
     if (isLocalPlayback) {
-      await _loadCachedDanmaku(bangumiId, pluginName, episode);
+      await _loadCachedDanmaku(bangumiId, pluginName, road, episode);
     } else {
       getDanDanmakuByBgmBangumiID(bangumiId, episode);
     }
   }
 
   Future<void> _loadCachedDanmaku(
-      int bangumiId, String pluginName, int episode) async {
+      int bangumiId, String pluginName, int road, int episode) async {
     if (danmakuLoading) {
       KazumiLogger()
           .i('PlayerController: danmaku is loading, ignore duplicate request');
@@ -654,6 +654,7 @@ abstract class _PlayerController with Store {
       final cachedDanmakus = await downloadController.getCachedDanmakus(
         bangumiId,
         pluginName,
+        road,
         episode,
       );
 
@@ -674,7 +675,7 @@ abstract class _PlayerController with Store {
               KazumiLogger()
                   .i('PlayerController: fetched ${res.length} danmakus online');
               _saveDanmakuToCache(
-                  downloadController, bangumiId, pluginName, episode, res);
+                  downloadController, bangumiId, pluginName, road, episode, res);
             }
           }
         } catch (e) {
@@ -692,11 +693,12 @@ abstract class _PlayerController with Store {
   }
 
   void _saveDanmakuToCache(DownloadController downloadController, int bangumiId,
-      String pluginName, int episode, List<Danmaku> danmakus) {
+      String pluginName, int road, int episode, List<Danmaku> danmakus) {
     try {
       downloadController.updateCachedDanmakus(
         bangumiId,
         pluginName,
+        road,
         episode,
         danmakus,
         bangumiID,

--- a/lib/repositories/download_repository.dart
+++ b/lib/repositories/download_repository.dart
@@ -21,8 +21,9 @@ abstract class IDownloadRepository {
   ///
   /// [bangumiId] 番剧 ID
   /// [pluginName] 插件名称
+  /// [road] 播放列表索引
   /// [episodeNumber] 集数编号
-  DownloadEpisode? getEpisode(int bangumiId, String pluginName, int episodeNumber);
+  DownloadEpisode? getEpisode(int bangumiId, String pluginName, int road, int episodeNumber);
 
   /// 获取已完成下载的集数列表
   ///
@@ -209,9 +210,10 @@ class DownloadRepository implements IDownloadRepository {
   }
 
   @override
-  DownloadEpisode? getEpisode(int bangumiId, String pluginName, int episodeNumber) {
+  DownloadEpisode? getEpisode(int bangumiId, String pluginName, int road, int episodeNumber) {
     final record = getRecordByBangumiId(bangumiId, pluginName);
-    return record?.episodes[episodeNumber];
+    final compositeKey = DownloadRecord.episodeKey(road, episodeNumber);
+    return record?.episodes[compositeKey];
   }
 
   @override


### PR DESCRIPTION
这是一个社区还未反馈的bug，前些天我发现时就在研究解决方案。

<img width="870" height="796" alt="image" src="https://github.com/user-attachments/assets/d237b24d-0cf4-4ebe-b4da-ea5921bda3d4" />
在anime7和7sefun下，如果选中任意源下载，则会同步所有状态至同渠道下的其他源剧集，并且会在下次下载的时候覆盖缓存。

这个PR解决了这个问题，并在下载管理进行区分。
<img width="1554" height="418" alt="image" src="https://github.com/user-attachments/assets/f8a92073-848f-4571-9cf7-d0a0a2eef48f" />


- 使用复合 key (road * 100000 + episodeNumber) 区分不同播放列表的同号集数
- 不同系列共享 bangumiId 时自动分配 alternative key (>= 10000000) 避免覆盖
- 选集面板使用 URL + road 精确匹配下载状态，避免跨系列误显示
- 下载管理页按源详情页 (sourceDetailUrl) 和播放列表 (road) 两层分组显示
- DownloadEpisode 新增 sourceDetailUrl/sourceTitle 字段用于分组标题
- 离线播放使用 episode 对象直接获取路径，绕过 composite key 查找
- 启动时自动迁移旧 episode key 到 composite key 格式