### PR TITLE
fix(bangumi): imported items count missing

### DIFF
--- a/lib/modules/bangumi/bangumi_collection.dart
+++ b/lib/modules/bangumi/bangumi_collection.dart
@@ -68,7 +68,7 @@ class BangumiCollection {
         'rank': rank,
         'score': score,
         'total': 0,
-        'count': List<int>.filled(10, 0),
+        'count': <int>[],
       },
       'info': '',
     });

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -55,8 +55,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     final votesCount = bangumiItem.votesCount;
     final missingVoteDistribution = votesCount.isEmpty ||
         bangumiItem.votes <= 0 ||
-        votesCount.length < 10 ||
-        votesCount.every((count) => count == 0);
+        votesCount.length < 10;
     return bangumiItem.summary == '' || missingVoteDistribution;
   }
 

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -51,6 +51,15 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
 
   final inputBangumiIten = Modular.args.data as BangumiItem;
 
+  bool _needsBangumiInfoRefresh(BangumiItem bangumiItem) {
+    final votesCount = bangumiItem.votesCount;
+    final missingVoteDistribution = votesCount.isEmpty ||
+        bangumiItem.votes <= 0 ||
+        votesCount.length < 10 ||
+        votesCount.every((count) => count == 0);
+    return bangumiItem.summary == '' || missingVoteDistribution;
+  }
+
   Future<void> loadCharacters() async {
     if (charactersIsLoading) return;
     setState(() {
@@ -150,8 +159,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     // Because the gap between different bangumi API response is too large, sometimes we need to query the bangumi info again
     // We need the type parameter to determine whether to attach the new data to the old data
     // We can't generally replace the old data with the new data, because the old data contains images url, update them will cause the image to reload and flicker
-    if (infoController.bangumiItem.summary == '' ||
-        infoController.bangumiItem.votesCount.isEmpty) {
+    if (_needsBangumiInfoRefresh(infoController.bangumiItem)) {
       queryBangumiInfoByID(infoController.bangumiItem.id, type: 'attach');
     }
     sourceTabController =


### PR DESCRIPTION
## 原因 

分页接口无评分人数和透视图：


```json
{
  "data": [
    {
      "subject": {
        "score": 6.9,
        "type": 2,
        "id": 424573,
        "eps": 12,
        "volumes": 0,
        "collection_total": 13964,
        "rank": 2889
      },
      "subject_id": 424573
    }
  ]
}
```

详情接口才有

```json
{
  "rating": {
    "rank": 2889,
    "total": 6325,
    "count": {
      "1": 12,
      "2": 15,
      "3": 31,
      "4": 94,
      "5": 297,
      "6": 1354,
      "7": 2763,
      "8": 1522,
      "9": 179,
      "10": 58
    },
    "score": 6.9
  }
}
```

考虑同步速度和接口频次（翻倍），不考虑在同步逻辑中加入详情请求补齐这部分数据。

## 本次改动

1. （新同步）取消同步 Bangumi 序列化全 0 的逻辑，初始化空数组；
2. （已存在）增加刷新条目补齐数据的判定条件；（评分人数为 0 刷新）

## 相关ISSUE 

- https://github.com/Predidit/Kazumi/issues/2034