### PR TITLE
fix(macos): prevent click-through on inactive window

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -20,4 +20,17 @@ class MainFlutterWindow: NSWindow {
     super.order(place, relativeTo: otherWin)
     hiddenWindowAtLaunch()
   }
+
+  override func sendEvent(_ event: NSEvent) {
+    if !isKeyWindow,
+       event.type == .leftMouseDown || event.type == .rightMouseDown || event.type == .otherMouseDown,
+       let contentView = self.contentView,
+       let hit = contentView.superview?.hitTest(event.locationInWindow),
+       hit == contentView || hit.isDescendant(of: contentView) {
+      NSApp.activate(ignoringOtherApps: true)
+      self.makeKeyAndOrderFront(nil)
+      return
+    }
+    super.sendEvent(event)
+  }
 }


### PR DESCRIPTION
在 macOS 上，当 Kazumi 窗口失去焦点时，点击窗口内部的 Flutter 控件会直接触发交互（例如意外跳转页面、打开番剧详情、点击或暂停当前播放）。

这与 macOS 原生应用的惯例不一致——Finder、Safari、系统设置等应用在非激活状态下被点击时，首次点击只应激活窗口，不应传递给内容区域。