### PR TITLE
fix(macos): 最小化到托盘后阻止应用自动 terminate

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -6,7 +6,7 @@ import AVKit
 @main
 class AppDelegate: FlutterAppDelegate {
     override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return true
+        return false
     }
     
     override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {


### PR DESCRIPTION
## 问题描述

macOS 上点击主窗口关闭按钮 (X) 后选择「最小化至托盘」，应用并不会驻留在托盘里，而是直接退出。在 \`flutter run\` (debug) 下表现为 \`Lost connection to device\`，release 下表现为静默退出。

复现步骤：
1. 启动 Kazumi (macOS)
2. 点击主窗口左上角红色关闭按钮
3. 在弹出的「退出确认」对话框中选择「最小化至托盘」
4. 观察：应用进程立即结束，托盘里也没有图标可以唤回窗口

## 根本原因

\`AppDelegate.applicationShouldTerminateAfterLastWindowClosed\` 返回 \`true\`，意味着「最后一个可见窗口消失后自动 terminate 应用」。

但 Kazumi 是托盘应用，调用链如下：
1. 用户点 X → \`setPreventClose(true)\` 拦截关闭 → 弹出确认对话框
2. 用户选「最小化至托盘」→ Dart 侧调用 \`windowManager.hide()\`
3. 原生侧 \`mainWindow.orderOut(nil)\` 隐藏主窗口
4. 此时 NSApp 检测到无可见窗口，触发 \`applicationShouldTerminateAfterLastWindowClosed\`
5. 原实现返回 \`true\` → NSApp 调用 \`terminate(_:)\` → 进程结束

托盘应用的设计本意是「窗口可关、进程驻留、仅通过托盘菜单的『退出 Kazumi』才真正结束」，应当返回 \`false\` 才符合该语义。

## 修复方法

将 \`applicationShouldTerminateAfterLastWindowClosed\` 改为返回 \`false\`。

## 验证

修复后：
- ✅ 点 X → 最小化至托盘，窗口隐藏，应用进程仍在
- ✅ 点托盘图标 / 托盘菜单「显示窗口」可唤回窗口
- ✅ 托盘菜单「退出 Kazumi」仍可正常退出
- ✅ 「退出确认」对话框中选「退出 Kazumi」仍可正常退出（走 \`exit(0)\`）

## 测试环境

- macOS 15 (Darwin 25.4.0)
- Flutter 3.44.0
- Debug + Release 均验证通过