### PR TITLE
refactor(episode_comments_card): 优化剧集评论卡片布局结构

### DIFF
--- a/lib/bean/card/episode_comments_card.dart
+++ b/lib/bean/card/episode_comments_card.dart
@@ -27,67 +27,79 @@ class EpisodeCommentsCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 CircleAvatar(
                   backgroundImage:
                       NetworkImage(commentItem.comment.user.avatar.large),
                 ),
                 const SizedBox(width: 8),
-                Column(
+                Expanded(child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(commentItem.comment.user.nickname),
-                    Text(Utils.dateFormat(commentItem.comment.createdAt)),
+                    Text(
+                      Utils.dateFormat(commentItem.comment.createdAt),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    BBCodeWidget(bbcode: userComment),
+                    if (commentItem.replies.isNotEmpty)
+                      ListView.builder(
+                        // Don't know why but ohos has bottom padding,
+                        // needs to set to 0 manually.
+                        padding: const EdgeInsets.only(bottom: 0),
+                        physics: const NeverScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        itemCount: commentItem.replies.length,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(left: 48),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    CircleAvatar(
+                                      backgroundImage: NetworkImage(
+                                          commentItem.replies[index].user.avatar.large),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Expanded(child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(commentItem.replies[index].user.nickname),
+                                        Text(
+                                          Utils.dateFormat(
+                                              commentItem.replies[index].createdAt),
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: Theme.of(context).colorScheme.outline,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 8),
+                                        BBCodeWidget(
+                                            bbcode: commentItem.replies[index].comment),
+                                      ],
+                                    ),
+                                    ),
+                                  ],
+                                ),
+
+                              ],
+                            ),
+                          );
+                        },
+                      ),
                   ],
+                ),
                 ),
               ],
             ),
-            const SizedBox(height: 8),
-            BBCodeWidget(bbcode: userComment),
-            if (commentItem.replies.isNotEmpty)
-              ListView.builder(
-                // Don't know why but ohos has bottom padding,
-                // needs to set to 0 manually.
-                padding: const EdgeInsets.only(bottom: 0),
-                physics: const NeverScrollableScrollPhysics(),
-                shrinkWrap: true,
-                itemCount: commentItem.replies.length,
-                itemBuilder: (context, index) {
-                  return Padding(
-                    padding: const EdgeInsets.only(left: 48),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Divider(
-                          color: Theme.of(context).dividerColor.withAlpha(60),
-                        ),
-                        Row(
-                          children: [
-                            CircleAvatar(
-                              backgroundImage: NetworkImage(
-                                  commentItem.replies[index].user.avatar.large),
-                            ),
-                            const SizedBox(width: 8),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(commentItem.replies[index].user.nickname),
-                                Text(
-                                  Utils.dateFormat(
-                                      commentItem.replies[index].createdAt),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 8),
-                        BBCodeWidget(
-                            bbcode: commentItem.replies[index].comment),
-                      ],
-                    ),
-                  );
-                },
-              ),
           ],
         ),
       ),

--- a/lib/bean/card/episode_comments_card.dart
+++ b/lib/bean/card/episode_comments_card.dart
@@ -1,6 +1,8 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:kazumi/bbcode/bbcode_widget.dart';
 import 'package:kazumi/modules/comments/comment_item.dart';
+import 'package:kazumi/pages/player/episode_comment_replies.dart';
 import 'package:kazumi/utils/utils.dart';
 
 class EpisodeCommentsCard extends StatelessWidget {
@@ -11,6 +13,8 @@ class EpisodeCommentsCard extends StatelessWidget {
 
   final EpisodeCommentItem commentItem;
 
+  static const int _maxPreviewReplies = 2;
+
   @override
   Widget build(BuildContext context) {
     // 对 用户评论 做判空操作，如果为空则显示“用户已删除”
@@ -18,6 +22,11 @@ class EpisodeCommentsCard extends StatelessWidget {
     if (userComment.isEmpty) {
       userComment = "<用户已删除>";
     }
+
+    final totalReplies = commentItem.replies.length;
+    final bool hasMoreReplies = totalReplies > _maxPreviewReplies;
+    final int previewCount =
+        math.min(_maxPreviewReplies, totalReplies);
 
     return Card(
       // color: Theme.of(context).colorScheme.secondaryContainer,
@@ -48,65 +57,11 @@ class EpisodeCommentsCard extends StatelessWidget {
                     const SizedBox(height: 8),
                     BBCodeWidget(bbcode: userComment),
                     if (commentItem.replies.isNotEmpty)
-                      ListView.builder(
-                        // Don't know why but ohos has bottom padding,
-                        // needs to set to 0 manually.
-                        padding: const EdgeInsets.only(bottom: 0),
-                        physics: const NeverScrollableScrollPhysics(),
-                        shrinkWrap: true,
-                        itemCount: commentItem.replies.length,
-                        itemBuilder: (context, index) {
-                          return Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                              borderRadius: BorderRadius.only(
-                                topLeft: Radius.circular(index == 0 ? 10 : 0),
-                                topRight: Radius.circular(index == 0 ? 10 : 0),
-                                bottomLeft: Radius.circular(index == commentItem.replies.length - 1 ? 10 : 0),
-                                bottomRight: Radius.circular(index == commentItem.replies.length - 1 ? 10 : 0),
-                              ),
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    CircleAvatar(
-                                      backgroundImage: NetworkImage(
-                                          commentItem.replies[index].user.avatar.large),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Expanded(child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Text(commentItem.replies[index].user.nickname),
-                                        Text(
-                                          Utils.dateFormat(
-                                              commentItem.replies[index].createdAt),
-                                          style: TextStyle(
-                                            fontSize: 12,
-                                            color: Theme.of(context).colorScheme.outline,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    ),
-                                  ],
-                                ),
-                                BBCodeWidget(
-                                    bbcode: commentItem.replies[index].comment),
-                                if (index < commentItem.replies.length - 1)
-                                  Divider(
-                                    height: 16,
-                                    thickness: 1,
-                                    color: Theme.of(context).colorScheme.outlineVariant,
-                                  ),
-                              ],
-                            ),
-                          );
-                        },
+                      _buildRepliesPreview(
+                        context: context,
+                        previewCount: previewCount,
+                        hasMoreReplies: hasMoreReplies,
+                        totalReplies: totalReplies,
                       ),
                   ],
                 ),
@@ -116,6 +71,118 @@ class EpisodeCommentsCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildRepliesPreview({
+    required BuildContext context,
+    required int previewCount,
+    required bool hasMoreReplies,
+    required int totalReplies,
+  }) {
+    final surfaceColor =
+        Theme.of(context).colorScheme.surfaceContainerHighest;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListView.builder(
+          // Don't know why but ohos has bottom padding,
+          // needs to set to 0 manually.
+          padding: const EdgeInsets.only(bottom: 0),
+          physics: const NeverScrollableScrollPhysics(),
+          shrinkWrap: true,
+          itemCount: previewCount,
+          itemBuilder: (context, index) {
+            final bool isFirst = index == 0;
+            final bool isLastVisibleReply = index == previewCount - 1;
+            final bool isBottomOfStack = isLastVisibleReply && !hasMoreReplies;
+            return Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: surfaceColor,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(isFirst ? 10 : 0),
+                  topRight: Radius.circular(isFirst ? 10 : 0),
+                  bottomLeft: Radius.circular(isBottomOfStack ? 10 : 0),
+                  bottomRight: Radius.circular(isBottomOfStack ? 10 : 0),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CircleAvatar(
+                        backgroundImage: NetworkImage(
+                            commentItem.replies[index].user.avatar.large),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(commentItem.replies[index].user.nickname),
+                          Text(
+                            Utils.dateFormat(
+                                commentItem.replies[index].createdAt),
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Theme.of(context).colorScheme.outline,
+                            ),
+                          ),
+                        ],
+                      ),
+                      ),
+                    ],
+                  ),
+                  BBCodeWidget(
+                      bbcode: commentItem.replies[index].comment),
+                  if (!isLastVisibleReply)
+                    Divider(
+                      height: 16,
+                      thickness: 1,
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+        if (hasMoreReplies)
+          Container(
+            width: double.infinity,
+            decoration: BoxDecoration(
+              color: surfaceColor,
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(10),
+                bottomRight: Radius.circular(10),
+              ),
+            ),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 4),
+                  minimumSize: const Size(0, 36),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.only(
+                      bottomLeft: Radius.circular(10),
+                      bottomRight: Radius.circular(10),
+                    ),
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    EpisodeCommentReplies.route(commentItem),
+                  );
+                },
+                child: Text('共 $totalReplies 条回复'),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/bean/card/episode_comments_card.dart
+++ b/lib/bean/card/episode_comments_card.dart
@@ -56,11 +56,20 @@ class EpisodeCommentsCard extends StatelessWidget {
                         shrinkWrap: true,
                         itemCount: commentItem.replies.length,
                         itemBuilder: (context, index) {
-                          return Padding(
-                            padding: const EdgeInsets.only(left: 48),
+                          return Container(
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.only(
+                                topLeft: Radius.circular(index == 0 ? 10 : 0),
+                                topRight: Radius.circular(index == 0 ? 10 : 0),
+                                bottomLeft: Radius.circular(index == commentItem.replies.length - 1 ? 10 : 0),
+                                bottomRight: Radius.circular(index == commentItem.replies.length - 1 ? 10 : 0),
+                              ),
+                            ),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
-                              children: <Widget>[
+                              children: [
                                 Row(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
@@ -81,15 +90,19 @@ class EpisodeCommentsCard extends StatelessWidget {
                                             color: Theme.of(context).colorScheme.outline,
                                           ),
                                         ),
-                                        const SizedBox(height: 8),
-                                        BBCodeWidget(
-                                            bbcode: commentItem.replies[index].comment),
                                       ],
                                     ),
                                     ),
                                   ],
                                 ),
-
+                                BBCodeWidget(
+                                    bbcode: commentItem.replies[index].comment),
+                                if (index < commentItem.replies.length - 1)
+                                  Divider(
+                                    height: 16,
+                                    thickness: 1,
+                                    color: Theme.of(context).colorScheme.outlineVariant,
+                                  ),
                               ],
                             ),
                           );

--- a/lib/pages/player/episode_comment_replies.dart
+++ b/lib/pages/player/episode_comment_replies.dart
@@ -1,0 +1,223 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:kazumi/bbcode/bbcode_widget.dart';
+import 'package:kazumi/modules/comments/comment_item.dart';
+import 'package:kazumi/utils/utils.dart';
+
+class EpisodeCommentReplies extends StatelessWidget {
+  const EpisodeCommentReplies({super.key, required this.commentItem});
+
+  final EpisodeCommentItem commentItem;
+
+  static Route<void> route(EpisodeCommentItem commentItem) {
+    return PageRouteBuilder<void>(
+      transitionDuration: const Duration(milliseconds: 260),
+      reverseTransitionDuration: const Duration(milliseconds: 220),
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return EpisodeCommentReplies(commentItem: commentItem);
+      },
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        final curved = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeOutCubic,
+          reverseCurve: Curves.easeInCubic,
+        );
+        return SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(1, 0),
+            end: Offset.zero,
+          ).animate(curved),
+          child: FadeTransition(
+            opacity: curved,
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String userComment = commentItem.comment.comment;
+    if (userComment.isEmpty) {
+      userComment = "<用户已删除>";
+    }
+
+    return Scaffold(
+      body: SelectionArea(
+        child: Column(
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(
+                    color: Theme.of(context).colorScheme.outline,
+                    width: 0.2,
+                  )
+                )
+              ),
+              child: Row(
+                spacing: 10,
+                children: [
+                  InkWell(
+                    onTap: () => Navigator.of(context).pop(),
+                    child: const Icon(Icons.arrow_back_outlined),
+                  ),
+                  Text('共 ${commentItem.replies.length} 条回复'),
+                ],
+              ),
+            ),
+            Expanded(child: CustomScrollView(
+              scrollBehavior: const ScrollBehavior().copyWith(
+                scrollbars: false,
+                dragDevices: {
+                  PointerDeviceKind.mouse,
+                  PointerDeviceKind.touch,
+                  PointerDeviceKind.trackpad,
+                },
+              ),
+              slivers: [
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        CircleAvatar(
+                          backgroundImage: NetworkImage(
+                              commentItem.comment.user.avatar.large),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Flexible(
+                                    child: Text(
+                                      commentItem.comment.user.nickname,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  _buildMainCommentBadge(context),
+                                ],
+                              ),
+                              Text(
+                                Utils.dateFormat(commentItem.comment.createdAt),
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Theme.of(context).colorScheme.outline,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              BBCodeWidget(bbcode: userComment),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: Divider(
+                    height: 1,
+                    thickness: 1,
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                    child: Text(
+                      '相关回复 共 ${commentItem.replies.length} 条',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                  ),
+                ),
+                SliverPadding(
+                  padding: const EdgeInsets.fromLTRB(12, 8, 12, 16),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                          (context, index) {
+                        final reply = commentItem.replies[index];
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              CircleAvatar(
+                                backgroundImage:
+                                NetworkImage(reply.user.avatar.large),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(reply.user.nickname),
+                                    Text(
+                                      Utils.dateFormat(reply.createdAt),
+                                      style: TextStyle(
+                                        fontSize: 12,
+                                        color:
+                                        Theme.of(context).colorScheme.outline,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    BBCodeWidget(bbcode: reply.comment),
+                                    if (index < commentItem.replies.length - 1)
+                                      Divider(
+                                        height: 16,
+                                        thickness: 1,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .outlineVariant,
+                                      ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                      childCount: commentItem.replies.length,
+                    ),
+                  ),
+                ),
+              ],
+            ))
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 主评论徽标
+  Widget _buildMainCommentBadge(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: scheme.primaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        '主评论',
+        style: TextStyle(
+          fontSize: 11,
+          height: 1.2,
+          color: scheme.onPrimaryContainer,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -31,10 +31,15 @@ class EpisodeCommentsSheet extends StatefulWidget {
 
 class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   final VideoPageController videoPageController =
-      Modular.get<VideoPageController>();
+  Modular.get<VideoPageController>();
   bool commentsQueryTimeout = false;
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
+  GlobalKey<RefreshIndicatorState>();
+
+  /// 嵌套导航器，用于评论回复详情页的路由跳转；
+  /// 推入的路由仅覆盖评论面板区域，而不会遮挡整个视频页面。
+  final GlobalKey<NavigatorState> _nestedNavigatorKey =
+  GlobalKey<NavigatorState>();
 
   /// episode input by [showEpisodeSelection]
   int ep = 0;
@@ -48,7 +53,7 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
     commentsQueryTimeout = false;
     await videoPageController
         .queryBangumiEpisodeCommentsByID(
-            videoPageController.bangumiItem.id, episode)
+        videoPageController.bangumiItem.id, episode)
         .then((_) {
       if (videoPageController.episodeCommentsList.isEmpty && mounted) {
         setState(() {
@@ -211,13 +216,13 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
           title: const Text('输入集数'),
           content: StatefulBuilder(
               builder: (BuildContext context, StateSetter setState) {
-            return TextField(
-              inputFormatters: <TextInputFormatter>[
-                FilteringTextInputFormatter.digitsOnly
-              ],
-              controller: textController,
-            );
-          }),
+                return TextField(
+                  inputFormatters: <TextInputFormatter>[
+                    FilteringTextInputFormatter.digitsOnly
+                  ],
+                  controller: textController,
+                );
+              }),
           actions: [
             TextButton(
               onPressed: () => KazumiDialog.dismiss(),
@@ -250,6 +255,20 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
   @override
   Widget build(BuildContext context) {
     final int episode = EpisodeInfo.of(context)!.episode;
+    return Navigator(
+        key: _nestedNavigatorKey,
+        onGenerateRoute: (settings) {
+          return PageRouteBuilder(
+            settings: settings,
+            transitionDuration: Duration.zero,
+            reverseTransitionDuration: Duration.zero,
+            pageBuilder: (_, __, ___) => _buildCommentsView(episode),
+          );
+        },
+    );
+  }
+
+  Widget _buildCommentsView(int episode) {
     return Scaffold(
       body: RefreshIndicator(
         key: _refreshIndicatorKey,


### PR DESCRIPTION
- 修改为左右内容布局（左侧用户头像，右侧用户昵称、发表时间、评论内容）
- 优化发表时间数据展示效果（使用主题浅灰色、文字缩小）
- 移除回复评论之间的Divider(分割线)，个人觉得缩进的回复内容展示已经可以明确评论之间的回复关系不需要分割线，反而分割线会影响美观

<img width="1162" height="2480" alt="Screenshot_2026-04-21-20-35-42-527_com predidit k" src="https://github.com/user-attachments/assets/1c4a660e-ff3c-4d04-9046-7bbf67ccfbfe" />
<img width="1162" height="2480" alt="Screenshot_2026-04-21-20-35-09-203_com predidit k" src="https://github.com/user-attachments/assets/fb3d0970-852d-4abb-acf6-628e14fe3568" />
