### PR TITLE
在时间表筛选里添加了仅显示在看筛选

### DIFF
--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -2,7 +2,7 @@
 // Do not modify
 // Check in to version control
 
-import 'package:hive_ce/hive.dart';
+import 'package:hive_ce/hive_ce.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/bangumi/bangumi_tag.dart';
 import 'package:kazumi/modules/collect/collect_change_module.dart';

--- a/lib/pages/timeline/timeline_controller.dart
+++ b/lib/pages/timeline/timeline_controller.dart
@@ -32,6 +32,9 @@ abstract class _TimelineController with Store {
   @observable
   late bool notShowWatchedBangumis = _collectRepository.getTimelineNotShowWatchedBangumis();
 
+  @observable
+  late bool onlyShowWatchingBangumis = _collectRepository.getTimelineOnlyShowWatchingBangumis();
+
   int sortType = 1;
 
   late DateTime selectedDate;
@@ -135,5 +138,15 @@ abstract class _TimelineController with Store {
 
   Set<int> loadWatchedBangumiIds() {
     return _collectRepository.getBangumiIdsByType(CollectType.watched);
+  }
+
+  @action
+  Future<void> setOnlyShowWatchingBangumis(bool value) async {
+    onlyShowWatchingBangumis = value;
+    await _collectRepository.updateTimelineOnlyShowWatchingBangumis(value);
+  }
+
+  Set<int> loadWatchingBangumiIds() {
+    return _collectRepository.getBangumiIdsByType(CollectType.watching);
   }
 }

--- a/lib/pages/timeline/timeline_controller.g.dart
+++ b/lib/pages/timeline/timeline_controller.g.dart
@@ -119,6 +119,29 @@ mixin _$TimelineController on _TimelineController, Store {
     });
   }
 
+  late final _$onlyShowWatchingBangumisAtom = Atom(
+      name: '_TimelineController.onlyShowWatchingBangumis', context: context);
+
+  @override
+  bool get onlyShowWatchingBangumis {
+    _$onlyShowWatchingBangumisAtom.reportRead();
+    return super.onlyShowWatchingBangumis;
+  }
+
+  bool _onlyShowWatchingBangumisIsInitialized = false;
+
+  @override
+  set onlyShowWatchingBangumis(bool value) {
+    _$onlyShowWatchingBangumisAtom.reportWrite(
+        value,
+        _onlyShowWatchingBangumisIsInitialized
+            ? super.onlyShowWatchingBangumis
+            : null, () {
+      super.onlyShowWatchingBangumis = value;
+      _onlyShowWatchingBangumisIsInitialized = true;
+    });
+  }
+
   late final _$setNotShowAbandonedBangumisAsyncAction = AsyncAction(
       '_TimelineController.setNotShowAbandonedBangumis',
       context: context);
@@ -139,6 +162,16 @@ mixin _$TimelineController on _TimelineController, Store {
         .run(() => super.setNotShowWatchedBangumis(value));
   }
 
+  late final _$setOnlyShowWatchingBangumisAsyncAction = AsyncAction(
+      '_TimelineController.setOnlyShowWatchingBangumis',
+      context: context);
+
+  @override
+  Future<void> setOnlyShowWatchingBangumis(bool value) {
+    return _$setOnlyShowWatchingBangumisAsyncAction
+        .run(() => super.setOnlyShowWatchingBangumis(value));
+  }
+
   @override
   String toString() {
     return '''
@@ -147,7 +180,8 @@ seasonString: ${seasonString},
 isLoading: ${isLoading},
 isTimeOut: ${isTimeOut},
 notShowAbandonedBangumis: ${notShowAbandonedBangumis},
-notShowWatchedBangumis: ${notShowWatchedBangumis}
+notShowWatchedBangumis: ${notShowWatchedBangumis},
+onlyShowWatchingBangumis: ${onlyShowWatchingBangumis}
     ''';
   }
 }

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -364,6 +364,23 @@ class _TimelinePageState extends State<TimelinePage>
             ),
           ),
         ),
+        Observer(
+          builder: (context) => InkWell(
+            onTap: () {
+              timelineController.setOnlyShowWatchingBangumis(
+                  !timelineController.onlyShowWatchingBangumis);
+            },
+            child: ListTile(
+              title: const Text('只显示在看的番剧'),
+              trailing: Switch(
+                value: timelineController.onlyShowWatchingBangumis,
+                onChanged: (value) {
+                  timelineController.setOnlyShowWatchingBangumis(value);
+                },
+              ),
+            ),
+          ),
+        ),
       ],
     );
   }
@@ -463,7 +480,7 @@ class _TimelinePageState extends State<TimelinePage>
               constraints: BoxConstraints(
                 maxHeight: (MediaQuery.sizeOf(context).height >=
                         LayoutBreakpoint.compact['height']!)
-                    ? MediaQuery.of(context).size.height * 1 / 4
+                    ? MediaQuery.of(context).size.height * 1 / 3
                     : MediaQuery.of(context).size.height,
                 maxWidth: (MediaQuery.sizeOf(context).width >=
                         LayoutBreakpoint.medium['width']!)
@@ -538,6 +555,13 @@ class _TimelinePageState extends State<TimelinePage>
         final watchedBangumiIds = timelineController.loadWatchedBangumiIds();
         filteredList = filteredList
             .where((item) => !watchedBangumiIds.contains(item.id))
+            .toList();
+      }
+
+      if (timelineController.onlyShowWatchingBangumis) {
+        final watchingBangumiIds = timelineController.loadWatchingBangumiIds();
+        filteredList = filteredList
+            .where((item) => watchingBangumiIds.contains(item.id))
             .toList();
       }
 

--- a/lib/repositories/collect_repository.dart
+++ b/lib/repositories/collect_repository.dart
@@ -46,6 +46,12 @@ abstract class ICollectRepository {
   /// 更新时间表页"不显示已看过番剧"设置
   Future<void> updateTimelineNotShowWatchedBangumis(bool value);
 
+  /// 获取时间表页"只显示在看的番剧"设置
+  bool getTimelineOnlyShowWatchingBangumis();
+
+  /// 更新时间表页"只显示在看的番剧"设置
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value);
+
   // ========== 其他设置 ==========
 
   /// 获取隐私模式设置
@@ -213,6 +219,37 @@ class CollectRepository implements ICollectRepository {
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: update timeline not show watched bangumis setting failed. value=$value',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() {
+    try {
+      final value = _settingBox.get(
+        SettingBoxKey.timelineOnlyShowWatchingBangumis,
+        defaultValue: false,
+      );
+      return value is bool ? value : false;
+    } catch (e, stackTrace) {
+      KazumiLogger().e(
+        'GStorage: get timeline only show watching bangumis setting failed, using default false',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {
+    try {
+      await _settingBox.put(SettingBoxKey.timelineOnlyShowWatchingBangumis, value);
+    } catch (e, stackTrace) {
+      KazumiLogger().e(
+        'GStorage: update timeline only show watching bangumis setting failed. value=$value',
         error: e,
         stackTrace: stackTrace,
       );

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -331,6 +331,7 @@ class SettingBoxKey {
       searchNotShowAbandonedBangumis = 'searchNotShowAbandonedBangumis',
       timelineNotShowAbandonedBangumis = 'timelineNotShowAbandonedBangumis',
       timelineNotShowWatchedBangumis = 'timelineNotShowWatchedBangumis',
+      timelineOnlyShowWatchingBangumis = 'timelineOnlyShowWatchingBangumis',
       useSystemFont = 'useSystemFont',
       forceAdBlocker = 'forceAdBlocker',
       backgroundPlayback = 'backgroundPlayback',


### PR DESCRIPTION
<img width="1700" height="1112" alt="image" src="https://github.com/user-attachments/assets/c09cd65c-b9aa-4458-a0f2-eb8535d79a34" />


当追的番超级多的时候 确实很难找到今天什么更新, 所以加了这个筛选功能 