### PR TITLE
Enhance version check update 

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -218,12 +218,15 @@ class Utils {
   static bool needUpdate(localVersion, remoteVersion) {
     List<String> localVersionList = localVersion.split('.');
     List<String> remoteVersionList = remoteVersion.split('.');
-    for (int i = 0; i < localVersionList.length; i++) {
-      int localVersion = int.parse(localVersionList[i]);
-      int remoteVersion = int.parse(remoteVersionList[i]);
-      if (remoteVersion > localVersion) {
+    final maxLength = max(localVersionList.length, remoteVersionList.length);
+    for (int i = 0; i < maxLength; i++) {
+      final int localSegment =
+          i < localVersionList.length ? int.parse(localVersionList[i]) : 0;
+      final int remoteSegment =
+          i < remoteVersionList.length ? int.parse(remoteVersionList[i]) : 0;
+      if (remoteSegment > localSegment) {
         return true;
-      } else if (remoteVersion < localVersion) {
+      } else if (remoteSegment < localSegment) {
         return false;
       }
     }


### PR DESCRIPTION
当前检查版本的实现方式不太灵活，若远程版本号段数多于本地，多余部分会被忽略；若本地段数多于远程，则可能导致数据越界，导致检查更新失败。此次改动可以让版本发布更加灵活。

相关讨论：https://github.com/Predidit/Kazumi/pull/2001#discussion_r3173315793

