### PR TITLE
add supplementary search entry

### DIFF
--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -429,10 +429,6 @@ class _SourceSheetState extends State<SourceSheet>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Divider(
-            height: 16,
-            color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
-          ),
           Align(
             alignment: Alignment.centerRight,
             child: Wrap(
@@ -454,7 +450,7 @@ class _SourceSheetState extends State<SourceSheet>
                   style: TextButton.styleFrom(
                     minimumSize: Size.zero,
                     padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     textStyle: Theme.of(context).textTheme.bodySmall,
@@ -466,7 +462,7 @@ class _SourceSheetState extends State<SourceSheet>
                   style: TextButton.styleFrom(
                     minimumSize: Size.zero,
                     padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     textStyle: Theme.of(context).textTheme.bodySmall,

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -417,42 +417,67 @@ class _SourceSheetState extends State<SourceSheet>
     return ListView(
       children: [
         ...cardList,
-        if (cardList.isNotEmpty) buildSearchActionCard(plugin.name),
+        if (cardList.isNotEmpty) showSupplementarySearchEntry(plugin.name),
       ],
     );
   }
 
   /// 构建结果列表底部补充检索入口，便于已有结果不准确时换用别名或手动检索关键词
-  Widget buildSearchActionCard(String pluginName) {
-    return Card(
-      elevation: 0,
-      margin: const EdgeInsets.all(10),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '没有找到想看的结果？',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
+  Widget showSupplementarySearchEntry(String pluginName) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 4, 18, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Divider(
+            height: 16,
+            color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 2,
+              runSpacing: 4,
               children: [
-                GeneralErrorButton(
-                  onPressed: () => showAliasSearchDialog(pluginName),
-                  text: '别名检索',
+                Text(
+                  '结果不准确？',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.color
+                            ?.withValues(alpha: 0.75),
+                      ),
                 ),
-                GeneralErrorButton(
+                TextButton(
+                  style: TextButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                    textStyle: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  onPressed: () => showAliasSearchDialog(pluginName),
+                  child: const Text('别名检索'),
+                ),
+                TextButton(
+                  style: TextButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                    textStyle: Theme.of(context).textTheme.bodySmall,
+                  ),
                   onPressed: () => showCustomSearchDialog(pluginName),
-                  text: '手动检索',
+                  child: const Text('手动检索'),
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -414,7 +414,47 @@ class _SourceSheetState extends State<SourceSheet>
         ],
       );
     }
-    return ListView(children: cardList);
+    return ListView(
+      children: [
+        ...cardList,
+        if (cardList.isNotEmpty) buildSearchActionCard(plugin.name),
+      ],
+    );
+  }
+
+  /// 构建结果列表底部补充检索入口，便于已有结果不准确时换用别名或手动检索关键词
+  Widget buildSearchActionCard(String pluginName) {
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.all(10),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '没有找到想看的结果？',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                GeneralErrorButton(
+                  onPressed: () => showAliasSearchDialog(pluginName),
+                  text: '别名检索',
+                ),
+                GeneralErrorButton(
+                  onPressed: () => showCustomSearchDialog(pluginName),
+                  text: '手动检索',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   void showAliasSearchDialog(String pluginName) {


### PR DESCRIPTION
- 在已有搜索结果的列表底部补充“别名检索”和“手动检索”入口，方便搜索结果不准确时手动重新检索

Related to #1672 #2011 #1954 #1227 #1451

*但是本地检索的记录并不会被复用，重新打开页面时仍然使用默认标题检索，建议加入本地缓存，通过键值对来复用检索关键词（与本次修改无关，只是观察到功能上的缺陷）*