### PR TITLE
fix: handleScreenshot causes a client crash

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -626,6 +626,12 @@ class _PlayerItemState extends State<PlayerItem>
   //截图
   Future<void> handleScreenshot() async {
     _playScreenshotFeedback();
+
+    if (isDesktop()) {
+      KazumiDialog.showToast(message: '桌面端暂未支持保存截图');
+      return;
+    }
+
     try {
       Uint8List? screenshot = await playerController.screenshotPng();
 
@@ -634,10 +640,6 @@ class _PlayerItemState extends State<PlayerItem>
         return;
       }
 
-      if (isDesktop()) {
-        KazumiDialog.showToast(message: '桌面端暂未支持保存截图');
-        return;
-      }
       final result = await SaverGallery.saveImage(
         screenshot,
         fileName: DateTime.timestamp().millisecondsSinceEpoch.toString(),


### PR DESCRIPTION
issue: #2146 

修复PC端handleScreenshot方法的逻辑错误导致客户端崩溃

https://github.com/user-attachments/assets/3226bc8f-01be-4688-a840-40fe0a31bcda

<img width="1280" height="858" alt="67ba965c-aecb-4d4a-acba-ce4eef354b3b" src="https://github.com/user-attachments/assets/460caade-1573-4e5e-8b11-95c076744e12" />