### PR TITLE
feat: add Windows title bar theme synchronization

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -14,6 +14,7 @@ import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/settings/theme_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:kazumi/utils/constants.dart';
+import 'package:flutter/services.dart';
 
 class AppWidget extends StatefulWidget {
   const AppWidget({super.key});
@@ -36,6 +37,15 @@ class _AppWidgetState extends State<AppWidget>
     setPreventClose();
     WidgetsBinding.instance.addObserver(this);
     super.initState();
+
+    // Sync Windows title bar theme on startup and when theme changes
+    if (Platform.isWindows) {
+      final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
+      _syncTitleBarTheme(themeProvider);
+      themeProvider.addListener(() {
+        if (mounted) _syncTitleBarTheme(themeProvider);
+      });
+    }
   }
 
   void setPreventClose() async {
@@ -167,15 +177,24 @@ class _AppWidgetState extends State<AppWidget>
   @override
   Future<void> didChangePlatformBrightness() async {
     super.didChangePlatformBrightness();
-    final ThemeProvider themeProvider = Provider.of<ThemeProvider>(context, listen: false);
-    KazumiLogger().i("Platform brightness changed, themeMode: ${themeProvider.themeMode}");
+    if (Platform.isWindows) {
+      final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
+      _syncTitleBarTheme(themeProvider);
+    }
+  }
 
-    // Only update title bar theme when following system
-    // If user has forced a specific theme, keep title bar consistent with app content
-    if (themeProvider.themeMode == ThemeMode.system && Platform.isWindows) {
-      final brightness = WidgetsBinding.instance.platformDispatcher.platformBrightness;
-      KazumiLogger().i("Updating title bar brightness: $brightness");
-      await windowManager.setBrightness(brightness);
+  /// Sync Windows title bar theme with app theme using native DwmSetWindowAttribute.
+  /// This bypasses the window_manager plugin's registry check to force dark/light
+  /// title bar regardless of system-wide theme setting.
+  Future<void> _syncTitleBarTheme(ThemeProvider themeProvider) async {
+    final bool isDark = themeProvider.isEffectiveDark();
+    try {
+      await const MethodChannel('com.predidit.kazumi/titlebar')
+          .invokeMethod('setImmersiveDarkMode', {'enable': isDark});
+    } catch (_) {
+      // Fallback to window_manager plugin if native channel fails
+      await windowManager.setBrightness(
+          isDark ? Brightness.dark : Brightness.light);
     }
   }
 
@@ -231,9 +250,9 @@ class _AppWidgetState extends State<AppWidget>
       themeProvider.setThemeMode(ThemeMode.system, notify: false);
     }
 
-    // Set Windows title bar theme based on app theme
+    // Sync Windows title bar theme after theme mode is set
     if (Platform.isWindows) {
-      windowManager.setBrightness(themeProvider.isEffectiveDark() ? Brightness.dark : Brightness.light);
+      _syncTitleBarTheme(themeProvider);
     }
 
     themeProvider.setFontFamily(useSystemFont, notify: false);

--- a/lib/pages/settings/theme_settings_page.dart
+++ b/lib/pages/settings/theme_settings_page.dart
@@ -13,7 +13,6 @@ import 'package:kazumi/bean/settings/color_type.dart';
 import 'package:kazumi/utils/utils.dart';
 import 'package:card_settings_ui/card_settings_ui.dart';
 import 'package:provider/provider.dart';
-import 'package:window_manager/window_manager.dart';
 
 class ThemeSettingsPage extends StatefulWidget {
   const ThemeSettingsPage({super.key});
@@ -123,11 +122,6 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
     setState(() {
       defaultThemeMode = theme;
     });
-
-    // Update Windows title bar theme
-    if (Platform.isWindows) {
-      await windowManager.setBrightness(themeProvider.isEffectiveDark() ? Brightness.dark : Brightness.light);
-    }
   }
 
   void updateOledEnhance() {

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -8,6 +8,11 @@
 #include <flutter/standard_method_codec.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <windows.h>
+#include <dwmapi.h>
+
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -53,6 +58,9 @@ bool FlutterWindow::OnCreate() {
 
   // Register Shortcut MethodChannel
   RegisterShortcutChannel();
+
+  // Register TitleBar Theme MethodChannel
+  RegisterTitleBarThemeChannel();
 
   return true;
 }
@@ -173,6 +181,32 @@ void FlutterWindow::RegisterShortcutChannel() {
       result->Success(flutter::EncodableValue(true));
     } else {
       result->Error("Failed", "Failed to create desktop shortcut");
+    }
+  });
+}
+
+// TitleBar Theme MethodChannel setup
+void FlutterWindow::RegisterTitleBarThemeChannel() {
+  auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      flutter_controller_->engine()->messenger(), "com.predidit.kazumi/titlebar",
+      &flutter::StandardMethodCodec::GetInstance());
+
+  channel->SetMethodCallHandler([this](const auto& call, auto result) {
+    if (call.method_name() == "setImmersiveDarkMode") {
+      const auto* arguments = std::get_if<flutter::EncodableMap>(call.arguments());
+      if (arguments) {
+        auto it = arguments->find(flutter::EncodableValue("enable"));
+        if (it != arguments->end()) {
+          BOOL dark_mode = std::get<bool>(it->second) ? TRUE : FALSE;
+          DwmSetWindowAttribute(GetHandle(), DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                &dark_mode, sizeof(dark_mode));
+          result->Success();
+          return;
+        }
+      }
+      result->Error("InvalidArguments", "Missing 'enable' argument");
+    } else {
+      result->NotImplemented();
     }
   });
 }

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -37,6 +37,9 @@ class FlutterWindow : public Win32Window {
 
   // Register Shortcut MethodChannel
   void RegisterShortcutChannel();
+
+  // Register TitleBar Theme MethodChannel
+  void RegisterTitleBarThemeChannel();
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_


### PR DESCRIPTION
由 Qwen 3.6 Plus 生成, fix #1757



<table>
  <td><img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/73462774-a606-46e5-acb8-8a0c470aed89" /></td>
  <td><img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/c67ac07a-e82b-4b45-82df-a48d54cd2f8f" /></td>
  <td><img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/36fe437a-bd8f-44cf-9842-f3e6ec18e9c0" /></td>
</table>



---

Copilot's Summary:

This pull request introduces a new mechanism for synchronizing the Windows title bar theme with the app's theme, using a native Windows API via a custom Flutter MethodChannel. This replaces the previous approach that relied on the `window_manager` plugin, ensuring more reliable and immediate updates to the title bar appearance when the app theme changes or when the system brightness changes. The changes also clean up redundant or now-unnecessary code related to the old approach.

**Windows Title Bar Theme Synchronization:**

* Added a native MethodChannel (`com.predidit.kazumi/titlebar`) to the Windows runner, using `DwmSetWindowAttribute` to set immersive dark mode for the title bar, bypassing registry checks and system-wide theme dependencies. (`windows/runner/flutter_window.cpp`, `windows/runner/flutter_window.h`) [[1]](diffhunk://#diff-f7fbded223eddc67dc75f68c2098da54474927db19561f4a39b7b6758e52913dR11-R15) [[2]](diffhunk://#diff-f7fbded223eddc67dc75f68c2098da54474927db19561f4a39b7b6758e52913dR62-R64) [[3]](diffhunk://#diff-f7fbded223eddc67dc75f68c2098da54474927db19561f4a39b7b6758e52913dR187-R212) [[4]](diffhunk://#diff-3a15bcf5c0bd9f374087dc600603b775d184e1748eecf9a6c8cd5cfde1d87de9R40-R42)
* Updated the Flutter app (`lib/app_widget.dart`) to use the new MethodChannel for syncing the Windows title bar theme on app startup, theme changes, and platform brightness changes. Falls back to the old plugin if the native call fails. [[1]](diffhunk://#diff-a819bc7d2b890c92ef2df734271bed0a2a0e2450da9f52a734b4aa3fb01c7cb2R17) [[2]](diffhunk://#diff-a819bc7d2b890c92ef2df734271bed0a2a0e2450da9f52a734b4aa3fb01c7cb2R40-R48) [[3]](diffhunk://#diff-a819bc7d2b890c92ef2df734271bed0a2a0e2450da9f52a734b4aa3fb01c7cb2L170-R197) [[4]](diffhunk://#diff-a819bc7d2b890c92ef2df734271bed0a2a0e2450da9f52a734b4aa3fb01c7cb2L234-R255)

**Code Cleanup and Refactoring:**

* Removed previous direct calls to `window_manager.setBrightness` from theme settings and theme change handlers, as these responsibilities are now handled by the new native channel. (`lib/pages/settings/theme_settings_page.dart`) [[1]](diffhunk://#diff-22593dd720cdfe3c7b5cdf9efcd43faaa6af77a21a36d4eb143ea0674c112dadL16) [[2]](diffhunk://#diff-22593dd720cdfe3c7b5cdf9efcd43faaa6af77a21a36d4eb143ea0674c112dadL126-L130)