### PR TITLE
feat: add Telegram group link to About page

### DIFF
--- a/lib/pages/about/about_page.dart
+++ b/lib/pages/about/about_page.dart
@@ -214,6 +214,21 @@ class _AboutPageState extends State<AboutPage> {
                 ),
               ],
             ),
+            SettingsSection(
+              title: Text('社区', style: TextStyle(fontFamily: fontFamily)),
+              tiles: [
+                SettingsTile.navigation(
+                  onPressed: (_) {
+                    launchUrl(Uri.parse(ApiEndpoints.telegramGroup),
+                        mode: LaunchMode.externalApplication);
+                  },
+                  title: Text('Telegram', style: TextStyle(fontFamily: fontFamily)),
+                  description: Text('Kazumi 官方 Telegram 群组',
+                      style: TextStyle(fontFamily: fontFamily)),
+                  value: Text('点击加入', style: TextStyle(fontFamily: fontFamily)),
+                ),
+              ],
+            ),
             if (Utils.isDesktop()) // 之后如果有非桌面平台的新选项可以移除
               SettingsSection(
                 title: Text('默认行为', style: TextStyle(fontFamily: fontFamily)),

--- a/lib/request/config/api_endpoints.dart
+++ b/lib/request/config/api_endpoints.dart
@@ -34,6 +34,9 @@ class ApiEndpoints {
   /// bangumi API Domain
   static const String bangumiAPIDomain = 'https://api.bgm.tv';
 
+  /// Telegram 群组
+  static const String telegramGroup = 'https://t.me/kazumi_app';
+
   /// 番剧信息
   static const String bangumiInfoByID = '/v0/subjects/{0}';
 


### PR DESCRIPTION
What's Changed:
1. 在关于页添加新的`社区`部分以及 Telegram 群组按钮及其对应端点

---

_by 自动补全_