### PR TITLE
fix: add user-selected read-only entitlement for file access

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
     <true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
     <true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
修复Macos无法选择本地图片问题