### PR TITLE
feat(darwin): expand SPM coverage to volume_controller + media_kit + inappwebview

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -631,10 +631,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_volume_controller
-      sha256: "22edb0993ad03ecbc8d1164daeb5b39d798d409625db692675a86889403b1532"
+      sha256: "27b95004d8abd7c6b24a63e555d721ef5f958fbe54551246567b72321494c6c8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "2.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -517,10 +517,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview_android
-      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
+      sha256: "8dfb76bd4e507112c3942c2272eeb01fab2e42be11374e5eb226f58698e7a04b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_internal_annotations:
     dependency: transitive
     description:
@@ -533,26 +533,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview_ios
-      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
+      sha256: ae8a78829398771be863aa3c8804a9d40728e1815e66c9c966f86d2cc3ae4fd9
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_macos:
     dependency: "direct main"
     description:
       name: flutter_inappwebview_macos
-      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
+      sha256: "545148cb5c46475ce669ab21621e9f2ad66e05f8e80b2cf49d4018879ab52393"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_platform_interface:
     dependency: "direct main"
     description:
       name: flutter_inappwebview_platform_interface
-      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
+      sha256: e3522c76e6760d1c0a9ff690e30e1503f226783d3277fa4d26675911977e9766
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0+1"
+    version: "1.4.0-beta.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -924,8 +924,8 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.1.11"
@@ -933,8 +933,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/android/media_kit_libs_android_video"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.3.6"
@@ -942,8 +942,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/ios/media_kit_libs_ios_video"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.1.4"
@@ -951,8 +951,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/linux/media_kit_libs_linux"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.1.3"
@@ -960,8 +960,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/macos/media_kit_libs_macos_video"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.1.4"
@@ -969,8 +969,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/ohos/media_kit_libs_ohos"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.0.0"
@@ -978,8 +978,8 @@ packages:
     dependency: "direct main"
     description:
       path: "libs/universal/media_kit_libs_video"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.0.5"
@@ -987,8 +987,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "libs/windows/media_kit_libs_windows_video"
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.0.10"
@@ -996,8 +996,8 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit_video
-      ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
-      resolved-ref: "21aacaf9600c4bd00f2a3c57310363bc0cc9597f"
+      ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
+      resolved-ref: "13b332ad3fd4cd5d84c64670eceda48a6d54504e"
       url: "https://github.com/Predidit/media-kit.git"
     source: git
     version: "1.2.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,49 +115,49 @@ dependencies:
   media_kit:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./media_kit
   media_kit_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./media_kit_video
   media_kit_libs_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/universal/media_kit_libs_video
 
 dependency_overrides:
   media_kit_libs_linux:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/linux/media_kit_libs_linux
   media_kit_libs_ios_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/ios/media_kit_libs_ios_video
   media_kit_libs_android_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/android/media_kit_libs_android_video
   media_kit_libs_windows_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/windows/media_kit_libs_windows_video
   media_kit_libs_macos_video:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/macos/media_kit_libs_macos_video
   media_kit_libs_ohos:
     git:
       url: https://github.com/Predidit/media-kit.git
-      ref: 21aacaf9600c4bd00f2a3c57310363bc0cc9597f
+      ref: 13b332ad3fd4cd5d84c64670eceda48a6d54504e
       path: ./libs/ohos/media_kit_libs_ohos
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   # fvp: ^0.28.0
   # video_player: ^2.9.1
 
-  flutter_volume_controller: ^1.3.2
+  flutter_volume_controller: ^2.0.0
   audio_video_progress_bar: ^2.0.2
   audio_service: ^0.18.15
   audio_service_mpris:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,10 +93,10 @@ dependencies:
   fl_chart: ^1.1.1
   flutter_foreground_task: ^9.0.0
   skeletonizer: ^2.1.2
-  flutter_inappwebview_platform_interface: ^1.3.0+1
-  flutter_inappwebview_ios: ^1.1.2
-  flutter_inappwebview_macos: ^1.1.2
-  flutter_inappwebview_android: ^1.1.3
+  flutter_inappwebview_platform_interface: ^1.4.0-beta.3
+  flutter_inappwebview_ios: ^1.2.0-beta.3
+  flutter_inappwebview_macos: ^1.2.0-beta.3
+  flutter_inappwebview_android: ^1.2.0-beta.3
   upgrader: ^12.3.0
   open_filex: ^4.7.0
   html: any


### PR DESCRIPTION
延续 [#2100](https://github.com/Predidit/Kazumi/pull/2100) 的 Darwin SPM 迁移，进一步把 **6 个插件**从 CocoaPods 兜底迁到 SPM：

| 平台 | PR #2100 后 | 本 PR 后 | 减少 |
|---|---|---|---|
| macOS | 6 个 | **2 个** | -4 (media_kit_video + media_kit_libs_macos_video + flutter_volume_controller + flutter_inappwebview_macos) |
| iOS | 7 个 | **3 个** | -4 (media_kit_video + media_kit_libs_ios_video + flutter_volume_controller + flutter_inappwebview_ios) |

剩余 CocoaPods 兜底（等上游插件适配 SPM）：
- **macOS (2)**：screen_retriever_macos、tray_manager
- **iOS (3)**：saver_gallery、open_filex、flutter_foreground_task

## 改动构成（3 commit）

### Commit `a04e775` — flutter_volume_controller 升级 to 2.0.0

\`flutter_volume_controller 2.0.0\` ([release notes](https://github.com/yosemiteyss/flutter_volume_controller/releases/tag/v2.0.0)) 主要变更：
- 添加 Swift Package Manager 支持（iOS + macOS）
- 添加 HarmonyOS (OHOS) 平台支持
- 最低 Flutter SDK 提升到 3.24.0

API 完全兼容 —— 现有 \`FlutterVolumeController.getVolume\` / \`setVolume\` / \`updateShowSystemUI\` / \`addListener\` / \`removeListener\` 调用无需修改。

### Commit `251f39b` — media_kit fork ref 升级到 13b332ad

把 9 处 \`media_kit\` 系列 git ref 从 \`21aacaf9\` (fork 旧 main HEAD) 升到 \`13b332ad\`（[Predidit/media-kit#31](https://github.com/Predidit/media-kit/pull/31) merge commit）。

PR #31 内容：
- Cherry-pick 上游 [Carapacik/spm](https://github.com/media-kit/media-kit/pull/1412) 的 SPM 集成（7 个 commit）
- \`Package.swift\` 通过 \`.binaryTarget(url:)\` 指向 [Predidit/libmpv-darwin-build 0.6.7](https://github.com/Predidit/libmpv-darwin-build/releases/tag/0.6.7) release 的 per-framework zip
- 0.6.7 release 来自 [Predidit/libmpv-darwin-build#4](https://github.com/Predidit/libmpv-darwin-build/pull/4)，给 fork 的 mpv 二进制构建添加：
  - 每个 xcframework 的 per-framework SPM zip 输出（CI 改动）
  - 每个 \`Mpv.framework\` 内的 \`Headers/\` 和 \`Modules/module.modulemap\`（Swift \`import Mpv\` 必需）

**保留了 fork 的 ad-blocker / win32 / ohos 等所有自定义 mpv 二进制 patch**。

### Commit `9da5d24` — flutter_inappwebview 升级到 1.2.0-beta.3

\`flutter_inappwebview 1.2.0-beta.3\` (platform_interface 1.4.0-beta.3) 添加了 Swift Package Manager 支持。

**为什么用 beta**：beta 线从 2024-11 跑了 18 个月（最新 beta.3 于 2026-02 发布），而 stable 线自 2024-10 起停在 1.1.x —— maintainer 把 SPM + 大量新功能都放在 beta 通道。等 stable 不现实。

升级范围：
- \`flutter_inappwebview_platform_interface\`: \`^1.3.0+1\` → \`^1.4.0-beta.3\`
- \`flutter_inappwebview_ios\`: \`^1.1.2\` → \`^1.2.0-beta.3\`
- \`flutter_inappwebview_macos\`: \`^1.1.2\` → \`^1.2.0-beta.3\`
- \`flutter_inappwebview_android\`: \`^1.1.3\` → \`^1.2.0-beta.3\`

API 兼容性 — Kazumi 的 WebView 代码 (\`lib/webview/video/impl/\`) 用 lambda 调 JavaScript handler 和 load 回调，与 beta API 完全兼容（被 deprecate 的 \`JavaScriptHandlerCallback\` typedef 只被间接引用；\`Future\` → \`FutureOr\` 返回类型放宽对 \`async\` lambda 完全向后兼容）。

## 端到端验证

| 验证项 | 结果 |
|---|---|
| \`flutter pub get\` SPM 列表含 media_kit_video / media_kit_libs_macos_video / flutter_volume_controller-2.0.0 / flutter_inappwebview_macos | ✅ |
| \`flutter analyze lib/webview/\` | ✅ 无错误，无 deprecation warning |
| \`flutter build macos --release\` | ✅ \`Built Kazumi.app (129.3MB)\` |
| \`codesign --verify --deep Kazumi.app\` | ✅ \`valid on disk\` + \`satisfies its Designated Requirement\`，所有 SPM xcframework 全部 verify 通过 |
| \`flutter build ios --release --no-codesign\` | ✅ \`Built Runner.app (64.6MB)\` |
| iOS unsigned IPA 真机自签后运行 (中间版本，含 media_kit / volume_controller 升级) | ✅ 视频解析 + 播放 + ad-blocker 行为正常 |
| **macOS 实测 inappwebview beta 视频解析** (本 PR 最终版) | ✅ 多个插件源视频解析 + 弹幕 + ad-blocker 行为正常 |

## 依赖关系（已就绪）

| 上游 PR | 状态 |
|---|---|
| [Predidit/libmpv-darwin-build#4](https://github.com/Predidit/libmpv-darwin-build/pull/4) (binary CI + modulemap) | ✅ MERGED |
| [Predidit/libmpv-darwin-build 0.6.7](https://github.com/Predidit/libmpv-darwin-build/releases/tag/0.6.7) | ✅ Published |
| [Predidit/media-kit#31](https://github.com/Predidit/media-kit/pull/31) (Package.swift) | ✅ MERGED |
| [Predidit/Kazumi#2100](https://github.com/Predidit/Kazumi/pull/2100) (初版 SPM 迁移) | ✅ MERGED |

## 不在 scope 内

- 其余 2 个 macOS / 3 个 iOS CocoaPods 兜底插件迁移（待上游或换库）
- 其他依赖升级