### PR TITLE
adaptive PiP aspect

### DIFF
--- a/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
@@ -31,6 +31,8 @@ class MainActivity: AudioServiceActivity() {
     private var pipActionReceiverRegistered = false
     private var autoEnterPipOnHomeGesture = false
     private var pipInPlayerPage = false
+    private var pipAspectWidth = 16
+    private var pipAspectHeight = 9
 
     private val actionPipPlayPause = "com.predidit.kazumi.pip.PLAY_PAUSE"
     private val actionPipForward = "com.predidit.kazumi.pip.FORWARD"
@@ -96,13 +98,15 @@ class MainActivity: AudioServiceActivity() {
             if (call.method == "isPictureInPictureSupported") {
                 result.success(isPictureInPictureSupported())
             } else if (call.method == "enterPictureInPictureMode") {
-                val width = call.argument<Int>("width") ?: 16
-                val height = call.argument<Int>("height") ?: 9
-                val entered = enterPictureInPicture(width, height)
+                pipAspectWidth = call.argument<Int>("width") ?: pipAspectWidth
+                pipAspectHeight = call.argument<Int>("height") ?: pipAspectHeight
+                val entered = enterPictureInPicture()
                 result.success(entered)
             } else if (call.method == "updatePictureInPictureActions") {
                 val playing = call.argument<Boolean>("playing") ?: false
                 val danmakuEnabled = call.argument<Boolean>("danmakuEnabled") ?: false
+                pipAspectWidth = call.argument<Int>("width") ?: pipAspectWidth
+                pipAspectHeight = call.argument<Int>("height") ?: pipAspectHeight
                 updatePictureInPictureActions(playing, danmakuEnabled)
                 result.success(true)
             } else if (call.method == "setAndroidAutoEnterPIPEnabled") {
@@ -145,14 +149,14 @@ class MainActivity: AudioServiceActivity() {
         return packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
     }
 
-    private fun enterPictureInPicture(width: Int, height: Int): Boolean {
+    private fun enterPictureInPicture(): Boolean {
         if (!isPictureInPictureSupported()) {
             return false
         }
         if (isInPictureInPictureMode) {
             return true
         }
-        return enterPictureInPictureMode(buildPictureInPictureParams(width, height))
+        return enterPictureInPictureMode(buildPictureInPictureParams())
     }
 
     private fun updatePictureInPictureActions(
@@ -167,12 +171,10 @@ class MainActivity: AudioServiceActivity() {
         refreshPictureInPictureParamsIfNeeded()
     }
 
-    private fun buildPictureInPictureParams(width: Int = 16, height: Int = 9): PictureInPictureParams {
-        val safeWidth = if (width > 0) width else 16
-        val safeHeight = if (height > 0) height else 9
+    private fun buildPictureInPictureParams(): PictureInPictureParams {
         val actions = buildPipActions()
         val builder = PictureInPictureParams.Builder()
-            .setAspectRatio(Rational(safeWidth, safeHeight))
+            .setAspectRatio(Rational(pipAspectWidth, pipAspectHeight))
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             builder.setAutoEnterEnabled(autoEnterPipOnHomeGesture && pipInPlayerPage)
             builder.setSeamlessResizeEnabled(false)

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -429,10 +429,6 @@ class _SourceSheetState extends State<SourceSheet>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Divider(
-            height: 16,
-            color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
-          ),
           Align(
             alignment: Alignment.centerRight,
             child: Wrap(
@@ -454,7 +450,7 @@ class _SourceSheetState extends State<SourceSheet>
                   style: TextButton.styleFrom(
                     minimumSize: Size.zero,
                     padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     textStyle: Theme.of(context).textTheme.bodySmall,
@@ -466,7 +462,7 @@ class _SourceSheetState extends State<SourceSheet>
                   style: TextButton.styleFrom(
                     minimumSize: Size.zero,
                     padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     textStyle: Theme.of(context).textTheme.bodySmall,

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -417,42 +417,67 @@ class _SourceSheetState extends State<SourceSheet>
     return ListView(
       children: [
         ...cardList,
-        if (cardList.isNotEmpty) buildSearchActionCard(plugin.name),
+        if (cardList.isNotEmpty) showSupplementarySearchEntry(plugin.name),
       ],
     );
   }
 
   /// 构建结果列表底部补充检索入口，便于已有结果不准确时换用别名或手动检索关键词
-  Widget buildSearchActionCard(String pluginName) {
-    return Card(
-      elevation: 0,
-      margin: const EdgeInsets.all(10),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '没有找到想看的结果？',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
+  Widget showSupplementarySearchEntry(String pluginName) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 4, 18, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Divider(
+            height: 16,
+            color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 2,
+              runSpacing: 4,
               children: [
-                GeneralErrorButton(
-                  onPressed: () => showAliasSearchDialog(pluginName),
-                  text: '别名检索',
+                Text(
+                  '结果不准确？',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.color
+                            ?.withValues(alpha: 0.75),
+                      ),
                 ),
-                GeneralErrorButton(
+                TextButton(
+                  style: TextButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                    textStyle: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  onPressed: () => showAliasSearchDialog(pluginName),
+                  child: const Text('别名检索'),
+                ),
+                TextButton(
+                  style: TextButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                    textStyle: Theme.of(context).textTheme.bodySmall,
+                  ),
                   onPressed: () => showCustomSearchDialog(pluginName),
-                  text: '手动检索',
+                  child: const Text('手动检索'),
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/info/source_sheet.dart
+++ b/lib/pages/info/source_sheet.dart
@@ -414,7 +414,47 @@ class _SourceSheetState extends State<SourceSheet>
         ],
       );
     }
-    return ListView(children: cardList);
+    return ListView(
+      children: [
+        ...cardList,
+        if (cardList.isNotEmpty) buildSearchActionCard(plugin.name),
+      ],
+    );
+  }
+
+  /// 构建结果列表底部补充检索入口，便于已有结果不准确时换用别名或手动检索关键词
+  Widget buildSearchActionCard(String pluginName) {
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.all(10),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '没有找到想看的结果？',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                GeneralErrorButton(
+                  onPressed: () => showAliasSearchDialog(pluginName),
+                  text: '别名检索',
+                ),
+                GeneralErrorButton(
+                  onPressed: () => showCustomSearchDialog(pluginName),
+                  text: '手动检索',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   void showAliasSearchDialog(String pluginName) {

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -127,6 +127,7 @@ class _PlayerItemState extends State<PlayerItem>
   int episodeNum = 0;
   bool? _lastPipPlaying;
   bool? _lastPipDanmakuEnabled;
+  late mobx.ReactionDisposer _playerSizeListener;
 
   late mobx.ReactionDisposer _fullscreenListener;
 
@@ -199,7 +200,26 @@ class _PlayerItemState extends State<PlayerItem>
     await PipUtils.updateAndroidPIPActions(
       playing: playing,
       danmakuEnabled: danmakuEnabled,
+      width: playerController.playerWidth,
+      height: playerController.playerHeight,
     );
+  }
+
+  Future<void> _syncPIPAspectWhenVideoSizeReady() async {
+    if (playerController.playerWidth <= 0 ||
+        playerController.playerHeight <= 0) {
+      return;
+    }
+    if (Platform.isAndroid) {
+      await _updateAndroidPIPActions(force: true);
+      return;
+    }
+    if (Utils.isDesktop() && videoPageController.isPip) {
+      await PipUtils.enterDesktopPIPWindow(
+        width: playerController.playerWidth,
+        height: playerController.playerHeight,
+      );
+    }
   }
 
   void _loadShortcuts() {
@@ -1455,6 +1475,12 @@ class _PlayerItemState extends State<PlayerItem>
         _handleFullscreenChange(context);
       },
     );
+    _playerSizeListener = mobx.reaction<String>(
+      (_) => '${playerController.playerWidth}:${playerController.playerHeight}',
+      (_) {
+        unawaited(_syncPIPAspectWhenVideoSizeReady());
+      },
+    );
     if (Platform.isAndroid) {
       PipUtils.initPipHandler(
         onAction: (action) async {
@@ -1535,6 +1561,7 @@ class _PlayerItemState extends State<PlayerItem>
     // We need to reuse the player after episode is changed and player item is disposed
     // We dispose player after video page disposed
     _fullscreenListener();
+    _playerSizeListener();
     WidgetsBinding.instance.removeObserver(this);
     windowManager.removeListener(this);
     playerTimer?.cancel();
@@ -1604,7 +1631,7 @@ class _PlayerItemState extends State<PlayerItem>
                   }
                 },
                 child: SizedBox(
-                  height: videoPageController.isFullscreen
+                  height: videoPageController.isFullscreen || videoPageController.isPip
                       ? (MediaQuery.of(context).size.height)
                       : (MediaQuery.of(context).size.width * 9.0 / (16.0)),
                   width: MediaQuery.of(context).size.width,
@@ -1682,7 +1709,7 @@ class _PlayerItemState extends State<PlayerItem>
                       top: 0,
                       left: 0,
                       right: 0,
-                      height: videoPageController.isFullscreen
+                      height: videoPageController.isFullscreen || videoPageController.isPip
                           ? MediaQuery.sizeOf(context).height
                           : (MediaQuery.sizeOf(context).width * 9 / 16),
                       child: DanmakuScreen(

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -1120,7 +1120,10 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                           if (videoPageController.isPip) {
                             await PipUtils.exitDesktopPIPWindow();
                           } else {
-                            await PipUtils.enterDesktopPIPWindow();
+                            await PipUtils.enterDesktopPIPWindow(
+                              width: playerController.playerWidth,
+                              height: playerController.playerHeight,
+                            );
                           }
                           videoPageController.isPip = !videoPageController.isPip;
                           return;
@@ -1134,8 +1137,13 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                         await PipUtils.updateAndroidPIPActions(
                           playing: playerController.playing,
                           danmakuEnabled: playerController.danmakuOn,
+                          width: playerController.playerWidth,
+                          height: playerController.playerHeight,
                         );
-                        final bool entered = await PipUtils.enterAndroidPIPWindow();
+                        final bool entered = await PipUtils.enterAndroidPIPWindow(
+                          width: playerController.playerWidth,
+                          height: playerController.playerHeight,
+                        );
                         if (!entered) {
                           KazumiDialog.showToast(message: '进入画中画失败');
                         }

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -570,7 +570,11 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                       if (videoPageController.isPip) {
                         await PipUtils.exitDesktopPIPWindow();
                       } else {
-                        await PipUtils.enterDesktopPIPWindow();
+                        // 进入画中画时使用播放源比例，避免窗口比例与视频比例不一致产生黑边
+                        await PipUtils.enterDesktopPIPWindow(
+                          width: playerController.playerWidth,
+                          height: playerController.playerHeight,
+                        );
                       }
                       videoPageController.isPip = !videoPageController.isPip;
                       return;
@@ -583,8 +587,13 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                     await PipUtils.updateAndroidPIPActions(
                       playing: playerController.playing,
                       danmakuEnabled: playerController.danmakuOn,
+                      width: playerController.playerWidth,
+                      height: playerController.playerHeight,
                     );
-                    final bool entered = await PipUtils.enterAndroidPIPWindow();
+                    final bool entered = await PipUtils.enterAndroidPIPWindow(
+                      width: playerController.playerWidth,
+                      height: playerController.playerHeight,
+                    );
                     if (!entered) {
                       KazumiDialog.showToast(message: '进入画中画失败');
                     }

--- a/lib/utils/pip_utils.dart
+++ b/lib/utils/pip_utils.dart
@@ -8,6 +8,15 @@ import 'package:window_manager/window_manager.dart';
 class PipUtils {
   static bool androidPIPInited = false;
 
+  // 比例约分
+  static Size getPIPAspectSize({required int width, required int height}) {
+    if (width <= 0 || height <= 0) {
+      return const Size(16, 9);
+    }
+    final int divisor = width.gcd(height);
+    return Size(width / divisor, height / divisor);
+  }
+
   static Future<bool> isAndroidPIPSupported() async {
     if (!Platform.isAndroid) {
       return false;
@@ -28,12 +37,13 @@ class PipUtils {
     if (!Platform.isAndroid) {
       return false;
     }
+    final Size aspectSize = getPIPAspectSize(width: width, height: height);
     const pipChannel = MethodChannel('com.predidit.kazumi/pip');
     try {
       final bool? entered =
           await pipChannel.invokeMethod('enterPictureInPictureMode', {
-        'width': width,
-        'height': height,
+        'width': aspectSize.width.toInt(),
+        'height': aspectSize.height.toInt(),
       });
       return entered ?? false;
     } on PlatformException catch (e) {
@@ -45,15 +55,20 @@ class PipUtils {
   static Future<void> updateAndroidPIPActions({
     required bool playing,
     required bool danmakuEnabled,
+    int width = 16,
+    int height = 9,
   }) async {
     if (!Platform.isAndroid) {
       return;
     }
+    final Size aspectSize = getPIPAspectSize(width: width, height: height);
     const pipChannel = MethodChannel('com.predidit.kazumi/pip');
     try {
       await pipChannel.invokeMethod('updatePictureInPictureActions', {
         'playing': playing,
         'danmakuEnabled': danmakuEnabled,
+        'width': aspectSize.width.toInt(),
+        'height': aspectSize.height.toInt(),
       });
     } on PlatformException catch (e) {
       KazumiLogger().e("Failed to update Android PIP actions: '${e.message}'.");
@@ -89,16 +104,22 @@ class PipUtils {
     }
   }
 
-  // 进入桌面设备小窗模式
-  static Future<void> enterDesktopPIPWindow() async {
+  // 进入桌面设备小窗模式，并用播放源比例固定窗口宽高比
+  static Future<void> enterDesktopPIPWindow(
+      {int width = 16, int height = 9}) async {
+    final Size aspectSize = getPIPAspectSize(width: width, height: height);
+    final double aspectRatio = aspectSize.width / aspectSize.height;
+    const double pipWidth = 480;
     await windowManager.setAlwaysOnTop(true);
-    await windowManager.setSize(const Size(480, 270));
+    await windowManager.setAspectRatio(aspectRatio);
+    await windowManager.setSize(Size(pipWidth, pipWidth / aspectRatio));
   }
 
   // 退出桌面设备小窗模式
   static Future<void> exitDesktopPIPWindow() async {
     bool isLowResolution = await Utils.isLowResolution();
     await windowManager.setAlwaysOnTop(false);
+    await windowManager.setAspectRatio(0);
     await windowManager.setSize(
         isLowResolution ? const Size(800, 600) : const Size(1280, 860));
     await windowManager.center();


### PR DESCRIPTION
- 根据播放源的实际画面比例设置“画中画”窗口比例
  - 测试了老动画《高达 seed》的4:3比例，理论上也支持宽屏等其他非16:9比例
- 固定桌面端“画中画”状态下的窗口比例，使播放画面全屏窗口，不再产生黑色背景区域
  - 修复了原“画中画”的交互问题，原“画中画”模式中仍然继承播放界面的布局设置逻辑，即宽高比小于1时出现选集的栏位，而画中画的本质需求是产生一个固定在顶部的无边框的纯播放画面小窗，原实现仅满足了固定于前端的要求，如需保留原本功能，应当如图改为提供一个直接“固定在最前端”的按钮而非“画中画”<img width="147" height="115" alt="image" src="https://github.com/user-attachments/assets/2de3a018-1062-4802-89a0-efd5fce223db" />

*因无弹幕 API，未测试新实现下的弹幕效果，android 与 windows11 平台已经过测试*

*另外有关最小窗口大小应该进行限制，我在测试中发现播放器没又设置最小窗口大小，导致小窗时 UI 在右侧产生 overflow，建议最小窗口宽度设置为328，可以保留一定的鼠标拖拽区域，但是这里存在的问题我会在一处 issue 中提及*