### PR TITLE
Add Enter key shortcut to focus danmaku input field

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -96,6 +96,7 @@ class _PlayerItemState extends State<PlayerItem>
 
   // 弹幕
   final _danmuKey = GlobalKey();
+  final FocusNode _danmakuTextFieldFocus = FocusNode();
   late bool _border;
   late double _opacity;
   late double _fontSize;
@@ -264,6 +265,12 @@ class _PlayerItemState extends State<PlayerItem>
       'speed3': () async => setPlaybackSpeed(3.0),
       'speedup': () async => handleSpeedChange('up'),
       'speeddown': () async => handleSpeedChange('down'),
+      'enterdanmaku': () {
+        if (playerController.danmaku.danmakuOn) {
+          displayVideoController();
+          _danmakuTextFieldFocus.requestFocus();
+        }
+      },
       // 开始对应长按功能
       // 如需对应长按功能，例如对功能'func'对应长按，请分别添加'funcRepeat'和'funcUp'。
       'forwardRepeat': () async => handleShortcutForwardRepeat(),
@@ -1700,6 +1707,7 @@ class _PlayerItemState extends State<PlayerItem>
     _panelVisibilityController.dispose();
     _screenshotFeedbackController.dispose();
     _disposePlayerMenu();
+    _danmakuTextFieldFocus.dispose();
     if (Platform.isAndroid) {
       unawaited(_syncAndroidPIPPlayerPageState(false));
       PipUtils.disposePipHandler();
@@ -1898,6 +1906,7 @@ class _PlayerItemState extends State<PlayerItem>
                                 widget.showDanmakuDestinationPickerAndSend,
                             pauseForTimedShutdown: widget.pauseForTimedShutdown,
                             disableAnimations: widget.disableAnimations,
+                            danmakuTextFieldFocus: _danmakuTextFieldFocus,
                             handleScreenShot: handleScreenshot,
                             skipOP: skipOP,
                           )

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -1707,7 +1707,6 @@ class _PlayerItemState extends State<PlayerItem>
     _panelVisibilityController.dispose();
     _screenshotFeedbackController.dispose();
     _disposePlayerMenu();
-    _danmakuTextFieldFocus.dispose();
     if (Platform.isAndroid) {
       unawaited(_syncAndroidPIPPlayerPageState(false));
       PipUtils.disposePipHandler();
@@ -1716,6 +1715,7 @@ class _PlayerItemState extends State<PlayerItem>
     unawaited(_audioController.deactivate());
     _audioController.clearCallbacks();
     super.dispose();
+    _danmakuTextFieldFocus.dispose();
   }
 
   @override

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -108,6 +108,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
 
   @override
   void dispose() {
+    textFieldFocus.removeListener(_onDanmakuTextFieldFocusChange);
     _releaseDanmakuTextFieldPanel();
     textController.dispose();
     if (widget.danmakuTextFieldFocus == null) {
@@ -126,6 +127,14 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   void _releaseDanmakuTextFieldPanel() {
     _danmakuTextFieldHold?.release();
     _danmakuTextFieldHold = null;
+  }
+
+  void _onDanmakuTextFieldFocusChange() {
+    if (textFieldFocus.hasFocus) {
+      _holdDanmakuTextFieldPanel();
+    } else {
+      _releaseDanmakuTextFieldPanel();
+    }
   }
 
   Widget get danmakuTextField {
@@ -304,6 +313,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   void initState() {
     super.initState();
     textFieldFocus = widget.danmakuTextFieldFocus ?? FocusNode();
+    textFieldFocus.addListener(_onDanmakuTextFieldFocusChange);
     playerController = widget.playerController;
     topOffsetAnimation = Tween<Offset>(
       begin: const Offset(0.0, -1.0),

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -49,6 +49,7 @@ class PlayerItemPanel extends StatefulWidget {
     required this.showSyncPlayEndPointSwitchDialog,
     required this.showDanmakuDestinationPickerAndSend,
     required this.pauseForTimedShutdown,
+    this.danmakuTextFieldFocus,
     this.disableAnimations = false,
   });
 
@@ -75,6 +76,7 @@ class PlayerItemPanel extends StatefulWidget {
   final void Function() showSyncPlayEndPointSwitchDialog;
   final void Function(String) showDanmakuDestinationPickerAndSend;
   final VoidCallback pauseForTimedShutdown;
+  final FocusNode? danmakuTextFieldFocus;
   final bool disableAnimations;
 
   @override
@@ -93,7 +95,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   final DownloadController downloadController =
       Modular.get<DownloadController>();
   final TextEditingController textController = TextEditingController();
-  final FocusNode textFieldFocus = FocusNode();
+  late final FocusNode textFieldFocus;
   PlayerPanelHold? _danmakuTextFieldHold;
   // SVG Caches
   String? cachedSvgString;
@@ -108,7 +110,9 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   void dispose() {
     _releaseDanmakuTextFieldPanel();
     textController.dispose();
-    textFieldFocus.dispose();
+    if (widget.danmakuTextFieldFocus == null) {
+      textFieldFocus.dispose();
+    }
     super.dispose();
   }
 
@@ -299,6 +303,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   @override
   void initState() {
     super.initState();
+    textFieldFocus = widget.danmakuTextFieldFocus ?? FocusNode();
     playerController = widget.playerController;
     topOffsetAnimation = Tween<Offset>(
       begin: const Offset(0.0, -1.0),

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -233,6 +233,7 @@ final Map<String, List<String>> defaultShortcuts = const {
   'speed3': ['3'],
   'speedup': ['X'],
   'speeddown': ['Z'],
+  'enterdanmaku': ['Enter'],
 };
 
 // 键位别名
@@ -268,4 +269,5 @@ final Map<String, String> shortcutsChineseName = {
   'speed3': '倍速：3x',
   'speedup': '倍速加',
   'speeddown': '倍速减',
+  'enterdanmaku': '弹幕输入',
 };


### PR DESCRIPTION
## Summary

Add an Enter key keyboard shortcut that focuses the danmaku text input field, matching the behavior of Bilibili's video player. When danmaku is enabled, pressing Enter shows the video control panel and moves focus to the danmaku input field so the user can start typing immediately.

Closes #2126

## Changes

- **`lib/utils/constants.dart`**: Added `'enterdanmaku': ['Enter']` to default shortcuts and `'弹幕输入'` Chinese label
- **`lib/pages/player/player_item_panel.dart`**: Added optional `danmakuTextFieldFocus` parameter so the parent can share a FocusNode for the danmaku text field
- **`lib/pages/player/player_item.dart`**: Created a shared FocusNode, wired the Enter key action to show the video controller and focus the danmaku text field

## Behavior

- When danmaku is on and the video is playing: pressing Enter focuses the danmaku input
- When danmaku is off: Enter does nothing
- When the danmaku text field is already focused: Enter still submits the danmaku text (TextField captures the key event first)
- The shortcut is automatically configurable via the keyboard settings page