### PR TITLE
feat: integrate download functionality into bangumi history card

### DIFF
--- a/lib/bean/card/bangumi_history_card.dart
+++ b/lib/bean/card/bangumi_history_card.dart
@@ -4,9 +4,10 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/widget/collect_button.dart';
+import 'package:kazumi/modules/download/download_module.dart';
 import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/pages/collect/collect_controller.dart';
-import 'package:kazumi/pages/history/history_controller.dart';
+import 'package:kazumi/pages/download/download_controller.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 import 'package:kazumi/plugins/plugins.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
@@ -34,12 +35,57 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
   final VideoPageController videoPageController =
       Modular.get<VideoPageController>();
   final PluginsController pluginsController = Modular.get<PluginsController>();
-  final HistoryController historyController = Modular.get<HistoryController>();
   final CollectController collectController = Modular.get<CollectController>();
+  final DownloadController downloadController =
+      Modular.get<DownloadController>();
+
+  bool _openOfflineFallback() {
+    final downloadedEpisodes = downloadController.getCompletedEpisodes(
+      widget.historyItem.bangumiItem.id,
+      widget.historyItem.adapterName,
+    );
+    DownloadEpisode? episode;
+    for (final item in downloadedEpisodes) {
+      if (item.episodeNumber == widget.historyItem.lastWatchEpisode) {
+        episode = item;
+        break;
+      }
+    }
+    if (episode == null) {
+      return false;
+    }
+    final localPath = downloadController.getLocalVideoPath(
+      widget.historyItem.bangumiItem.id,
+      widget.historyItem.adapterName,
+      episode.episodeNumber,
+    );
+    if (localPath == null) {
+      return false;
+    }
+
+    videoPageController.initForOfflinePlayback(
+      bangumiItem: widget.historyItem.bangumiItem,
+      pluginName: widget.historyItem.adapterName,
+      episodeNumber: episode.episodeNumber,
+      episodeName: episode.episodeName,
+      road: episode.road,
+      videoPath: localPath,
+      downloadedEpisodes: downloadedEpisodes,
+    );
+    Modular.to.pushNamed('/video/');
+    return true;
+  }
 
   Future<void> _onTap() async {
     if (widget.showDelete) {
       KazumiDialog.showToast(message: '编辑模式');
+      return;
+    }
+    if (widget.historyItem.lastSrc.isEmpty) {
+      if (_openOfflineFallback()) {
+        return;
+      }
+      KazumiDialog.showToast(message: '未找到关联番剧源或本地下载');
       return;
     }
     KazumiDialog.showLoading(
@@ -63,14 +109,13 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
       return;
     }
     videoPageController.bangumiItem = widget.historyItem.bangumiItem;
-    videoPageController.title =
-        widget.historyItem.bangumiItem.nameCn == ''
-            ? widget.historyItem.bangumiItem.name
-            : widget.historyItem.bangumiItem.nameCn;
+    videoPageController.title = widget.historyItem.bangumiItem.nameCn == ''
+        ? widget.historyItem.bangumiItem.name
+        : widget.historyItem.bangumiItem.nameCn;
     videoPageController.src = widget.historyItem.lastSrc;
     try {
-      await videoPageController.queryRoads(widget.historyItem.lastSrc,
-          videoPageController.currentPlugin.name);
+      await videoPageController.queryRoads(
+          widget.historyItem.lastSrc, videoPageController.currentPlugin.name);
       KazumiDialog.dismiss();
       Modular.to.pushNamed('/video/');
     } catch (_) {
@@ -88,10 +133,9 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
     final String title = widget.historyItem.bangumiItem.nameCn == ''
         ? widget.historyItem.bangumiItem.name
         : widget.historyItem.bangumiItem.nameCn;
-    final String episodeText =
-        widget.historyItem.lastWatchEpisodeName.isEmpty
-            ? '第${widget.historyItem.lastWatchEpisode}话'
-            : widget.historyItem.lastWatchEpisodeName;
+    final String episodeText = widget.historyItem.lastWatchEpisodeName.isEmpty
+        ? '第${widget.historyItem.lastWatchEpisode}话'
+        : widget.historyItem.lastWatchEpisodeName;
 
     return Dismissible(
       key: ValueKey(widget.historyItem.key),
@@ -203,8 +247,11 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
                             ),
                             const SizedBox(width: 4),
                             Text(
-                              Utils.formatTimestampToRelativeTime(
-                                  widget.historyItem.lastWatchTime.millisecondsSinceEpoch ~/ 1000),
+                              Utils.formatTimestampToRelativeTime(widget
+                                      .historyItem
+                                      .lastWatchTime
+                                      .millisecondsSinceEpoch ~/
+                                  1000),
                               style: theme.textTheme.labelSmall?.copyWith(
                                 color: colorScheme.outline,
                               ),

--- a/lib/modules/download/download_module.dart
+++ b/lib/modules/download/download_module.dart
@@ -22,16 +22,14 @@ class DownloadRecord {
   @HiveField(5)
   DateTime createdAt;
 
+  @HiveField(6, defaultValue: '')
+  String sourceUrl;
+
   String get key => '${pluginName}_$bangumiId';
 
-  DownloadRecord(
-    this.bangumiId,
-    this.bangumiName,
-    this.bangumiCover,
-    this.pluginName,
-    this.episodes,
-    this.createdAt,
-  );
+  DownloadRecord(this.bangumiId, this.bangumiName, this.bangumiCover,
+      this.pluginName, this.episodes, this.createdAt,
+      {this.sourceUrl = ''});
 }
 
 @HiveType(typeId: 8)

--- a/lib/modules/download/download_module.g.dart
+++ b/lib/modules/download/download_module.g.dart
@@ -23,13 +23,14 @@ class DownloadRecordAdapter extends TypeAdapter<DownloadRecord> {
       fields[3] as String,
       (fields[4] as Map).cast<int, DownloadEpisode>(),
       fields[5] as DateTime,
+      sourceUrl: fields[6] == null ? '' : fields[6] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, DownloadRecord obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.bangumiId)
       ..writeByte(1)
@@ -41,7 +42,9 @@ class DownloadRecordAdapter extends TypeAdapter<DownloadRecord> {
       ..writeByte(4)
       ..write(obj.episodes)
       ..writeByte(5)
-      ..write(obj.createdAt);
+      ..write(obj.createdAt)
+      ..writeByte(6)
+      ..write(obj.sourceUrl);
   }
 
   @override

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -281,6 +281,7 @@ abstract class _DownloadController with Store {
         ),
       ),
       record.createdAt,
+      sourceUrl: record.sourceUrl,
     );
   }
 
@@ -439,6 +440,7 @@ abstract class _DownloadController with Store {
     required String episodeName,
     required int road,
     required String episodePageUrl,
+    String sourceUrl = '',
   }) async {
     final recordKey = '${pluginName}_$bangumiId';
 
@@ -450,11 +452,21 @@ abstract class _DownloadController with Store {
           pluginName,
           {},
           DateTime.now(),
+          sourceUrl: sourceUrl,
         );
+
+    final sourceUrlUpdated = record.sourceUrl.isEmpty && sourceUrl.isNotEmpty;
+    if (sourceUrlUpdated) {
+      record.sourceUrl = sourceUrl;
+    }
 
     if (episodePageUrl.isNotEmpty) {
       for (final entry in record.episodes.entries) {
         if (entry.value.episodePageUrl == episodePageUrl) {
+          if (sourceUrlUpdated) {
+            await _repository.putRecord(record);
+            refreshRecords();
+          }
           KazumiLogger().i(
               'DownloadController: episode URL already exists at position ${entry.key}, skipping');
           return;

--- a/lib/pages/download/download_episode_sheet.dart
+++ b/lib/pages/download/download_episode_sheet.dart
@@ -247,6 +247,7 @@ class _DownloadEpisodeSheetState extends State<DownloadEpisodeSheet> {
         episodeName: identifier,
         road: widget.road,
         episodePageUrl: episodePageUrl,
+        sourceUrl: videoPageController.src,
       );
     }
 

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -887,19 +887,20 @@ class _PlayerItemState extends State<PlayerItem>
         });
       }
       // 历史记录相关
-      if (playerController.playerPlaying &&
-          !videoPageController.loading &&
-          !videoPageController.isOfflineMode) {
+      if (playerController.playerPlaying && !videoPageController.loading) {
         final pluginName = videoPageController.isOfflineMode
             ? videoPageController.offlinePluginName
             : videoPageController.currentPlugin.name;
+        final historySource = videoPageController.isOfflineMode
+            ? videoPageController.offlineHistorySourceUrl
+            : videoPageController.src;
         historyController.updateHistory(
             videoPageController.actualEpisodeNumber,
             videoPageController.currentRoad,
             pluginName,
             videoPageController.bangumiItem,
             playerController.playerPosition,
-            videoPageController.src,
+            historySource,
             videoPageController.roadList[videoPageController.currentRoad]
                 .identifier[videoPageController.currentEpisode - 1]);
       }

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -170,6 +170,16 @@ abstract class _VideoPageController with Store {
 
   String get offlinePluginName => _offlinePluginName;
 
+  String get offlineHistorySourceUrl {
+    if (!isOfflineMode) {
+      return src;
+    }
+    return downloadRepository
+            .getRecordByBangumiId(bangumiItem.id, _offlinePluginName)
+            ?.sourceUrl ??
+        '';
+  }
+
   /// 获取当前实际的集数编号
   /// 在线模式下直接返回 currentEpisode
   /// 离线模式下从 roadList.data 中获取实际的 episodeNumber
@@ -191,7 +201,7 @@ abstract class _VideoPageController with Store {
     errorMessage = null;
 
     if (isOfflineMode) {
-      await _changeOfflineEpisode(episode, 0);
+      await _changeOfflineEpisode(episode, offset);
       return;
     }
 

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -127,6 +127,14 @@ class _VideoPageState extends State<VideoPage>
     videoPageController.showTabBody = true;
     videoPageController.historyOffset = 0;
     currentRoad = videoPageController.currentRoad;
+    final progress = historyController.findProgress(
+      videoPageController.bangumiItem,
+      videoPageController.offlinePluginName,
+      videoPageController.actualEpisodeNumber,
+    );
+    if (progress != null && playResume) {
+      videoPageController.historyOffset = progress.progress.inSeconds;
+    }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (videoPageController.offlineVideoPath != null) {
@@ -282,6 +290,20 @@ class _VideoPageState extends State<VideoPage>
     videoPageController.episodeInfo.reset();
     videoPageController.episodeCommentsList.clear();
     await playerController.stop();
+    if (videoPageController.isOfflineMode && offset == 0 && playResume) {
+      final actualEpisodeNumber = int.tryParse(
+            videoPageController.roadList[currentRoad].data[episode - 1],
+          ) ??
+          episode;
+      final progress = historyController.findProgress(
+        videoPageController.bangumiItem,
+        videoPageController.offlinePluginName,
+        actualEpisodeNumber,
+      );
+      if (progress != null) {
+        offset = progress.progress.inSeconds;
+      }
+    }
     await videoPageController.changeEpisode(episode,
         currentRoad: currentRoad, offset: offset);
   }


### PR DESCRIPTION
- Added DownloadController to manage offline playback of downloaded episodes.
- Implemented logic to handle offline fallback when no source is available.
- Updated DownloadRecord to include sourceUrl for tracking download origins.
- Enhanced video playback history tracking with source URL adjustments.
- Refactored video controller to support offline mode and resume playback from last watched position.

<img width="1024" height="680" alt="动画2" src="https://github.com/user-attachments/assets/e7d05eaf-4f09-4f71-a0ab-a41d2ac3bcba" />