### PR TITLE
feat: 在番剧详情页增加继续观看入口

### DIFF
--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -442,6 +442,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
             }),
           ),
           floatingActionButton: Wrap(
+            alignment: WrapAlignment.end,
             spacing: 12,
             runSpacing: 12,
             children: [

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -10,15 +10,19 @@ import 'package:kazumi/utils/storage.dart';
 import 'package:kazumi/pages/info/info_controller.dart';
 import 'package:kazumi/bean/card/bangumi_info_card.dart';
 import 'package:kazumi/pages/info/source_sheet.dart';
+import 'package:kazumi/plugins/plugins.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
+import 'package:kazumi/repositories/history_repository.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
+import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/utils/logger.dart';
 import 'package:kazumi/pages/info/info_tabview.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/bean/appbar/drag_to_move_bar.dart' as dtb;
 
 class InfoPage extends StatefulWidget {
@@ -35,6 +39,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
   final VideoPageController videoPageController =
       Modular.get<VideoPageController>();
   final PluginsController pluginsController = Modular.get<PluginsController>();
+  final IHistoryRepository historyRepository =
+      Modular.get<IHistoryRepository>();
   late TabController sourceTabController;
   late TabController infoTabController;
   late bool showRating;
@@ -172,7 +178,76 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
       await infoController.queryBangumiInfoByID(id, type: type);
       setState(() {});
     } catch (e) {
-      KazumiLogger().e('InfoController: failed to query bangumi info by ID', error: e);
+      KazumiLogger()
+          .e('InfoController: failed to query bangumi info by ID', error: e);
+    }
+  }
+
+  void showSourceSheet() {
+    showModalBottomSheet(
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: (MediaQuery.sizeOf(context).height >=
+                LayoutBreakpoint.compact['height']!)
+            ? MediaQuery.of(context).size.height * 3 / 4
+            : MediaQuery.of(context).size.height,
+        maxWidth: (MediaQuery.sizeOf(context).width >=
+                LayoutBreakpoint.medium['width']!)
+            ? MediaQuery.of(context).size.width * 9 / 16
+            : MediaQuery.of(context).size.width,
+      ),
+      clipBehavior: Clip.antiAlias,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      showDragHandle: true,
+      context: context,
+      builder: (context) {
+        return SourceSheet(
+          tabController: sourceTabController,
+          infoController: infoController,
+        );
+      },
+    );
+  }
+
+  Future<void> continueWatching(History history) async {
+    KazumiDialog.showLoading(
+      msg: '获取中',
+      barrierDismissible: Utils.isDesktop(),
+      onDismiss: () {
+        videoPageController.cancelQueryRoads();
+      },
+    );
+
+    Plugin? plugin;
+    for (final item in pluginsController.pluginList) {
+      if (item.name == history.adapterName) {
+        plugin = item;
+        break;
+      }
+    }
+    if (plugin == null) {
+      KazumiDialog.dismiss();
+      KazumiDialog.showToast(message: '未找到关联番剧源');
+      return;
+    }
+
+    videoPageController.bangumiItem = history.bangumiItem;
+    videoPageController.currentPlugin = plugin;
+    videoPageController.title = history.bangumiItem.nameCn == ''
+        ? history.bangumiItem.name
+        : history.bangumiItem.nameCn;
+    videoPageController.src = history.lastSrc;
+
+    try {
+      await videoPageController.queryRoads(
+        history.lastSrc,
+        videoPageController.currentPlugin.name,
+      );
+      KazumiDialog.dismiss();
+      Modular.to.pushNamed('/video/');
+    } catch (_) {
+      KazumiLogger().w('QueryManager: failed to query video playlist');
+      KazumiDialog.dismiss();
     }
   }
 
@@ -181,6 +256,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     final List<String> tabs = <String>['概览', '吐槽', '角色', '评论', '制作人员'];
     final bool showWindowButton = GStorage.setting
         .get(SettingBoxKey.showWindowButton, defaultValue: false);
+    final History? continueHistory =
+        historyRepository.getContinueHistory(infoController.bangumiItem);
     return PopScope(
       canPop: true,
       child: DefaultTabController(
@@ -355,31 +432,26 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
               );
             }),
           ),
-          floatingActionButton: FloatingActionButton.extended(
-            icon: const Icon(Icons.play_arrow_rounded),
-            label: Text('开始观看'),
-            onPressed: () async {
-              showModalBottomSheet(
-                isScrollControlled: true,
-                constraints: BoxConstraints(
-                  maxHeight: (MediaQuery.sizeOf(context).height >=
-                          LayoutBreakpoint.compact['height']!)
-                      ? MediaQuery.of(context).size.height * 3 / 4
-                      : MediaQuery.of(context).size.height,
-                  maxWidth: (MediaQuery.sizeOf(context).width >=
-                          LayoutBreakpoint.medium['width']!)
-                      ? MediaQuery.of(context).size.width * 9 / 16
-                      : MediaQuery.of(context).size.width,
+          floatingActionButton: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              if (continueHistory != null)
+                FloatingActionButton.extended(
+                  heroTag: 'continue_watch_${infoController.bangumiItem.id}',
+                  icon: const Icon(Icons.history_rounded),
+                  label: Text(
+                    '继续观看 第${continueHistory.lastWatchEpisode}话',
+                  ),
+                  onPressed: () => continueWatching(continueHistory),
                 ),
-                clipBehavior: Clip.antiAlias,
-                backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                showDragHandle: true,
-                context: context,
-                builder: (context) {
-                  return SourceSheet(tabController: sourceTabController, infoController: infoController);
-                },
-              );
-            },
+              FloatingActionButton.extended(
+                heroTag: 'start_watch_${infoController.bangumiItem.id}',
+                icon: const Icon(Icons.play_arrow_rounded),
+                label: const Text('开始观看'),
+                onPressed: showSourceSheet,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -204,9 +204,17 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
         return SourceSheet(
           tabController: sourceTabController,
           infoController: infoController,
+          onVideoPageClosed: refreshContinueState,
         );
       },
     );
+  }
+
+  void refreshContinueState() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
   }
 
   Future<void> continueWatching(History history) async {
@@ -244,7 +252,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
         videoPageController.currentPlugin.name,
       );
       KazumiDialog.dismiss();
-      Modular.to.pushNamed('/video/');
+      await Modular.to.pushNamed('/video/');
+      refreshContinueState();
     } catch (_) {
       KazumiLogger().w('QueryManager: failed to query video playlist');
       KazumiDialog.dismiss();

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -22,10 +22,12 @@ class SourceSheet extends StatefulWidget {
     super.key,
     required this.tabController,
     required this.infoController,
+    this.onVideoPageClosed,
   });
 
   final TabController tabController;
   final InfoController infoController;
+  final VoidCallback? onVideoPageClosed;
 
   @override
   State<SourceSheet> createState() => _SourceSheetState();
@@ -653,7 +655,8 @@ class _SourceSheetState extends State<SourceSheet>
                                     await videoPageController.queryRoads(
                                         searchItem.src, plugin.name);
                                     KazumiDialog.dismiss();
-                                    Modular.to.pushNamed('/video/');
+                                    await Modular.to.pushNamed('/video/');
+                                    widget.onVideoPageClosed?.call();
                                   } catch (_) {
                                     KazumiLogger().w(
                                         "QueryManager: failed to query video playlist");

--- a/lib/repositories/history_repository.dart
+++ b/lib/repositories/history_repository.dart
@@ -17,6 +17,12 @@ abstract class IHistoryRepository {
   /// 返回历史记录，不存在返回null
   History? getHistory(String adapterName, BangumiItem bangumiItem);
 
+  /// 获取特定番剧最新的一条继续观看记录
+  ///
+  /// [bangumiItem] 番剧信息
+  /// 返回最新历史记录，不存在返回null
+  History? getContinueHistory(BangumiItem bangumiItem);
+
   /// 更新或创建历史记录
   ///
   /// [episode] 集数
@@ -104,6 +110,31 @@ class HistoryRepository implements IHistoryRepository {
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: get history failed. bangumi=${bangumiItem.name}',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
+  @override
+  History? getContinueHistory(BangumiItem bangumiItem) {
+    try {
+      final histories = _historiesBox.values
+          .where((history) => history.bangumiItem.id == bangumiItem.id)
+          .toList();
+      if (histories.isEmpty) {
+        return null;
+      }
+      histories.sort(
+        (a, b) =>
+            b.lastWatchTime.millisecondsSinceEpoch -
+            a.lastWatchTime.millisecondsSinceEpoch,
+      );
+      return histories.first;
+    } catch (e, stackTrace) {
+      KazumiLogger().e(
+        'GStorage: get continue history failed. bangumi=${bangumiItem.name}',
         error: e,
         stackTrace: stackTrace,
       );


### PR DESCRIPTION
对于https://github.com/Predidit/Kazumi/issues/1974 自动匹配上次使用的播放源，增加了一个继续观看按钮
<img width="1263" height="843" alt="image" src="https://github.com/user-attachments/assets/6c5a5b79-591e-49f6-a6a3-1c02b1662651" />

HistoryRepository
新增 getContinueHistory(BangumiItem)，用于获取当前番剧最新一条观看历史
InfoPage
根据历史记录决定是否展示“继续观看”按钮
新增 continueWatching 逻辑，复用历史记录恢复播放
抽出 showSourceSheet
增加 refreshContinueState，用于播放页返回后的状态刷新
SourceSheet
新增 onVideoPageClosed 回调
进入播放页后等待返回，再通知详情页刷新续播状态

因为我没有多种设备，所以测试不足