### PR TITLE
修复 Windows 下载解析超时后闪退

### DIFF
--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -23,7 +24,7 @@ abstract class _DownloadController with Store {
   final _repository = Modular.get<IDownloadRepository>();
   final _downloadManager = Modular.get<IDownloadManager>();
   final _backgroundService = BackgroundDownloadService();
-  WebViewVideoSourceService? _videoSourceService;
+  final _resolverPool = VideoSourceResolverPool();
 
   @observable
   ObservableList<DownloadRecord> records = ObservableList<DownloadRecord>();
@@ -32,7 +33,7 @@ abstract class _DownloadController with Store {
       ObservableMap<String, DownloadRecord>();
 
   final List<_ResolveRequest> _resolveQueue = [];
-  bool _isResolving = false;
+  final Map<String, VideoSourceResolverLease> _activeResolveLeases = {};
   bool _isBackgroundServiceInitialized = false;
 
   Future<void> init() async {
@@ -494,104 +495,184 @@ abstract class _DownloadController with Store {
     _processResolveQueue();
   }
 
-  Future<void> _processResolveQueue() async {
-    if (_isResolving || _resolveQueue.isEmpty) return;
-    _isResolving = true;
+  void _processResolveQueue() {
+    if (_resolveQueue.isEmpty) return;
 
-    while (_resolveQueue.isNotEmpty) {
-      final request = _resolveQueue.removeAt(0);
-      await _resolveAndEnqueue(request);
+    _resolverPool.resize(
+      GStorage.getSetting(SettingsKeys.downloadParallelEpisodes),
+    );
+
+    var index = 0;
+    while (index < _resolveQueue.length) {
+      final request = _resolveQueue[index];
+      final key = _resolveTaskKey(request.recordKey, request.episodeNumber);
+
+      if (_activeResolveLeases.containsKey(key)) {
+        index++;
+        continue;
+      }
+
+      final lease = _resolverPool.tryAcquire(key);
+      if (lease == null) return;
+
+      _resolveQueue.removeAt(index);
+      _activeResolveLeases[key] = lease;
+      unawaited(_resolveAndEnqueue(request, lease));
     }
-
-    _isResolving = false;
   }
 
-  Future<void> _resolveAndEnqueue(_ResolveRequest request) async {
-    final plugin = _findPlugin(request.pluginName);
-    if (plugin == null) {
-      _failEpisode(request.recordKey, request.episodeNumber,
-          '找不到插件 ${request.pluginName}');
-      return;
-    }
+  Future<void> _resolveAndEnqueue(
+      _ResolveRequest request, VideoSourceResolverLease lease) async {
+    final key = _resolveTaskKey(request.recordKey, request.episodeNumber);
+    var wasCancelled = false;
 
-    final record = _repository.getRecord(request.recordKey);
-    if (record == null) return;
-    final episode = record.episodes[request.episodeNumber];
-    if (episode == null) return;
-
-    if (episode.status != DownloadStatus.resolving) return;
-
-    final fullUrl = plugin.buildFullUrl(request.episodePageUrl);
-
-    KazumiLogger().i(
-        'DownloadController: resolving video URL for episode ${request.episodeNumber} from $fullUrl');
-
-    String? m3u8Url;
-    final videoSourceService =
-        _videoSourceService ??= WebViewVideoSourceService();
     try {
-      final source = await videoSourceService.resolve(
-        fullUrl,
-        useLegacyParser: plugin.useLegacyParser,
-        timeout: const Duration(seconds: 30),
-      );
-      m3u8Url = source.url;
-    } on VideoSourceTimeoutException {
-      KazumiLogger().w('DownloadController: WebView resolution timed out');
-    } on VideoSourceCancelledException {
-      KazumiLogger().i('DownloadController: WebView resolution cancelled');
-    } catch (e) {
-      KazumiLogger()
-          .e('DownloadController: WebView resolution failed', error: e);
+      final plugin = _findPlugin(request.pluginName);
+      if (plugin == null) {
+        _failEpisode(request.recordKey, request.episodeNumber,
+            '找不到插件 ${request.pluginName}');
+        return;
+      }
+
+      final record = _repository.getRecord(request.recordKey);
+      if (record == null) return;
+      final episode = record.episodes[request.episodeNumber];
+      if (episode == null) return;
+
+      if (episode.status != DownloadStatus.resolving) return;
+
+      final fullUrl = plugin.buildFullUrl(request.episodePageUrl);
+
+      KazumiLogger().i(
+          'DownloadController: resolving video URL for episode ${request.episodeNumber} from $fullUrl');
+
+      String? m3u8Url;
+      try {
+        if (lease.isCancelled) {
+          throw const VideoSourceCancelledException();
+        }
+        final source = await lease.resolve(
+          fullUrl,
+          useLegacyParser: plugin.useLegacyParser,
+          timeout: const Duration(seconds: 30),
+        );
+        m3u8Url = source.url;
+      } on VideoSourceTimeoutException {
+        if (lease.isCancelled) {
+          wasCancelled = true;
+        } else {
+          KazumiLogger().w('DownloadController: WebView resolution timed out');
+        }
+      } on VideoSourceCancelledException {
+        wasCancelled = true;
+        KazumiLogger().i('DownloadController: WebView resolution cancelled');
+      } catch (e) {
+        if (lease.isCancelled) {
+          wasCancelled = true;
+        } else {
+          lease.retire();
+          KazumiLogger()
+              .e('DownloadController: WebView resolution failed', error: e);
+        }
+      }
+
+      if (wasCancelled || lease.isCancelled) {
+        return;
+      }
+
+      if (m3u8Url == null || m3u8Url.isEmpty) {
+        _failEpisode(request.recordKey, request.episodeNumber, '解析视频源超时');
+        return;
+      }
+
+      KazumiLogger().i(
+          'DownloadController: resolved M3U8 URL for episode ${request.episodeNumber}: $m3u8Url');
+
+      // Update episode with resolved URL
+      final freshRecord = _repository.getRecord(request.recordKey);
+      if (freshRecord == null) return;
+      final freshEpisode = freshRecord.episodes[request.episodeNumber];
+      if (freshEpisode == null) return;
+
+      if (freshEpisode.status != DownloadStatus.resolving) return;
+
+      freshEpisode.networkM3u8Url = m3u8Url;
+      freshEpisode.status = DownloadStatus.downloading;
+      await _repository.updateEpisode(
+          request.recordKey, request.episodeNumber, freshEpisode);
+      _refreshRecord(request.recordKey);
+
+      await _startBackgroundServiceIfNeeded();
+
+      final httpHeaders = plugin.buildHttpHeaders();
+      bool adBlockerEnabled =
+          _repository.getForceAdBlocker() || plugin.adBlocker;
+
+      await _downloadManager.enqueue(DownloadRequest(
+        recordKey: request.recordKey,
+        bangumiId: request.bangumiId,
+        pluginName: request.pluginName,
+        episodeNumber: request.episodeNumber,
+        m3u8Url: m3u8Url,
+        httpHeaders: httpHeaders,
+        adBlockerEnabled: adBlockerEnabled,
+        episode: freshEpisode,
+      ));
+
+      final bool downloadDanmaku =
+          GStorage.getSetting(SettingsKeys.downloadDanmaku);
+      if (downloadDanmaku) {
+        _fetchAndCacheDanmakuAsync(
+          request.recordKey,
+          request.bangumiId,
+          request.episodeNumber,
+        );
+      }
+    } finally {
+      _releaseResolveLease(key, lease);
     }
+  }
 
-    if (m3u8Url == null || m3u8Url.isEmpty) {
-      _failEpisode(request.recordKey, request.episodeNumber, '解析视频源超时');
-      return;
+  void _releaseResolveLease(String key, VideoSourceResolverLease lease) {
+    if (_activeResolveLeases[key] == lease) {
+      _activeResolveLeases.remove(key);
     }
+    _resolverPool.release(lease);
+    _processResolveQueue();
+  }
 
-    KazumiLogger().i(
-        'DownloadController: resolved M3U8 URL for episode ${request.episodeNumber}: $m3u8Url');
+  String _resolveTaskKey(String recordKey, int episodeNumber) =>
+      '${recordKey.length}:$recordKey:$episodeNumber';
 
-    // Update episode with resolved URL
-    final freshRecord = _repository.getRecord(request.recordKey);
-    if (freshRecord == null) return;
-    final freshEpisode = freshRecord.episodes[request.episodeNumber];
-    if (freshEpisode == null) return;
+  bool _resolveTaskKeyBelongsToRecord(String key, String recordKey) =>
+      key.startsWith('${recordKey.length}:$recordKey:');
 
-    if (freshEpisode.status != DownloadStatus.resolving) return;
+  void _cancelResolve(String recordKey, int episodeNumber) {
+    final key = _resolveTaskKey(recordKey, episodeNumber);
+    _resolveQueue.removeWhere(
+        (r) => r.recordKey == recordKey && r.episodeNumber == episodeNumber);
+    _activeResolveLeases.remove(key)?.cancel();
+    _resolverPool.cancel(key);
+  }
 
-    freshEpisode.networkM3u8Url = m3u8Url;
-    freshEpisode.status = DownloadStatus.downloading;
-    await _repository.updateEpisode(
-        request.recordKey, request.episodeNumber, freshEpisode);
-    _refreshRecord(request.recordKey);
-
-    await _startBackgroundServiceIfNeeded();
-
-    final httpHeaders = plugin.buildHttpHeaders();
-    bool adBlockerEnabled = _repository.getForceAdBlocker() || plugin.adBlocker;
-
-    await _downloadManager.enqueue(DownloadRequest(
-      recordKey: request.recordKey,
-      bangumiId: request.bangumiId,
-      pluginName: request.pluginName,
-      episodeNumber: request.episodeNumber,
-      m3u8Url: m3u8Url,
-      httpHeaders: httpHeaders,
-      adBlockerEnabled: adBlockerEnabled,
-      episode: freshEpisode,
-    ));
-
-    final bool downloadDanmaku =
-        GStorage.getSetting(SettingsKeys.downloadDanmaku);
-    if (downloadDanmaku) {
-      _fetchAndCacheDanmakuAsync(
-        request.recordKey,
-        request.bangumiId,
-        request.episodeNumber,
-      );
+  void _cancelResolveRecord(String recordKey) {
+    _resolveQueue.removeWhere((r) => r.recordKey == recordKey);
+    final activeKeys = _activeResolveLeases.keys
+        .where((key) => _resolveTaskKeyBelongsToRecord(key, recordKey))
+        .toList();
+    for (final key in activeKeys) {
+      _activeResolveLeases.remove(key)?.cancel();
+      _resolverPool.cancel(key);
     }
+  }
+
+  void _cancelAllResolves() {
+    _resolveQueue.clear();
+    for (final lease in _activeResolveLeases.values.toList()) {
+      lease.cancel();
+    }
+    _activeResolveLeases.clear();
+    _resolverPool.cancelAll();
   }
 
   void _fetchAndCacheDanmakuAsync(
@@ -671,9 +752,7 @@ abstract class _DownloadController with Store {
       int bangumiId, String pluginName, int episodeNumber) async {
     final recordKey = '${pluginName}_$bangumiId';
     _downloadManager.pause(recordKey, episodeNumber);
-
-    _resolveQueue.removeWhere(
-        (r) => r.recordKey == recordKey && r.episodeNumber == episodeNumber);
+    _cancelResolve(recordKey, episodeNumber);
 
     final record = _repository.getRecord(recordKey);
     if (record != null) {
@@ -690,7 +769,7 @@ abstract class _DownloadController with Store {
   Future<void> pauseAllDownloads() async {
     KazumiLogger().i('DownloadController: pausing all downloads');
 
-    _resolveQueue.clear();
+    _cancelAllResolves();
 
     for (final record in records) {
       for (final entry in record.episodes.entries) {
@@ -754,6 +833,7 @@ abstract class _DownloadController with Store {
         episode: episode,
       ));
     } else {
+      _cancelResolve(recordKey, episodeNumber);
       episode.status = DownloadStatus.resolving;
       episode.errorMessage = '';
       episode.progressPercent = 0.0;
@@ -776,8 +856,7 @@ abstract class _DownloadController with Store {
       int bangumiId, String pluginName, int episodeNumber) async {
     final recordKey = '${pluginName}_$bangumiId';
     _downloadManager.cancel(recordKey, episodeNumber);
-    _resolveQueue.removeWhere(
-        (r) => r.recordKey == recordKey && r.episodeNumber == episodeNumber);
+    _cancelResolve(recordKey, episodeNumber);
     await _downloadManager.deleteEpisodeFiles(
         bangumiId, pluginName, episodeNumber);
     await _repository.deleteEpisode(recordKey, episodeNumber);
@@ -794,7 +873,7 @@ abstract class _DownloadController with Store {
         _speeds.remove('${recordKey}_$ep');
       }
     }
-    _resolveQueue.removeWhere((r) => r.recordKey == recordKey);
+    _cancelResolveRecord(recordKey);
     await _downloadManager.deleteRecordFiles(bangumiId, pluginName);
     await _repository.deleteRecord(recordKey);
     _refreshRecord(recordKey);
@@ -806,8 +885,7 @@ abstract class _DownloadController with Store {
     final recordKey = '${pluginName}_$bangumiId';
     _downloadManager.cancel(recordKey, episodeNumber);
     _speeds.remove('${recordKey}_$episodeNumber');
-    _resolveQueue.removeWhere(
-        (r) => r.recordKey == recordKey && r.episodeNumber == episodeNumber);
+    _cancelResolve(recordKey, episodeNumber);
     await _downloadManager.deleteEpisodeFiles(
         bangumiId, pluginName, episodeNumber);
     await _repository.deleteEpisode(recordKey, episodeNumber);
@@ -832,8 +910,7 @@ abstract class _DownloadController with Store {
       return;
     }
 
-    _resolveQueue.removeWhere(
-        (r) => r.recordKey == recordKey && r.episodeNumber == episodeNumber);
+    _cancelResolve(recordKey, episodeNumber);
 
     if (episode.networkM3u8Url.isNotEmpty) {
       episode.status = DownloadStatus.downloading;

--- a/lib/pages/download/download_controller.dart
+++ b/lib/pages/download/download_controller.dart
@@ -23,6 +23,7 @@ abstract class _DownloadController with Store {
   final _repository = Modular.get<IDownloadRepository>();
   final _downloadManager = Modular.get<IDownloadManager>();
   final _backgroundService = BackgroundDownloadService();
+  WebViewVideoSourceService? _videoSourceService;
 
   @observable
   ObservableList<DownloadRecord> records = ObservableList<DownloadRecord>();
@@ -526,7 +527,8 @@ abstract class _DownloadController with Store {
         'DownloadController: resolving video URL for episode ${request.episodeNumber} from $fullUrl');
 
     String? m3u8Url;
-    final videoSourceService = WebViewVideoSourceService();
+    final videoSourceService =
+        _videoSourceService ??= WebViewVideoSourceService();
     try {
       final source = await videoSourceService.resolve(
         fullUrl,
@@ -541,8 +543,6 @@ abstract class _DownloadController with Store {
     } catch (e) {
       KazumiLogger()
           .e('DownloadController: WebView resolution failed', error: e);
-    } finally {
-      videoSourceService.dispose();
     }
 
     if (m3u8Url == null || m3u8Url.isEmpty) {

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -527,8 +527,11 @@ abstract class _VideoPageController with Store {
     if (!_logStreamController.isClosed) {
       _logStreamController.close();
     }
-    _videoSourceService?.dispose();
+    final videoSourceService = _videoSourceService;
     _videoSourceService = null;
+    if (videoSourceService != null) {
+      unawaited(videoSourceService.dispose());
+    }
   }
 
   void resetEpisodeComments() {

--- a/lib/services/video_source/services.dart
+++ b/lib/services/video_source/services.dart
@@ -2,4 +2,5 @@
 library;
 
 export 'video_source_service.dart';
+export 'video_source_resolver_pool.dart';
 export 'webview_video_source_service.dart';

--- a/lib/services/video_source/video_source_resolver_pool.dart
+++ b/lib/services/video_source/video_source_resolver_pool.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+
+import 'package:kazumi/services/video_source/video_source_service.dart';
+import 'package:kazumi/services/video_source/webview_video_source_service.dart';
+
+class VideoSourceResolverPool {
+  final List<_VideoSourceResolverWorker> _workers = [];
+  final Map<String, VideoSourceResolverLease> _activeLeases = {};
+  int _maxWorkers = 1;
+
+  void resize(int maxWorkers) {
+    _maxWorkers = maxWorkers.clamp(1, 5).toInt();
+    _trimIdleWorkers();
+  }
+
+  VideoSourceResolverLease? tryAcquire(String key) {
+    if (_activeLeases.containsKey(key)) return null;
+
+    _trimIdleWorkers();
+
+    var worker = _findIdleWorker();
+    if (worker == null && _workers.length < _maxWorkers) {
+      worker = _VideoSourceResolverWorker();
+      _workers.add(worker);
+    }
+    if (worker == null) return null;
+
+    worker.isBusy = true;
+    final lease = VideoSourceResolverLease._(key, worker);
+    _activeLeases[key] = lease;
+    return lease;
+  }
+
+  bool cancel(String key) {
+    final lease = _activeLeases[key];
+    if (lease == null) return false;
+    lease.cancel();
+    return true;
+  }
+
+  void cancelAll() {
+    for (final lease in _activeLeases.values.toList()) {
+      lease.cancel();
+    }
+  }
+
+  void release(VideoSourceResolverLease lease) {
+    if (_activeLeases[lease.key] != lease) return;
+
+    _activeLeases.remove(lease.key);
+    final worker = lease._worker;
+    worker.isBusy = false;
+
+    if (lease.shouldRetire || worker.isRetired) {
+      worker.retire();
+      _workers.remove(worker);
+      unawaited(worker.dispose());
+      return;
+    }
+
+    _trimIdleWorkers();
+  }
+
+  Future<void> dispose() async {
+    cancelAll();
+    final workers = _workers.toList();
+    _activeLeases.clear();
+    _workers.clear();
+    await Future.wait(workers.map((worker) => worker.dispose()));
+  }
+
+  _VideoSourceResolverWorker? _findIdleWorker() {
+    for (final worker in _workers) {
+      if (!worker.isBusy && !worker.isRetired) {
+        return worker;
+      }
+    }
+    return null;
+  }
+
+  void _trimIdleWorkers() {
+    while (_workers.length > _maxWorkers) {
+      _VideoSourceResolverWorker? idleWorker;
+      for (final worker in _workers) {
+        if (!worker.isBusy) {
+          idleWorker = worker;
+          break;
+        }
+      }
+      if (idleWorker == null) return;
+
+      idleWorker.retire();
+      _workers.remove(idleWorker);
+      unawaited(idleWorker.dispose());
+    }
+  }
+}
+
+class VideoSourceResolverLease {
+  final String key;
+  final _VideoSourceResolverWorker _worker;
+  bool _isCancelled = false;
+  bool _shouldRetire = false;
+
+  VideoSourceResolverLease._(this.key, this._worker);
+
+  bool get isCancelled => _isCancelled;
+  bool get shouldRetire => _shouldRetire;
+
+  Future<VideoSource> resolve(
+    String episodeUrl, {
+    required bool useLegacyParser,
+    int offset = 0,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    if (_isCancelled) {
+      throw const VideoSourceCancelledException();
+    }
+    return _worker.resolve(
+      episodeUrl,
+      useLegacyParser: useLegacyParser,
+      offset: offset,
+      timeout: timeout,
+    );
+  }
+
+  void cancel() {
+    _isCancelled = true;
+    _worker.cancel();
+  }
+
+  void retire() {
+    _shouldRetire = true;
+    _worker.retire();
+  }
+}
+
+class _VideoSourceResolverWorker {
+  final WebViewVideoSourceService _service = WebViewVideoSourceService();
+  bool isBusy = false;
+  bool isRetired = false;
+
+  _VideoSourceResolverWorker();
+
+  Future<VideoSource> resolve(
+    String episodeUrl, {
+    required bool useLegacyParser,
+    int offset = 0,
+    Duration timeout = const Duration(seconds: 30),
+  }) {
+    return _service.resolve(
+      episodeUrl,
+      useLegacyParser: useLegacyParser,
+      offset: offset,
+      timeout: timeout,
+    );
+  }
+
+  void cancel() {
+    _service.cancel();
+  }
+
+  void retire() {
+    isRetired = true;
+  }
+
+  Future<void> dispose() {
+    return _service.dispose();
+  }
+}

--- a/lib/services/video_source/video_source_service.dart
+++ b/lib/services/video_source/video_source_service.dart
@@ -91,5 +91,5 @@ abstract class IVideoSourceService {
   void cancel();
 
   /// 释放资源
-  void dispose();
+  Future<void> dispose();
 }

--- a/lib/services/video_source/webview_video_source_service.dart
+++ b/lib/services/video_source/webview_video_source_service.dart
@@ -93,12 +93,14 @@ class WebViewVideoSourceService implements IVideoSourceService {
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     cancel();
-    _logSubscription?.cancel();
+    await _logSubscription?.cancel();
     _logSubscription = null;
-    _logController.close();
-    _webview?.dispose();
+    if (!_logController.isClosed) {
+      await _logController.close();
+    }
+    await _webview?.dispose();
     _webview = null;
   }
 }

--- a/lib/services/video_source/webview_video_source_service.dart
+++ b/lib/services/video_source/webview_video_source_service.dart
@@ -11,6 +11,7 @@ import 'package:kazumi/services/video_source/video_source_service.dart';
 class WebViewVideoSourceService implements IVideoSourceService {
   VideoWebviewController? _webview;
   StreamSubscription? _logSubscription;
+  Completer<void>? _cancelCompleter;
 
   /// 单个服务实例不能实现并发解析，单个服务实例只能持有一个 WebView。
   /// 服务可以在正在进行的解析未完成时，取消该解析并开始新的解析。
@@ -28,8 +29,15 @@ class WebViewVideoSourceService implements IVideoSourceService {
     int offset = 0,
     Duration timeout = const Duration(seconds: 15),
   }) async {
+    final previousCancelCompleter = _cancelCompleter;
+    if (previousCancelCompleter != null &&
+        !previousCancelCompleter.isCompleted) {
+      previousCancelCompleter.complete();
+    }
     _resolveId++;
     final currentResolveId = _resolveId;
+    final cancelCompleter = Completer<void>();
+    _cancelCompleter = cancelCompleter;
 
     if (_webview == null) {
       _webview = VideoWebviewControllerFactory.getController();
@@ -53,7 +61,7 @@ class WebViewVideoSourceService implements IVideoSourceService {
         throw const VideoSourceCancelledException();
       }
 
-      final event = await _webview!.onVideoURLParser.first.timeout(
+      final parserFuture = _webview!.onVideoURLParser.first.timeout(
         timeout,
         onTimeout: () {
           if (currentResolveId != _resolveId) {
@@ -62,6 +70,10 @@ class WebViewVideoSourceService implements IVideoSourceService {
           throw VideoSourceTimeoutException(timeout);
         },
       );
+      final cancelFuture = cancelCompleter.future.then<(String, int)>((_) {
+        throw const VideoSourceCancelledException();
+      });
+      final event = await Future.any([parserFuture, cancelFuture]);
 
       if (currentResolveId != _resolveId) {
         throw const VideoSourceCancelledException();
@@ -81,8 +93,12 @@ class WebViewVideoSourceService implements IVideoSourceService {
       }
       rethrow;
     } finally {
-      if (currentResolveId == _resolveId) {
+      if (currentResolveId == _resolveId ||
+          identical(_cancelCompleter, cancelCompleter)) {
         await _webview?.unloadPage();
+      }
+      if (identical(_cancelCompleter, cancelCompleter)) {
+        _cancelCompleter = null;
       }
     }
   }
@@ -90,6 +106,10 @@ class WebViewVideoSourceService implements IVideoSourceService {
   @override
   void cancel() {
     _resolveId++;
+    final cancelCompleter = _cancelCompleter;
+    if (cancelCompleter != null && !cancelCompleter.isCompleted) {
+      cancelCompleter.complete();
+    }
   }
 
   @override

--- a/lib/webview/video/impl/video_webview_android_impl.dart
+++ b/lib/webview/video/impl/video_webview_android_impl.dart
@@ -281,8 +281,8 @@ class VideoWebviewAndroidImpl
   }
 
   @override
-  void dispose() {
-    headlessWebView?.dispose();
+  Future<void> dispose() async {
+    await headlessWebView?.dispose();
     headlessWebView = null;
     webviewController = null;
     disposeEventControllers();

--- a/lib/webview/video/impl/video_webview_apple_impl.dart
+++ b/lib/webview/video/impl/video_webview_apple_impl.dart
@@ -324,8 +324,8 @@ class VideoWebviewAppleImpl
   }
 
   @override
-  void dispose() {
-    headlessWebView?.dispose();
+  Future<void> dispose() async {
+    await headlessWebView?.dispose();
     headlessWebView = null;
     webviewController = null;
     disposeEventControllers();

--- a/lib/webview/video/impl/video_webview_impl.dart
+++ b/lib/webview/video/impl/video_webview_impl.dart
@@ -432,10 +432,10 @@ class VideoWebviewImpl
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     videoParserTimer?.cancel();
     videoParserTimer = null;
-    headlessWebView?.dispose();
+    await headlessWebView?.dispose();
     headlessWebView = null;
     webviewController = null;
     disposeEventControllers();

--- a/lib/webview/video/impl/video_webview_linux_impl.dart
+++ b/lib/webview/video/impl/video_webview_linux_impl.dart
@@ -79,7 +79,7 @@ class VideoWebviewLinuxImpl extends VideoWebviewController<Webview> {
   }
 
   @override
-  void dispose() {
+  Future<void> dispose() async {
     webviewController?.close();
     webviewController = null;
     bridgeInited = false;

--- a/lib/webview/video/impl/video_webview_windows_impl.dart
+++ b/lib/webview/video/impl/video_webview_windows_impl.dart
@@ -82,24 +82,24 @@ class VideoWebviewWindowsImpl
 
   @override
   Future<void> unloadPage() async {
-    subscriptions.forEach((s) {
+    for (final s in subscriptions) {
       try {
         s.cancel();
       } catch (_) {}
-    });
+    }
     subscriptions.clear();
     await redirect2Blank();
   }
 
   @override
-  void dispose() {
-    subscriptions.forEach((s) {
+  Future<void> dispose() async {
+    for (final s in subscriptions) {
       try {
         s.cancel();
       } catch (_) {}
-    });
+    }
     subscriptions.clear();
-    headlessWebview?.dispose();
+    await headlessWebview?.dispose();
     headlessWebview = null;
     disposeEventControllers();
   }

--- a/lib/webview/video/video_webview_controller.dart
+++ b/lib/webview/video/video_webview_controller.dart
@@ -70,7 +70,7 @@ abstract class VideoWebviewController<T> {
   Future<void> unloadPage();
 
   /// WebView dispose method.
-  void dispose();
+  Future<void> dispose();
 }
 
 class VideoWebviewControllerFactory {


### PR DESCRIPTION
## 修复内容
- 下载视频源解析复用同一个 WebViewVideoSourceService，避免每次解析结束后立即销毁 Windows HeadlessWebview。
- 将视频 WebView dispose 链路改为 Future<void>，Windows 实现会等待 headlessWebview.dispose() 完成。
- 同步更新播放页释放调用，使用 unawaited 适配同步生命周期。

## 崩溃原因
Windows 下载番剧时，如果 WebView 视频源解析超时，下载控制器会在 finally 中立刻 dispose 新建的 WebViewVideoSourceService。Windows 实现会进一步销毁 HeadlessWebview，而此时 WebView2 可能仍处于页面加载或脚本回调状态，容易触发原生层销毁竞态，表现为进程直接闪退，Dart 日志中不会出现普通未捕获异常栈。

## 修复方式
- DownloadController 持有并复用一个 WebViewVideoSourceService。
- 单次解析超时后仍由 resolve() 的 finally 执行 unloadPage() 释放页面资源，但不销毁整个 HeadlessWebview。
- 仅在服务真正 dispose 时销毁 WebView，并等待底层异步 dispose 完成，降低 Windows WebView2 原生销毁竞态。

## 测试结果
- 平台：Windows。
- 手动复现下载视频源解析超时场景，超时后下载项失败并显示“解析视频源超时”，应用不再闪退。
- 聚焦静态检查：dart analyze lib/pages/download/download_controller.dart lib/pages/video/video_controller.dart lib/services/video_source lib/webview/video；无 error，仅剩既有 info。
- 全量 dart analyze 仍存在本 PR 之外的既有 error：plugin_view_page.dart 的 ReorderableList 参数，以及 player_screenshot_service.dart 的 safeScreenshot 调用。