### PR TITLE
feat(search): 添加搜索建议功能

### DIFF
--- a/lib/modules/bangumi/bangumi_netx_item.dart
+++ b/lib/modules/bangumi/bangumi_netx_item.dart
@@ -1,0 +1,97 @@
+class BangumiNetxItem {
+  int id;
+  String name;
+  String nameCn;
+  int type;
+  String info;
+  BangumiNetxRating rating;
+  bool locked;
+  bool nsfw;
+  BangumiNetxImages images;
+
+  BangumiNetxItem({
+    required this.id,
+    required this.name,
+    required this.nameCn,
+    required this.type,
+    required this.info,
+    required this.rating,
+    required this.locked,
+    required this.nsfw,
+    required this.images,
+  });
+
+  factory BangumiNetxItem.fromJson(Map<String, dynamic> json) {
+    return BangumiNetxItem(
+      id: json['id'] ?? 0,
+      name: json['name'] ?? '',
+      nameCn: (json['nameCN'] ?? '').toString(),
+      type: json['type'] ?? 2,
+      info: json['info'] ?? '',
+      rating: BangumiNetxRating.fromJson(json['rating'] ?? {}),
+      locked: json['locked'] ?? false,
+      nsfw: json['nsfw'] ?? false,
+      images: BangumiNetxImages.fromJson(json['images'] ?? {}),
+    );
+  }
+}
+
+class BangumiNetxRating {
+  int rank;
+  List<int> count;
+  double score;
+  int total;
+
+  BangumiNetxRating({
+    required this.rank,
+    required this.count,
+    required this.score,
+    required this.total,
+  });
+
+  factory BangumiNetxRating.fromJson(Map<String, dynamic> json) {
+    final dynamic countData = json['count'];
+    List<int> parsedCount = [];
+    if (countData is List) {
+      parsedCount = countData.map((e) => (e as num).toInt()).toList();
+    } else if (countData is Map<String, dynamic>) {
+      parsedCount = List<int>.generate(
+        10,
+        (i) => ((countData['${i + 1}'] ?? 0) as num).toInt(),
+      );
+    }
+
+    return BangumiNetxRating(
+      rank: (json['rank'] ?? 0) as int,
+      count: parsedCount,
+      score: ((json['score'] ?? 0.0) as num).toDouble(),
+      total: (json['total'] ?? 0) as int,
+    );
+  }
+}
+
+class BangumiNetxImages {
+  String large;
+  String common;
+  String medium;
+  String small;
+  String grid;
+
+  BangumiNetxImages({
+    required this.large,
+    required this.common,
+    required this.medium,
+    required this.small,
+    required this.grid,
+  });
+
+  factory BangumiNetxImages.fromJson(Map<String, dynamic> json) {
+    return BangumiNetxImages(
+      large: json['large'] ?? '',
+      common: json['common'] ?? '',
+      medium: json['medium'] ?? '',
+      small: json['small'] ?? '',
+      grid: json['grid'] ?? '',
+    );
+  }
+}

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -47,6 +47,10 @@ abstract class _SearchPageController with Store {
   @observable
   ObservableList<ResultItem> imageSearchResults = ObservableList.of([]);
 
+  /// 搜索建议结果
+  @observable
+  ObservableList<String> suggestedResults = ObservableList.of([]);
+
   @action
   void loadSearchHistories() {
     final histories = _searchHistoryRepository.getAllHistories();
@@ -107,6 +111,24 @@ abstract class _SearchPageController with Store {
     bangumiList.addAll(result);
     isLoading = false;
     isTimeOut = bangumiList.isEmpty;
+  }
+
+  /// 获取搜索建议
+  @action
+  Future<void> fetchSearchSuggestions(String input) async {
+    if (input.isEmpty) return;
+
+    final parser = SearchParser(input);
+    final keywords = parser.parseKeywords();
+    final String? tag = parser.parseTag();
+    final String? sort = parser.parseSort();
+
+    final results = await BangumiHTTP.bangumiSearchNext(keywords,
+        tags: [if (tag != null) tag], sort: sort ?? 'heat');
+
+    suggestedResults.addAll(results
+        .map((e) => e.nameCn.isNotEmpty ? e.nameCn : e.name)
+        .where((name) => name.isNotEmpty));
   }
 
   @action

--- a/lib/pages/search/search_controller.g.dart
+++ b/lib/pages/search/search_controller.g.dart
@@ -167,6 +167,22 @@ mixin _$SearchPageController on _SearchPageController, Store {
     });
   }
 
+  late final _$suggestedResultsAtom =
+      Atom(name: '_SearchPageController.suggestedResults', context: context);
+
+  @override
+  ObservableList<String> get suggestedResults {
+    _$suggestedResultsAtom.reportRead();
+    return super.suggestedResults;
+  }
+
+  @override
+  set suggestedResults(ObservableList<String> value) {
+    _$suggestedResultsAtom.reportWrite(value, super.suggestedResults, () {
+      super.suggestedResults = value;
+    });
+  }
+
   late final _$searchBangumiAsyncAction =
       AsyncAction('_SearchPageController.searchBangumi', context: context);
 
@@ -174,6 +190,16 @@ mixin _$SearchPageController on _SearchPageController, Store {
   Future<void> searchBangumi(String input, {String type = 'add'}) {
     return _$searchBangumiAsyncAction
         .run(() => super.searchBangumi(input, type: type));
+  }
+
+  late final _$fetchSearchSuggestionsAsyncAction = AsyncAction(
+      '_SearchPageController.fetchSearchSuggestions',
+      context: context);
+
+  @override
+  Future<void> fetchSearchSuggestions(String input) {
+    return _$fetchSearchSuggestionsAsyncAction
+        .run(() => super.fetchSearchSuggestions(input));
   }
 
   late final _$deleteSearchHistoryAsyncAction = AsyncAction(
@@ -269,7 +295,8 @@ bangumiList: ${bangumiList},
 searchHistories: ${searchHistories},
 isImageSearching: ${isImageSearching},
 imageSearchError: ${imageSearchError},
-imageSearchResults: ${imageSearchResults}
+imageSearchResults: ${imageSearchResults},
+suggestedResults: ${suggestedResults}
     ''';
   }
 }

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/bean/card/bangumi_card.dart';
@@ -26,6 +28,8 @@ class _SearchPageState extends State<SearchPage> {
   final SearchPageController searchPageController = SearchPageController();
   final ScrollController scrollController = ScrollController();
 
+  Timer? searchDebounce;
+
   final List<Tab> tabs = [
     Tab(text: "排序方式"),
     Tab(text: "过滤器"),
@@ -36,6 +40,7 @@ class _SearchPageState extends State<SearchPage> {
     super.initState();
     scrollController.addListener(scrollListener);
     searchPageController.loadSearchHistories();
+    searchController.addListener(handleSearchTextChanged);
     if (widget.inputTag != '') {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         final String tagString = 'tag:${Uri.decodeComponent(widget.inputTag)}';
@@ -48,8 +53,17 @@ class _SearchPageState extends State<SearchPage> {
   @override
   void dispose() {
     searchPageController.bangumiList.clear();
+    searchDebounce?.cancel();
     scrollController.removeListener(scrollListener);
     super.dispose();
+  }
+
+  void handleSearchTextChanged() {
+    searchDebounce?.cancel();
+    searchPageController.suggestedResults.clear();
+    searchDebounce = Timer(const Duration(seconds: 2), () {
+      searchPageController.fetchSearchSuggestions(searchController.text);
+    });
   }
 
   void scrollListener() {
@@ -239,10 +253,30 @@ class _SearchPageState extends State<SearchPage> {
                   Observer(
                     builder: (context) {
                       if (controller.text.isNotEmpty) {
-                        return Container(
-                          height: 400,
-                          alignment: Alignment.center,
-                          child: Text("无可用搜索建议，回车以直接检索"),
+                        if (searchPageController.suggestedResults.isEmpty) {
+                          return Container(
+                            height: 400,
+                            alignment: Alignment.center,
+                            child: Text("无可用搜索建议，回车以直接检索"),
+                          );
+                        }
+                        return Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            for (var suggestion in searchPageController.suggestedResults)
+                              ListTile(
+                                title: Text(suggestion),
+                                onTap: () {
+                                  controller.text = suggestion;
+                                  searchPageController.searchBangumi(
+                                      suggestion,
+                                      type: 'init');
+                                  if (searchController.isOpen) {
+                                    searchController.closeView(suggestion);
+                                  }
+                                },
+                              ),
+                          ],
                         );
                       } else {
                         return Column(

--- a/lib/request/api.dart
+++ b/lib/request/api.dart
@@ -50,6 +50,8 @@ class Api {
   static const String bangumiCharacterCommentsByIDNext = '/p1/characters/{0}/comments';
   /// 番剧工作人员信息
   static const String bangumiStaffByIDNext = '/p1/subjects/{0}/staffs/persons';
+  /// 条目搜索
+  static const String bangumiSearchNext = '/p1/search/subjects?limit={1}&offset={2}';
 
   /// DanDanPlay API Domain
   static const String dandanAPIDomain = 'https://api.dandanplay.net';

--- a/lib/request/bangumi.dart
+++ b/lib/request/bangumi.dart
@@ -2,6 +2,7 @@ import 'package:kazumi/utils/logger.dart';
 import 'package:kazumi/request/api.dart';
 import 'package:kazumi/request/request.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/bangumi_netx_item.dart';
 import 'package:kazumi/modules/comments/comment_response.dart';
 import 'package:kazumi/modules/characters/characters_response.dart';
 import 'package:kazumi/modules/bangumi/episode_item.dart';
@@ -199,6 +200,53 @@ class BangumiHTTP {
       }
     } catch (e) {
       KazumiLogger().e('Network: unknown search problem', error: e);
+    }
+    return bangumiList;
+  }
+
+  static Future<List<BangumiNetxItem>> bangumiSearchNext(String keyword,
+      {List<String> tags = const [],
+      int limit = 20,
+      int offset = 0,
+      String sort = 'heat'}) async {
+    List<BangumiNetxItem> bangumiList = [];
+
+    var params = <String, dynamic>{
+      'keyword': keyword,
+      'sort': sort,
+      "filter": {
+        "type": [2],
+        "tag": tags,
+        "rank": (sort == 'rank') ? [">0", "<=99999"] : [">=0", "<=99999"],
+        "nsfw": false
+      },
+    };
+
+    try {
+      final res = await Request().post(
+        Api.formatUrl(
+          Api.bangumiAPINextDomain + Api.bangumiSearchNext,
+          [keyword, limit, offset],
+        ),
+        data: params,
+      );
+      final jsonData = res.data;
+      final jsonList = jsonData['data'];
+      for (dynamic jsonItem in jsonList) {
+        if (jsonItem is Map<String, dynamic>) {
+          try {
+            BangumiNetxItem bangumiItem = BangumiNetxItem.fromJson(jsonItem);
+            if (bangumiItem.nameCn.isNotEmpty || bangumiItem.name.isNotEmpty) {
+              bangumiList.add(bangumiItem);
+            }
+          } catch (e) {
+            KazumiLogger().e('Network: resolve next search results failed',
+                error: e);
+          }
+        }
+      }
+    } catch (e) {
+      KazumiLogger().e('Network: unknown next search problem', error: e);
     }
     return bangumiList;
   }


### PR DESCRIPTION
- 添加新的搜索 API bangumiSearchNext
- 在 SearchPageController 中添加 suggestedResults 观察属性和 fetchSearchSuggestions 方法获取搜索建议数据
- 使用https://next.bgm.tv/p1/search/subjects搜比https://api.bgm.tv/v0/search/subjects返回的数据少，这个因该可以减少对bangumi的压力

<img width="1148" height="853" alt="image" src="https://github.com/user-attachments/assets/4b0f8a96-4b39-42b4-ad68-90ccbda8b424" />
