### PR TITLE
chore: replace print() with logger, add log rotation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,8 +21,8 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    avoid_print: true
+    no_leading_underscores_for_local_identifiers: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/pages/info/character_page.dart
+++ b/lib/pages/info/character_page.dart
@@ -28,10 +28,11 @@ class _CharacterPageState extends State<CharacterPage> {
     setState(() {
       loadingCharacter = true;
     });
-    await BangumiApi.getCharacterByCharacterID(widget.characterID)
-        .then((character) {
-      characterFullItem = character;
-    });
+    final result = await BangumiApi.getCharacterByCharacterID(widget.characterID);
+    characterFullItem = switch (result) {
+      Success(:final value) => value,
+      Failure() => CharacterFullItem.fromTemplate(),
+    };
     if (mounted) {
       setState(() {
         loadingCharacter = false;

--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -95,34 +95,34 @@ abstract class _InfoController with Store {
   }
 
   Future<void> _updateBangumiInfoByID(int id, {required String type}) async {
-    final value = await BangumiApi.getBangumiInfoByID(id);
-    if (value == null) {
-      return;
-    }
-    if (type == "init") {
-      bangumiItem = value;
-    } else {
-      bangumiItem.summary = value.summary;
-      bangumiItem.tags = value.tags;
-      bangumiItem.rank = value.rank;
-      bangumiItem.airDate = value.airDate;
-      bangumiItem.airWeekday = value.airWeekday;
-      bangumiItem.alias = value.alias;
-      bangumiItem.ratingScore = value.ratingScore;
-      bangumiItem.votes = value.votes;
-      bangumiItem.votesCount = value.votesCount;
-      final incomingInterest = value.interest;
-      final previousInterest = bangumiItem.interest;
-      if (incomingInterest == null) {
-        bangumiItem.interest = null;
-      } else if (previousInterest == null || !previousInterest.hasUserProfile) {
-        bangumiItem.interest = incomingInterest;
+    final result = await BangumiApi.getBangumiInfoByID(id);
+    if (result case Success(:final value)) {
+      if (type == "init") {
+        bangumiItem = value;
       } else {
-        bangumiItem.interest =
-            incomingInterest.copyWithUser(user: previousInterest.user);
+        bangumiItem.summary = value.summary;
+        bangumiItem.tags = value.tags;
+        bangumiItem.rank = value.rank;
+        bangumiItem.airDate = value.airDate;
+        bangumiItem.airWeekday = value.airWeekday;
+        bangumiItem.alias = value.alias;
+        bangumiItem.ratingScore = value.ratingScore;
+        bangumiItem.votes = value.votes;
+        bangumiItem.votesCount = value.votesCount;
+        final incomingInterest = value.interest;
+        final previousInterest = bangumiItem.interest;
+        if (incomingInterest == null) {
+          bangumiItem.interest = null;
+        } else if (previousInterest == null ||
+            !previousInterest.hasUserProfile) {
+          bangumiItem.interest = incomingInterest;
+        } else {
+          bangumiItem.interest =
+              incomingInterest.copyWithUser(user: previousInterest.user);
+        }
       }
+      await collectController.updateLocalCollect(bangumiItem);
     }
-    await collectController.updateLocalCollect(bangumiItem);
   }
 
   Future<void> queryBangumiCommentsByID(int id, {bool refresh = true}) async {

--- a/lib/pages/player/episode_comments_sheet.dart
+++ b/lib/pages/player/episode_comments_sheet.dart
@@ -218,9 +218,12 @@ class _EpisodeCommentsSheetState extends State<EpisodeCommentsSheet> {
     final int selectedEpisode =
         ep == 0 ? EpisodeInfoWidget.of(context)!.episode : ep;
     KazumiDialog.showLoading(msg: '分集列表加载中');
-    final List<EpisodeInfo> episodeList =
-        await BangumiApi.getBangumiEpisodesByID(
-            videoPageController.bangumiItem.id);
+    final result = await BangumiApi.getBangumiEpisodesByID(
+        videoPageController.bangumiItem.id);
+    final List<EpisodeInfo> episodeList = switch (result) {
+      Success(:final value) => value,
+      Failure() => <EpisodeInfo>[],
+    };
     KazumiDialog.dismiss();
     if (!mounted) {
       return;

--- a/lib/pages/popular/popular_controller.dart
+++ b/lib/pages/popular/popular_controller.dart
@@ -45,11 +45,13 @@ abstract class _PopularController with Store {
       trendList.clear();
     }
     isLoadingMore = true;
-    var result = _bangumiMirrorEnabled
+    final result = _bangumiMirrorEnabled
         ? await BangumiApi.getBangumiMirrorPopularSubjects(
             offset: trendList.length)
         : await BangumiApi.getBangumiTrendsList(offset: trendList.length);
-    trendList.addAll(result);
+    if (result case Success(:final value)) {
+      trendList.addAll(value);
+    }
     isLoadingMore = false;
     isTimeOut = trendList.isEmpty;
   }
@@ -60,7 +62,7 @@ abstract class _PopularController with Store {
     }
     isLoadingMore = true;
     var tag = currentTag;
-    var result = _bangumiMirrorEnabled
+    final result = _bangumiMirrorEnabled
         ? await BangumiApi.getBangumiMirrorPopularSubjects(
             tag: tag,
             offset: bangumiList.length,
@@ -69,7 +71,9 @@ abstract class _PopularController with Store {
             rank: Random().nextInt(8000) + 1,
             tag: tag,
           );
-    bangumiList.addAll(result);
+    if (result case Success(:final value)) {
+      bangumiList.addAll(value);
+    }
     isLoadingMore = false;
     isTimeOut = bangumiList.isEmpty;
   }

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -95,18 +95,20 @@ abstract class _SearchPageController with Store {
     if (idString != null) {
       final id = int.tryParse(idString);
       if (id != null) {
-        final BangumiItem? item = await BangumiApi.getBangumiInfoByID(id);
-        if (item != null) {
-          bangumiList.add(item);
+        final infoResult = await BangumiApi.getBangumiInfoByID(id);
+        if (infoResult case Success(:final value)) {
+          bangumiList.add(value);
         }
         return;
       }
     }
-    var result = await BangumiApi.bangumiSearch(keywords,
+    final searchResult = await BangumiApi.bangumiSearch(keywords,
         tags: [if (tag != null) tag],
         offset: bangumiList.length,
         sort: sort ?? 'heat');
-    bangumiList.addAll(result);
+    if (searchResult case Success(:final value)) {
+      bangumiList.addAll(value);
+    }
     isLoading = false;
     isTimeOut = bangumiList.isEmpty;
   }

--- a/lib/pages/settings/proxy/proxy_settings_page.dart
+++ b/lib/pages/settings/proxy/proxy_settings_page.dart
@@ -15,11 +15,13 @@ class ProxySettingsPage extends StatefulWidget {
 
 class _ProxySettingsPageState extends State<ProxySettingsPage> {
   late bool proxyEnable;
+  late bool allowBadCertificates;
 
   @override
   void initState() {
     super.initState();
     proxyEnable = GStorage.getSetting(SettingsKeys.proxyEnable);
+    allowBadCertificates = GStorage.getSetting(SettingsKeys.allowBadCertificates);
   }
 
   void onBackPressed(BuildContext context) {
@@ -47,6 +49,13 @@ class _ProxySettingsPageState extends State<ProxySettingsPage> {
     });
   }
 
+  Future<void> updateAllowBadCertificates(bool value) async {
+    await GStorage.putSetting(SettingsKeys.allowBadCertificates, value);
+    setState(() {
+      allowBadCertificates = value;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final fontFamily = Theme.of(context).textTheme.bodyMedium?.fontFamily;
@@ -71,6 +80,17 @@ class _ProxySettingsPageState extends State<ProxySettingsPage> {
                   description: Text('启用后网络请求将通过代理服务器',
                       style: TextStyle(fontFamily: fontFamily)),
                   initialValue: proxyEnable,
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) async {
+                    await updateAllowBadCertificates(
+                        value ?? !allowBadCertificates);
+                  },
+                  title: Text('允许不安全证书',
+                      style: TextStyle(fontFamily: fontFamily)),
+                  description: Text('启用后代理服务器的 TLS 证书将不被验证（仅当代理使用自签名证书时需要）',
+                      style: TextStyle(fontFamily: fontFamily)),
+                  initialValue: allowBadCertificates,
                 ),
                 SettingsTile.navigation(
                   onPressed: (_) async {

--- a/lib/pages/timeline/timeline_controller.dart
+++ b/lib/pages/timeline/timeline_controller.dart
@@ -56,9 +56,11 @@ abstract class _TimelineController with Store {
     isLoading = true;
     isTimeOut = false;
     bangumiCalendar.clear();
-    final resBangumiCalendar = await BangumiApi.getCalendar();
+    final result = await BangumiApi.getCalendar();
     bangumiCalendar.clear();
-    bangumiCalendar.addAll(resBangumiCalendar);
+    if (result case Success(:final value)) {
+      bangumiCalendar.addAll(value);
+    }
     changeSortType(sortType);
     isLoading = false;
     isTimeOut = bangumiCalendar.isEmpty;
@@ -69,11 +71,13 @@ abstract class _TimelineController with Store {
       isLoading = true;
       isTimeOut = false;
       bangumiCalendar.clear();
-      final resBangumiCalendar =
+      final result =
           await BangumiApi.getBangumiMirrorSeasonCalendar(
               AnimeSeason(selectedDate).toSeasonStartAndEnd());
       bangumiCalendar.clear();
-      bangumiCalendar.addAll(resBangumiCalendar);
+      if (result case Success(:final value)) {
+        bangumiCalendar.addAll(value);
+      }
       isLoading = false;
       isTimeOut = bangumiCalendar.every((innerList) => innerList.isEmpty);
       if (!isTimeOut) {
@@ -92,10 +96,12 @@ abstract class _TimelineController with Store {
     var resBangumiCalendar = List.generate(7, (_) => <BangumiItem>[]);
     for (time = 0; time < maxTime; time++) {
       final offset = time * limit;
-      var newList = await BangumiApi.getCalendarBySearch(
+      final searchResult = await BangumiApi.getCalendarBySearch(
           AnimeSeason(selectedDate).toSeasonStartAndEnd(), limit, offset);
-      for (int i = 0; i < resBangumiCalendar.length; ++i) {
-        resBangumiCalendar[i].addAll(newList[i]);
+      if (searchResult case Success(:final value)) {
+        for (int i = 0; i < resBangumiCalendar.length; ++i) {
+          resBangumiCalendar[i].addAll(value[i]);
+        }
       }
       bangumiCalendar.clear();
       bangumiCalendar.addAll(resBangumiCalendar);

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -515,7 +515,8 @@ abstract class _VideoPageController with Store {
         return;
       }
       loading = false;
-      errorMessage = '视频解析失败：${e.toString()}';
+      KazumiLogger().e('视频解析失败', error: e);
+      errorMessage = '视频解析失败，请检查网络或重试';
     }
   }
 
@@ -540,13 +541,14 @@ abstract class _VideoPageController with Store {
   Future<bool> queryBangumiEpisodeCommentsByID(int id, int episode) async {
     final session = _commentSessions.begin();
     final EpisodeInfo latestEpisodeInfo;
-    try {
-      latestEpisodeInfo = await BangumiApi.getBangumiEpisodeByID(id, episode);
-    } catch (_) {
-      if (session.isStale) {
-        return false;
-      }
-      rethrow;
+    switch (await BangumiApi.getBangumiEpisodeByID(id, episode)) {
+      case Success(:final value):
+        latestEpisodeInfo = value;
+      case Failure(:final error):
+        if (session.isStale) {
+          return false;
+        }
+        throw error;
     }
     if (session.isStale) {
       return false;

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -2,6 +2,8 @@ import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/request/config/api_endpoints.dart';
 import 'package:kazumi/request/clients/bangumi_client.dart';
 import 'package:kazumi/request/core/network_exception.dart';
+import 'package:kazumi/request/apis/bangumi_result.dart';
+export 'package:kazumi/request/apis/bangumi_result.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/comments/comment_response.dart';
 import 'package:kazumi/modules/characters/characters_response.dart';
@@ -17,7 +19,7 @@ import 'package:kazumi/modules/comments/comment_item.dart';
 class BangumiApi {
   static final BangumiClient _client = BangumiClient.instance;
 
-  static Future<List<List<BangumiItem>>> getCalendar() async {
+  static Future<Result<List<List<BangumiItem>>>> getCalendar() async {
     List<List<BangumiItem>> bangumiCalendar = [];
     try {
       final jsonData = await _client.get(
@@ -34,15 +36,16 @@ class BangumiApi {
         }
         bangumiCalendar.add(bangumiList);
       }
+      return Success(bangumiCalendar);
     } catch (e) {
       KazumiLogger().e('Resolve calendar failed', error: e);
+      return Failure(e);
     }
-    return bangumiCalendar;
   }
 
   // Official fallback for season switching. Mirror mode uses the cached
   // /kazumi/v1/calendar/season endpoint instead of Bangumi search.
-  static Future<List<List<BangumiItem>>> getCalendarBySearch(
+  static Future<Result<List<List<BangumiItem>>>> getCalendarBySearch(
       List<String> dateRange, int limit, int offset) async {
     List<BangumiItem> bangumiList = [];
     List<List<BangumiItem>> bangumiCalendar = [];
@@ -71,10 +74,6 @@ class BangumiApi {
           bangumiList.add(BangumiItem.fromJson(jsonItem));
         }
       }
-    } catch (e) {
-      KazumiLogger().e('Resolve bangumi list failed', error: e);
-    }
-    try {
       for (int weekday = 1; weekday <= 7; weekday++) {
         List<BangumiItem> bangumiDayList = [];
         for (BangumiItem bangumiItem in bangumiList) {
@@ -84,11 +83,11 @@ class BangumiApi {
         }
         bangumiCalendar.add(bangumiDayList);
       }
+      return Success(bangumiCalendar);
     } catch (e) {
-      KazumiLogger()
-          .e('Network: fetch bangumi item to calendar failed', error: e);
+      KazumiLogger().e('Resolve bangumi list failed', error: e);
+      return Failure(e);
     }
-    return bangumiCalendar;
   }
 
   static String buildBangumiMirrorSeasonCalendarPath(List<String> dateRange) {
@@ -101,7 +100,7 @@ class BangumiApi {
     ).toString();
   }
 
-  static Future<List<List<BangumiItem>>> getBangumiMirrorSeasonCalendar(
+  static Future<Result<List<List<BangumiItem>>>> getBangumiMirrorSeasonCalendar(
       List<String> dateRange) async {
     List<List<BangumiItem>> bangumiCalendar = [];
     try {
@@ -123,14 +122,15 @@ class BangumiApi {
         }
         bangumiCalendar.add(bangumiList);
       }
+      return Success(bangumiCalendar);
     } catch (e) {
       KazumiLogger().e('Network: resolve bangumi mirror season calendar failed',
           error: e);
+      return Failure(e);
     }
-    return bangumiCalendar;
   }
 
-  static Future<List<BangumiItem>> getBangumiList(
+  static Future<Result<List<BangumiItem>>> getBangumiList(
       {int rank = 2, String tag = ''}) async {
     List<BangumiItem> bangumiList = [];
     late Map<String, dynamic> params;
@@ -170,13 +170,14 @@ class BangumiApi {
           bangumiList.add(BangumiItem.fromJson(jsonItem));
         }
       }
+      return Success(bangumiList);
     } catch (e) {
       KazumiLogger().e('Network: resolve bangumi list failed', error: e);
+      return Failure(e);
     }
-    return bangumiList;
   }
 
-  static Future<List<BangumiItem>> getBangumiTrendsList(
+  static Future<Result<List<BangumiItem>>> getBangumiTrendsList(
       {int type = 2, int limit = 24, int offset = 0}) async {
     List<BangumiItem> bangumiList = [];
     var params = <String, dynamic>{
@@ -195,10 +196,11 @@ class BangumiApi {
           bangumiList.add(BangumiItem.fromJson(jsonItem['subject']));
         }
       }
+      return Success(bangumiList);
     } catch (e) {
       KazumiLogger().e('Network: resolve bangumi trends list failed', error: e);
+      return Failure(e);
     }
-    return bangumiList;
   }
 
   static String buildBangumiMirrorPopularPath({
@@ -216,7 +218,7 @@ class BangumiApi {
     ).toString();
   }
 
-  static Future<List<BangumiItem>> getBangumiMirrorPopularSubjects({
+  static Future<Result<List<BangumiItem>>> getBangumiMirrorPopularSubjects({
     String tag = '',
     int limit = 24,
     int offset = 0,
@@ -237,14 +239,15 @@ class BangumiApi {
           bangumiList.add(BangumiItem.fromJson(jsonItem));
         }
       }
+      return Success(bangumiList);
     } catch (e) {
       KazumiLogger()
           .e('Network: resolve bangumi mirror popular list failed', error: e);
+      return Failure(e);
     }
-    return bangumiList;
   }
 
-  static Future<List<BangumiItem>> bangumiSearch(String keyword,
+  static Future<Result<List<BangumiItem>>> bangumiSearch(String keyword,
       {List<String> tags = const [],
       int offset = 0,
       String sort = 'heat'}) async {
@@ -282,13 +285,14 @@ class BangumiApi {
           }
         }
       }
+      return Success(bangumiList);
     } catch (e) {
       KazumiLogger().e('Network: unknown search problem', error: e);
+      return Failure(e);
     }
-    return bangumiList;
   }
 
-  static Future<BangumiItem?> getBangumiInfoByID(int id) async {
+  static Future<Result<BangumiItem>> getBangumiInfoByID(int id) async {
     try {
       final jsonData = await _client.get(
         ApiEndpoints.formatUrl(
@@ -296,15 +300,14 @@ class BangumiApi {
                 ApiEndpoints.bangumiInfoByIDNext,
             [id]),
       );
-      return BangumiItem.fromJson(jsonData);
+      return Success(BangumiItem.fromJson(jsonData));
     } catch (e) {
       KazumiLogger().e('Network: resolve bangumi item failed', error: e);
-      return null;
+      return Failure(e);
     }
   }
 
-  static Future<EpisodeInfo> getBangumiEpisodeByID(int id, int episode) async {
-    EpisodeInfo episodeInfo = EpisodeInfo.fromTemplate();
+  static Future<Result<EpisodeInfo>> getBangumiEpisodeByID(int id, int episode) async {
     var params = <String, dynamic>{
       'subject_id': id,
       'offset': episode - 1,
@@ -315,14 +318,14 @@ class BangumiApi {
         ApiEndpoints.bangumiAPIDomain + ApiEndpoints.bangumiEpisodeByID,
         queryParameters: params,
       );
-      episodeInfo = EpisodeInfo.fromJson(jsonData['data'][0]);
+      return Success(EpisodeInfo.fromJson(jsonData['data'][0]));
     } catch (e) {
       KazumiLogger().e('Network: resolve bangumi episode failed', error: e);
+      return Failure(e);
     }
-    return episodeInfo;
   }
 
-  static Future<List<EpisodeInfo>> getBangumiEpisodesByID(int id) async {
+  static Future<Result<List<EpisodeInfo>>> getBangumiEpisodesByID(int id) async {
     final List<EpisodeInfo> episodeList = [];
     const int limit = 100;
     int offset = 0;
@@ -348,11 +351,12 @@ class BangumiApi {
             .map((jsonItem) => EpisodeInfo.fromJson(jsonItem)));
         offset += data.length;
       } while (total == null || offset < total);
+      return Success(episodeList);
     } catch (e) {
       KazumiLogger()
           .e('Network: resolve bangumi episode list failed', error: e);
+      return Failure(e);
     }
-    return episodeList;
   }
 
   static Future<CommentResponse> getBangumiCommentsByID(int id,
@@ -406,8 +410,7 @@ class BangumiApi {
     return CharactersResponse.fromJson(jsonData);
   }
 
-  static Future<CharacterFullItem> getCharacterByCharacterID(int id) async {
-    CharacterFullItem characterFullItem = CharacterFullItem.fromTemplate();
+  static Future<Result<CharacterFullItem>> getCharacterByCharacterID(int id) async {
     try {
       final jsonData = await _client.get(
         ApiEndpoints.formatUrl(
@@ -415,11 +418,11 @@ class BangumiApi {
                 ApiEndpoints.bangumiCharacterInfoByCharacterIDNext,
             [id]),
       );
-      characterFullItem = CharacterFullItem.fromJson(jsonData);
+      return Success(CharacterFullItem.fromJson(jsonData));
     } catch (e) {
       KazumiLogger().e('Network: resolve character info failed', error: e);
+      return Failure(e);
     }
-    return characterFullItem;
   }
 
   static Future<String?> getUsername() async {

--- a/lib/request/apis/bangumi_result.dart
+++ b/lib/request/apis/bangumi_result.dart
@@ -1,0 +1,27 @@
+/// A discriminated union for operation results, replacing silent null/empty
+/// returns so callers are forced by the compiler to handle both outcomes.
+///
+/// Usage:
+/// ```dart
+/// final result = await BangumiApi.getCalendar();
+/// switch (result) {
+///   case Success(:final value):
+///     // use value (List<List<BangumiItem>>)
+///   case Failure(:final error):
+///     // handle error
+/// }
+/// ```
+sealed class Result<T> {
+  const Result();
+}
+
+final class Success<T> extends Result<T> {
+  const Success(this.value);
+  final T value;
+}
+
+final class Failure<T> extends Result<T> {
+  const Failure(this.error, [this.stackTrace]);
+  final Object error;
+  final StackTrace? stackTrace;
+}

--- a/lib/request/core/network_config.dart
+++ b/lib/request/core/network_config.dart
@@ -94,7 +94,8 @@ class NetworkConfig {
       sendTimeout: sendTimeout,
       proxyHost: parsed.$1,
       proxyPort: parsed.$2,
-      allowBadCertificates: true,
+      allowBadCertificates:
+          GStorage.getSetting(SettingsKeys.allowBadCertificates),
     );
   }
 }

--- a/lib/services/logging/logger.dart
+++ b/lib/services/logging/logger.dart
@@ -107,6 +107,9 @@ class KazumiLogOutput extends LogOutput {
   static final Lock _logLock = Lock();
   static String? _logFilePath;
 
+  static const int _maxLogSizeBytes = 5 * 1024 * 1024; // 5 MB
+  static const int _maxLogFiles = 3;
+
   static Future<String> _getLogFilePath() async {
     if (_logFilePath != null) return _logFilePath!;
 
@@ -139,6 +142,14 @@ class KazumiLogOutput extends LogOutput {
         final filePath = await _getLogFilePath();
         final file = File(filePath);
 
+        // Rotate if the current log exceeds the size limit.
+        if (await file.exists()) {
+          final size = await file.length();
+          if (size >= _maxLogSizeBytes) {
+            await _rotateLogFiles(filePath);
+          }
+        }
+
         final timestamp = DateTime.now().toString();
 
         final buffer = StringBuffer();
@@ -157,6 +168,23 @@ class KazumiLogOutput extends LogOutput {
         print('Failed to write log to file: $e');
       }
     });
+  }
+
+  /// Rotate logs when the active file exceeds [_maxLogSizeBytes].
+  /// Keeps at most [_maxLogFiles] rotated copies by shifting
+  /// existing files and renaming the active log to .1.
+  Future<void> _rotateLogFiles(String activePath) async {
+    final oldestFile = File('$activePath.$_maxLogFiles');
+    if (await oldestFile.exists()) {
+      await oldestFile.delete();
+    }
+    for (int i = _maxLogFiles - 1; i >= 1; i--) {
+      final oldFile = File('$activePath.$i');
+      if (await oldFile.exists()) {
+        await oldFile.rename('$activePath.${i + 1}');
+      }
+    }
+    await File(activePath).rename('$activePath.1');
   }
 
   /// Remove ANSI escape codes from string to ensure clean log files
@@ -254,13 +282,24 @@ Future<File> getLogsPath() async {
 
 Future<bool> clearLogs() async {
   try {
-    final file = await getLogsPath();
+    final filePath = await KazumiLogOutput._getLogFilePath();
     await KazumiLogOutput._logLock.synchronized(() async {
-      await file.writeAsString('');
+      // Clear active log
+      final file = File(filePath);
+      if (await file.exists()) {
+        await file.writeAsString('');
+      }
+      // Clear rotated log files
+      for (int i = 1; i <= KazumiLogOutput._maxLogFiles; i++) {
+        final rotated = File('$filePath.$i');
+        if (await rotated.exists()) {
+          await rotated.delete();
+        }
+      }
     });
     return true;
   } catch (e) {
-    print('Error clearing file: $e');
+    print('Error clearing logs: $e');
     return false;
   }
 }

--- a/lib/services/player/syncplay_client.dart
+++ b/lib/services/player/syncplay_client.dart
@@ -4,6 +4,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:kazumi/services/logging/logger.dart';
+
 const double PING_MOVING_AVERAGE_WEIGHT = 0.85;
 
 class SyncplayException implements Exception {
@@ -273,9 +275,9 @@ class SyncplayClient {
     try {
       await _socket?.close();
       _socket = null;
-      print('SyncPlay: connecting to Syncplay server: $_host:$_port');
+      KazumiLogger().i('SyncPlay: connecting to Syncplay server: $_host:$_port');
       _socket = await Socket.connect(_host, _port);
-      print('SyncPlay: connected to Syncplay server: $_host:$_port');
+      KazumiLogger().i('SyncPlay: connected to Syncplay server: $_host:$_port');
       _setupSocketHandlers();
       if (enableTLS) {
         requestTLS();
@@ -289,12 +291,12 @@ class SyncplayClient {
   }
 
   Future<void> requestTLS() async {
-    print('SyncPlay: requesting TLS connection upgrade');
+    KazumiLogger().i('SyncPlay: requesting TLS connection upgrade');
     await _sendMessage(TLSMessage(message: 'send'));
   }
 
   Future<void> joinRoom(String room, String username) async {
-    print('SyncPlay: joining room: $room as $username');
+    KazumiLogger().i('SyncPlay: joining room: $room as $username');
     await _sendMessage(HelloMessage(
       username: username,
       version: '1.7.0',
@@ -342,7 +344,7 @@ class SyncplayClient {
   }
 
   Future<void> disconnect() async {
-    print('SyncPlay: disconnecting from Syncplay server: $_host:$_port');
+    KazumiLogger().i('SyncPlay: disconnecting from Syncplay server: $_host:$_port');
     await _generalMessageController?.close();
     _generalMessageController = null;
     await _roomMessageController?.close();
@@ -441,12 +443,12 @@ class SyncplayClient {
             _socket = await SecureSocket.secure(plainSocket!);
             _setupSocketHandlers();
             _isTLS = true;
-            print('SyncPlay: TLS connection established');
+            KazumiLogger().i('SyncPlay: TLS connection established');
             try {
               plainSocket.close();
             } catch (_) {}
           } catch (e) {
-            print('SyncPlay: TLS connection upgrade failed: $e');
+            KazumiLogger().e('SyncPlay: TLS connection upgrade failed', error: e);
             _socket = plainSocket;
             _isTLS = false;
           }
@@ -459,7 +461,7 @@ class SyncplayClient {
           json['Hello']['room'].containsKey('name')) {
         _username = json['Hello']['username'];
         _currentRoom = json['Hello']['room']['name'];
-        print(
+        KazumiLogger().i(
             'SyncPlay: joined room: $_currentRoom as $_username, version: ${json['Hello']['version']}');
         _setReady();
       }

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -1,0 +1,694 @@
+enum SettingGroup {
+  player,
+  danmaku,
+  theme,
+  interface,
+  proxy,
+  webdav,
+  download,
+  bangumi,
+  collect,
+  sync,
+  update,
+  misc,
+}
+
+class SettingContext {
+  const SettingContext({this.compactLayout = false});
+
+  final bool compactLayout;
+}
+
+class SettingKey<T> {
+  const SettingKey(
+    this.name,
+    this.defaultValue, {
+    required this.group,
+    this.defaultResolver,
+  });
+
+  final String name;
+  final T defaultValue;
+  final SettingGroup group;
+  final T Function(SettingContext context)? defaultResolver;
+
+  T resolveDefault(SettingContext context) {
+    return defaultResolver?.call(context) ?? defaultValue;
+  }
+}
+
+// Add new settings here. SettingsKeys is the public typed registry used by
+// callers; new keys can use literal string names directly.
+class SettingsKeys {
+  static const hAenable = SettingKey<bool>(
+    _SettingBoxKey.hAenable,
+    true,
+    group: SettingGroup.player,
+  );
+  static const hardwareDecoder = SettingKey<String>(
+    _SettingBoxKey.hardwareDecoder,
+    'auto-safe',
+    group: SettingGroup.player,
+  );
+  static const searchEnhanceEnable = SettingKey<bool>(
+    _SettingBoxKey.searchEnhanceEnable,
+    true,
+    group: SettingGroup.misc,
+  );
+  static const autoUpdate = SettingKey<bool>(
+    _SettingBoxKey.autoUpdate,
+    true,
+    group: SettingGroup.update,
+  );
+  static const alwaysOntop = SettingKey<bool>(
+    _SettingBoxKey.alwaysOntop,
+    false,
+    group: SettingGroup.misc,
+  );
+  static const defaultPlaySpeed = SettingKey<double>(
+    _SettingBoxKey.defaultPlaySpeed,
+    1.0,
+    group: SettingGroup.player,
+  );
+  static const defaultShortcutForwardPlaySpeed = SettingKey<double>(
+    _SettingBoxKey.defaultShortcutForwardPlaySpeed,
+    2.0,
+    group: SettingGroup.player,
+  );
+  static const defaultAspectRatioType = SettingKey<int>(
+    _SettingBoxKey.defaultAspectRatioType,
+    1,
+    group: SettingGroup.player,
+  );
+  static const buttonSkipTime = SettingKey<int>(
+    _SettingBoxKey.buttonSkipTime,
+    80,
+    group: SettingGroup.player,
+  );
+  static const arrowKeySkipTime = SettingKey<int>(
+    _SettingBoxKey.arrowKeySkipTime,
+    10,
+    group: SettingGroup.player,
+  );
+  static const danmakuEnhance = SettingKey<bool>(
+    _SettingBoxKey.danmakuEnhance,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuBorder = SettingKey<bool>(
+    _SettingBoxKey.danmakuBorder,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuBorderSize = SettingKey<double>(
+    _SettingBoxKey.danmakuBorderSize,
+    1.5,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuOpacity = SettingKey<double>(
+    _SettingBoxKey.danmakuOpacity,
+    1.0,
+    group: SettingGroup.danmaku,
+  );
+  static final danmakuFontSize = SettingKey<double>(
+    _SettingBoxKey.danmakuFontSize,
+    25.0,
+    group: SettingGroup.danmaku,
+    defaultResolver: (context) => context.compactLayout ? 16.0 : 25.0,
+  );
+  static const danmakuTop = SettingKey<bool>(
+    _SettingBoxKey.danmakuTop,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuScroll = SettingKey<bool>(
+    _SettingBoxKey.danmakuScroll,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuBottom = SettingKey<bool>(
+    _SettingBoxKey.danmakuBottom,
+    false,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuMassive = SettingKey<bool>(
+    _SettingBoxKey.danmakuMassive,
+    false,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuDeduplication = SettingKey<bool>(
+    _SettingBoxKey.danmakuDeduplication,
+    false,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuArea = SettingKey<double>(
+    _SettingBoxKey.danmakuArea,
+    1.0,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuColor = SettingKey<bool>(
+    _SettingBoxKey.danmakuColor,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuDuration = SettingKey<double>(
+    _SettingBoxKey.danmakuDuration,
+    8.0,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuLineHeight = SettingKey<double>(
+    _SettingBoxKey.danmakuLineHeight,
+    1.6,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuTimeOffset = SettingKey<double>(
+    _SettingBoxKey.danmakuTimeOffset,
+    0.0,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuEnabledByDefault = SettingKey<bool>(
+    _SettingBoxKey.danmakuEnabledByDefault,
+    false,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuBiliBiliSource = SettingKey<bool>(
+    _SettingBoxKey.danmakuBiliBiliSource,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuGamerSource = SettingKey<bool>(
+    _SettingBoxKey.danmakuGamerSource,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuDanDanSource = SettingKey<bool>(
+    _SettingBoxKey.danmakuDanDanSource,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuFontWeight = SettingKey<int>(
+    _SettingBoxKey.danmakuFontWeight,
+    4,
+    group: SettingGroup.danmaku,
+  );
+  static const danmakuFollowSpeed = SettingKey<bool>(
+    _SettingBoxKey.danmakuFollowSpeed,
+    true,
+    group: SettingGroup.danmaku,
+  );
+  static const themeMode = SettingKey<String>(
+    _SettingBoxKey.themeMode,
+    'system',
+    group: SettingGroup.theme,
+  );
+  static const themeColor = SettingKey<String>(
+    _SettingBoxKey.themeColor,
+    'default',
+    group: SettingGroup.theme,
+  );
+  static const privateMode = SettingKey<bool>(
+    _SettingBoxKey.privateMode,
+    false,
+    group: SettingGroup.player,
+  );
+  static const autoPlay = SettingKey<bool>(
+    _SettingBoxKey.autoPlay,
+    true,
+    group: SettingGroup.player,
+  );
+  static const autoPlayNext = SettingKey<bool>(
+    _SettingBoxKey.autoPlayNext,
+    true,
+    group: SettingGroup.player,
+  );
+  static const playResume = SettingKey<bool>(
+    _SettingBoxKey.playResume,
+    true,
+    group: SettingGroup.player,
+  );
+  static const showPlayerError = SettingKey<bool>(
+    _SettingBoxKey.showPlayerError,
+    true,
+    group: SettingGroup.player,
+  );
+  static const oledEnhance = SettingKey<bool>(
+    _SettingBoxKey.oledEnhance,
+    false,
+    group: SettingGroup.theme,
+  );
+  static const displayMode = SettingKey<String?>(
+    _SettingBoxKey.displayMode,
+    null,
+    group: SettingGroup.interface,
+  );
+  static const enableGitProxy = SettingKey<bool>(
+    _SettingBoxKey.enableGitProxy,
+    false,
+    group: SettingGroup.proxy,
+  );
+  static const enableBangumiProxy = SettingKey<bool>(
+    _SettingBoxKey.enableBangumiProxy,
+    false,
+    group: SettingGroup.proxy,
+  );
+  static const enableSystemProxy = SettingKey<bool>(
+    _SettingBoxKey.enableSystemProxy,
+    false,
+    group: SettingGroup.proxy,
+  );
+  static const defaultStartupPage = SettingKey<String>(
+    _SettingBoxKey.defaultStartupPage,
+    '/tab/popular/',
+    group: SettingGroup.interface,
+  );
+  static const isWideScreen = SettingKey<bool>(
+    _SettingBoxKey.isWideScreen,
+    false,
+    group: SettingGroup.interface,
+  );
+  static const webDavEnable = SettingKey<bool>(
+    _SettingBoxKey.webDavEnable,
+    false,
+    group: SettingGroup.webdav,
+  );
+  static const webDavEnableHistory = SettingKey<bool>(
+    _SettingBoxKey.webDavEnableHistory,
+    false,
+    group: SettingGroup.webdav,
+  );
+  static const webDavEnableCollect = SettingKey<bool>(
+    _SettingBoxKey.webDavEnableCollect,
+    false,
+    group: SettingGroup.webdav,
+  );
+  static const webDavURL = SettingKey<String>(
+    _SettingBoxKey.webDavURL,
+    '',
+    group: SettingGroup.webdav,
+  );
+  static const webDavUsername = SettingKey<String>(
+    _SettingBoxKey.webDavUsername,
+    '',
+    group: SettingGroup.webdav,
+  );
+  static const webDavPassword = SettingKey<String>(
+    _SettingBoxKey.webDavPassword,
+    '',
+    group: SettingGroup.webdav,
+  );
+  static const lowMemoryMode = SettingKey<bool>(
+    _SettingBoxKey.lowMemoryMode,
+    false,
+    group: SettingGroup.player,
+  );
+  static const showWindowButton = SettingKey<bool>(
+    _SettingBoxKey.showWindowButton,
+    false,
+    group: SettingGroup.theme,
+  );
+  static const useDynamicColor = SettingKey<bool>(
+    _SettingBoxKey.useDynamicColor,
+    false,
+    group: SettingGroup.theme,
+  );
+  static const exitBehavior = SettingKey<int>(
+    _SettingBoxKey.exitBehavior,
+    2,
+    group: SettingGroup.interface,
+  );
+  static const playerDebugMode = SettingKey<bool>(
+    _SettingBoxKey.playerDebugMode,
+    false,
+    group: SettingGroup.player,
+  );
+  static const syncPlayEndPoint = SettingKey<String>(
+    _SettingBoxKey.syncPlayEndPoint,
+    '127.0.0.1:8999',
+    group: SettingGroup.player,
+  );
+  static const androidEnableOpenSLES = SettingKey<bool>(
+    _SettingBoxKey.androidEnableOpenSLES,
+    true,
+    group: SettingGroup.player,
+  );
+  static const androidVideoRenderer = SettingKey<String>(
+    _SettingBoxKey.androidVideoRenderer,
+    'auto',
+    group: SettingGroup.player,
+  );
+  static const androidAutoEnterPIP = SettingKey<bool>(
+    _SettingBoxKey.androidAutoEnterPIP,
+    false,
+    group: SettingGroup.player,
+  );
+  static const defaultSuperResolutionType = SettingKey<int>(
+    _SettingBoxKey.defaultSuperResolutionType,
+    1,
+    group: SettingGroup.player,
+  );
+  static const superResolutionWarn = SettingKey<bool>(
+    _SettingBoxKey.superResolutionWarn,
+    false,
+    group: SettingGroup.player,
+  );
+  static const playerDisableAnimations = SettingKey<bool>(
+    _SettingBoxKey.playerDisableAnimations,
+    false,
+    group: SettingGroup.player,
+  );
+  static const playerLogLevel = SettingKey<int>(
+    _SettingBoxKey.playerLogLevel,
+    2,
+    group: SettingGroup.player,
+  );
+  static const searchNotShowWatchedBangumis = SettingKey<bool>(
+    _SettingBoxKey.searchNotShowWatchedBangumis,
+    false,
+    group: SettingGroup.collect,
+  );
+  static const searchNotShowAbandonedBangumis = SettingKey<bool>(
+    _SettingBoxKey.searchNotShowAbandonedBangumis,
+    false,
+    group: SettingGroup.collect,
+  );
+  static const timelineNotShowAbandonedBangumis = SettingKey<bool>(
+    _SettingBoxKey.timelineNotShowAbandonedBangumis,
+    false,
+    group: SettingGroup.collect,
+  );
+  static const timelineNotShowWatchedBangumis = SettingKey<bool>(
+    _SettingBoxKey.timelineNotShowWatchedBangumis,
+    false,
+    group: SettingGroup.collect,
+  );
+  static const timelineOnlyShowWatchingBangumis = SettingKey<bool>(
+    _SettingBoxKey.timelineOnlyShowWatchingBangumis,
+    false,
+    group: SettingGroup.collect,
+  );
+  static const useSystemFont = SettingKey<bool>(
+    _SettingBoxKey.useSystemFont,
+    false,
+    group: SettingGroup.theme,
+  );
+  static const forceAdBlocker = SettingKey<bool>(
+    _SettingBoxKey.forceAdBlocker,
+    false,
+    group: SettingGroup.player,
+  );
+  static const backgroundPlayback = SettingKey<bool>(
+    _SettingBoxKey.backgroundPlayback,
+    false,
+    group: SettingGroup.player,
+  );
+  static const proxyEnable = SettingKey<bool>(
+    _SettingBoxKey.proxyEnable,
+    false,
+    group: SettingGroup.proxy,
+  );
+  static const proxyConfigured = SettingKey<bool>(
+    _SettingBoxKey.proxyConfigured,
+    false,
+    group: SettingGroup.proxy,
+  );
+  static const proxyUrl = SettingKey<String>(
+    _SettingBoxKey.proxyUrl,
+    '',
+    group: SettingGroup.proxy,
+  );
+  static const proxyTestUrl = SettingKey<String>(
+    _SettingBoxKey.proxyTestUrl,
+    '',
+    group: SettingGroup.proxy,
+  );
+  static const showRating = SettingKey<bool>(
+    _SettingBoxKey.showRating,
+    true,
+    group: SettingGroup.interface,
+  );
+  static const downloadParallelEpisodes = SettingKey<int>(
+    _SettingBoxKey.downloadParallelEpisodes,
+    2,
+    group: SettingGroup.download,
+  );
+  static const downloadParallelSegments = SettingKey<int>(
+    _SettingBoxKey.downloadParallelSegments,
+    3,
+    group: SettingGroup.download,
+  );
+  static const downloadDanmaku = SettingKey<bool>(
+    _SettingBoxKey.downloadDanmaku,
+    true,
+    group: SettingGroup.download,
+  );
+  static const shortcutDialogShown = SettingKey<bool>(
+    _SettingBoxKey.shortcutDialogShown,
+    false,
+    group: SettingGroup.misc,
+  );
+  static const bangumiSyncEnable = SettingKey<bool>(
+    _SettingBoxKey.bangumiSyncEnable,
+    false,
+    group: SettingGroup.bangumi,
+  );
+  static const bangumiAccessToken = SettingKey<String>(
+    _SettingBoxKey.bangumiAccessToken,
+    '',
+    group: SettingGroup.bangumi,
+  );
+  static const bangumiSyncPriority = SettingKey<int>(
+    _SettingBoxKey.bangumiSyncPriority,
+    0,
+    group: SettingGroup.bangumi,
+  );
+  static const bangumiImmediateSyncToastEnable = SettingKey<bool>(
+    _SettingBoxKey.bangumiImmediateSyncToastEnable,
+    true,
+    group: SettingGroup.bangumi,
+  );
+  static const brightnessVolumeGesture = SettingKey<bool>(
+    _SettingBoxKey.brightnessVolumeGesture,
+    true,
+    group: SettingGroup.player,
+  );
+  static const historySyncDeviceId = SettingKey<String>(
+    _SettingBoxKey.historySyncDeviceId,
+    '',
+    group: SettingGroup.sync,
+  );
+  static const historySyncSequence = SettingKey<int>(
+    _SettingBoxKey.historySyncSequence,
+    0,
+    group: SettingGroup.sync,
+  );
+  static const historySyncSnapshotInitialized = SettingKey<bool>(
+    _SettingBoxKey.historySyncSnapshotInitialized,
+    false,
+    group: SettingGroup.sync,
+  );
+  static const allowBadCertificates = SettingKey<bool>(
+    _SettingBoxKey.allowBadCertificates,
+    false,
+    group: SettingGroup.proxy,
+  );
+
+  static final List<SettingKey<Object?>> all = [
+    hAenable,
+    hardwareDecoder,
+    searchEnhanceEnable,
+    autoUpdate,
+    alwaysOntop,
+    defaultPlaySpeed,
+    defaultShortcutForwardPlaySpeed,
+    defaultAspectRatioType,
+    buttonSkipTime,
+    arrowKeySkipTime,
+    danmakuEnhance,
+    danmakuBorder,
+    danmakuBorderSize,
+    danmakuOpacity,
+    danmakuFontSize,
+    danmakuTop,
+    danmakuScroll,
+    danmakuBottom,
+    danmakuMassive,
+    danmakuDeduplication,
+    danmakuArea,
+    danmakuColor,
+    danmakuDuration,
+    danmakuLineHeight,
+    danmakuTimeOffset,
+    danmakuEnabledByDefault,
+    danmakuBiliBiliSource,
+    danmakuGamerSource,
+    danmakuDanDanSource,
+    danmakuFontWeight,
+    danmakuFollowSpeed,
+    themeMode,
+    themeColor,
+    privateMode,
+    autoPlay,
+    autoPlayNext,
+    playResume,
+    showPlayerError,
+    oledEnhance,
+    displayMode,
+    enableGitProxy,
+    enableBangumiProxy,
+    enableSystemProxy,
+    defaultStartupPage,
+    isWideScreen,
+    webDavEnable,
+    webDavEnableHistory,
+    webDavEnableCollect,
+    webDavURL,
+    webDavUsername,
+    webDavPassword,
+    lowMemoryMode,
+    showWindowButton,
+    useDynamicColor,
+    exitBehavior,
+    playerDebugMode,
+    syncPlayEndPoint,
+    androidEnableOpenSLES,
+    androidVideoRenderer,
+    androidAutoEnterPIP,
+    defaultSuperResolutionType,
+    superResolutionWarn,
+    playerDisableAnimations,
+    playerLogLevel,
+    searchNotShowWatchedBangumis,
+    searchNotShowAbandonedBangumis,
+    timelineNotShowAbandonedBangumis,
+    timelineNotShowWatchedBangumis,
+    timelineOnlyShowWatchingBangumis,
+    useSystemFont,
+    forceAdBlocker,
+    backgroundPlayback,
+    proxyEnable,
+    proxyConfigured,
+    proxyUrl,
+    proxyTestUrl,
+    showRating,
+    downloadParallelEpisodes,
+    downloadParallelSegments,
+    downloadDanmaku,
+    shortcutDialogShown,
+    bangumiSyncEnable,
+    bangumiAccessToken,
+    bangumiSyncPriority,
+    bangumiImmediateSyncToastEnable,
+    brightnessVolumeGesture,
+    historySyncDeviceId,
+    historySyncSequence,
+    historySyncSnapshotInitialized,
+    allowBadCertificates,
+  ];
+
+  static List<SettingKey<Object?>> byGroup(SettingGroup group) {
+    return [
+      for (final key in all)
+        if (key.group == group) key
+    ];
+  }
+
+  SettingsKeys._();
+}
+// Historical Hive key names used by settings created before the typed registry.
+// Keep these strings stable so existing users keep their saved settings.
+// New settings do not need to be added here unless they intentionally reuse an
+// existing persisted key.
+class _SettingBoxKey {
+  static const String hAenable = 'hAenable',
+      hardwareDecoder = 'hardwareDecoder',
+      searchEnhanceEnable = 'searchEnhanceEnable',
+      autoUpdate = 'autoUpdate',
+      alwaysOntop = 'alwaysOntop',
+      defaultPlaySpeed = 'defaultPlaySpeed',
+      defaultShortcutForwardPlaySpeed = 'defaultShortcutForwardPlaySpeed',
+      defaultAspectRatioType = 'defaultAspectRatioType',
+      buttonSkipTime = 'buttonSkipTime',
+      arrowKeySkipTime = 'arrowKeySkipTime',
+      danmakuEnhance = 'danmakuEnhance',
+      danmakuBorder = 'danmakuBorder',
+      danmakuBorderSize = 'danmakuBorderSize',
+      danmakuOpacity = 'danmakuOpacity',
+      danmakuFontSize = 'danmakuFontSize',
+      danmakuTop = 'danmakuTop',
+      danmakuScroll = 'danmakuScroll',
+      danmakuBottom = 'danmakuBottom',
+      danmakuMassive = 'danmakuMassive',
+      danmakuDeduplication = 'danmakuDeduplication',
+      danmakuArea = 'danmakuArea',
+      danmakuColor = 'danmakuColor',
+      danmakuDuration = 'danmakuDuration',
+      danmakuLineHeight = 'danmakuLineHeight',
+      danmakuTimeOffset = 'danmakuTimeOffset',
+      danmakuEnabledByDefault = 'danmakuEnabledByDefault',
+      danmakuBiliBiliSource = 'danmakuBiliBiliSource',
+      danmakuGamerSource = 'danmakuGamerSource',
+      danmakuDanDanSource = 'danmakuDanDanSource',
+      danmakuFontWeight = 'danmakuFontWeight',
+      danmakuFollowSpeed = 'danmakuFollowSpeed',
+      themeMode = 'themeMode',
+      themeColor = 'themeColor',
+      privateMode = 'privateMode',
+      autoPlay = 'autoPlay',
+      autoPlayNext = 'autoPlayNext',
+      playResume = 'playResume',
+      showPlayerError = 'showPlayerError',
+      oledEnhance = 'oledEnhance',
+      displayMode = 'displayMode',
+      enableGitProxy = 'enableGitProxy',
+      enableBangumiProxy = 'enableBangumiProxy',
+      enableSystemProxy = 'enableSystemProxy',
+      defaultStartupPage = 'defaultStartupPage',
+
+      /// Deprecated
+      isWideScreen = 'isWideScreen',
+      webDavEnable = 'webDavEnable',
+      webDavEnableHistory = 'webDavEnableHistory',
+      webDavEnableCollect = 'webDavEnableCollect',
+      webDavURL = 'webDavURL',
+      webDavUsername = 'webDavUsername',
+      webDavPassword = 'webDavPasswd',
+      lowMemoryMode = 'lowMemoryMode',
+      showWindowButton = 'showWindowButton',
+      useDynamicColor = 'useDynamicColor',
+      exitBehavior = 'exitBehavior',
+      playerDebugMode = 'playerDebugMode',
+      syncPlayEndPoint = 'syncPlayEndPoint',
+      androidEnableOpenSLES = 'androidEnableOpenSLES',
+      androidVideoRenderer = 'androidVideoRenderer',
+      androidAutoEnterPIP = 'androidAutoEnterPIP',
+      defaultSuperResolutionType = 'defaultSuperResolutionType',
+      superResolutionWarn = 'superResolutionWarn',
+      playerDisableAnimations = 'playerDisableAnimations',
+      playerLogLevel = 'playerLogLevel',
+      searchNotShowWatchedBangumis = 'searchNotShowWatchedBangumis',
+      searchNotShowAbandonedBangumis = 'searchNotShowAbandonedBangumis',
+      timelineNotShowAbandonedBangumis = 'timelineNotShowAbandonedBangumis',
+      timelineNotShowWatchedBangumis = 'timelineNotShowWatchedBangumis',
+      timelineOnlyShowWatchingBangumis = 'timelineOnlyShowWatchingBangumis',
+      useSystemFont = 'useSystemFont',
+      forceAdBlocker = 'forceAdBlocker',
+      backgroundPlayback = 'backgroundPlayback',
+      proxyEnable = 'proxyEnable',
+      proxyConfigured = 'proxyConfigured',
+      proxyUrl = 'proxyUrl',
+      proxyTestUrl = 'proxyTestUrl',
+      showRating = 'showRating',
+      downloadParallelEpisodes = 'downloadParallelEpisodes',
+      downloadParallelSegments = 'downloadParallelSegments',
+      downloadDanmaku = 'downloadDanmaku',
+      shortcutDialogShown = 'shortcutDialogShown',
+      bangumiSyncEnable = 'bangumiSyncEnable',
+      bangumiAccessToken = 'bangumiAccessToken',
+      bangumiSyncPriority = 'bangumiSyncPriority',
+      bangumiImmediateSyncToastEnable = 'bangumiImmediateSyncToastEnable',
+      brightnessVolumeGesture = 'brightnessVolumeGesture',
+      historySyncDeviceId = 'historySyncDeviceId',
+      historySyncSequence = 'historySyncSequence',
+      historySyncSnapshotInitialized = 'historySyncSnapshotInitialized',
+      allowBadCertificates = 'allowBadCertificates';
+}

--- a/lib/services/storage/storage.dart
+++ b/lib/services/storage/storage.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:path_provider/path_provider.dart';
@@ -11,597 +12,9 @@ import 'package:kazumi/modules/collect/collect_change_module.dart';
 import 'package:kazumi/modules/collect/collect_sync_merger.dart';
 import 'package:kazumi/modules/search/search_history_module.dart';
 import 'package:kazumi/modules/download/download_module.dart';
+import 'package:kazumi/services/storage/settings_keys.dart';
 
-enum SettingGroup {
-  player,
-  danmaku,
-  theme,
-  interface,
-  proxy,
-  webdav,
-  download,
-  bangumi,
-  collect,
-  sync,
-  update,
-  misc,
-}
-
-class SettingContext {
-  const SettingContext({this.compactLayout = false});
-
-  final bool compactLayout;
-}
-
-class SettingKey<T> {
-  const SettingKey(
-    this.name,
-    this.defaultValue, {
-    required this.group,
-    this.defaultResolver,
-  });
-
-  final String name;
-  final T defaultValue;
-  final SettingGroup group;
-  final T Function(SettingContext context)? defaultResolver;
-
-  T resolveDefault(SettingContext context) {
-    return defaultResolver?.call(context) ?? defaultValue;
-  }
-}
-
-// Add new settings here. SettingsKeys is the public typed registry used by
-// callers; new keys can use literal string names directly.
-class SettingsKeys {
-  static const hAenable = SettingKey<bool>(
-    _SettingBoxKey.hAenable,
-    true,
-    group: SettingGroup.player,
-  );
-  static const hardwareDecoder = SettingKey<String>(
-    _SettingBoxKey.hardwareDecoder,
-    'auto-safe',
-    group: SettingGroup.player,
-  );
-  static const searchEnhanceEnable = SettingKey<bool>(
-    _SettingBoxKey.searchEnhanceEnable,
-    true,
-    group: SettingGroup.misc,
-  );
-  static const autoUpdate = SettingKey<bool>(
-    _SettingBoxKey.autoUpdate,
-    true,
-    group: SettingGroup.update,
-  );
-  static const alwaysOntop = SettingKey<bool>(
-    _SettingBoxKey.alwaysOntop,
-    false,
-    group: SettingGroup.misc,
-  );
-  static const defaultPlaySpeed = SettingKey<double>(
-    _SettingBoxKey.defaultPlaySpeed,
-    1.0,
-    group: SettingGroup.player,
-  );
-  static const defaultShortcutForwardPlaySpeed = SettingKey<double>(
-    _SettingBoxKey.defaultShortcutForwardPlaySpeed,
-    2.0,
-    group: SettingGroup.player,
-  );
-  static const defaultAspectRatioType = SettingKey<int>(
-    _SettingBoxKey.defaultAspectRatioType,
-    1,
-    group: SettingGroup.player,
-  );
-  static const buttonSkipTime = SettingKey<int>(
-    _SettingBoxKey.buttonSkipTime,
-    80,
-    group: SettingGroup.player,
-  );
-  static const arrowKeySkipTime = SettingKey<int>(
-    _SettingBoxKey.arrowKeySkipTime,
-    10,
-    group: SettingGroup.player,
-  );
-  static const danmakuEnhance = SettingKey<bool>(
-    _SettingBoxKey.danmakuEnhance,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuBorder = SettingKey<bool>(
-    _SettingBoxKey.danmakuBorder,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuBorderSize = SettingKey<double>(
-    _SettingBoxKey.danmakuBorderSize,
-    1.5,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuOpacity = SettingKey<double>(
-    _SettingBoxKey.danmakuOpacity,
-    1.0,
-    group: SettingGroup.danmaku,
-  );
-  static final danmakuFontSize = SettingKey<double>(
-    _SettingBoxKey.danmakuFontSize,
-    25.0,
-    group: SettingGroup.danmaku,
-    defaultResolver: (context) => context.compactLayout ? 16.0 : 25.0,
-  );
-  static const danmakuTop = SettingKey<bool>(
-    _SettingBoxKey.danmakuTop,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuScroll = SettingKey<bool>(
-    _SettingBoxKey.danmakuScroll,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuBottom = SettingKey<bool>(
-    _SettingBoxKey.danmakuBottom,
-    false,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuMassive = SettingKey<bool>(
-    _SettingBoxKey.danmakuMassive,
-    false,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuDeduplication = SettingKey<bool>(
-    _SettingBoxKey.danmakuDeduplication,
-    false,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuArea = SettingKey<double>(
-    _SettingBoxKey.danmakuArea,
-    1.0,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuColor = SettingKey<bool>(
-    _SettingBoxKey.danmakuColor,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuDuration = SettingKey<double>(
-    _SettingBoxKey.danmakuDuration,
-    8.0,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuLineHeight = SettingKey<double>(
-    _SettingBoxKey.danmakuLineHeight,
-    1.6,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuTimeOffset = SettingKey<double>(
-    _SettingBoxKey.danmakuTimeOffset,
-    0.0,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuEnabledByDefault = SettingKey<bool>(
-    _SettingBoxKey.danmakuEnabledByDefault,
-    false,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuBiliBiliSource = SettingKey<bool>(
-    _SettingBoxKey.danmakuBiliBiliSource,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuGamerSource = SettingKey<bool>(
-    _SettingBoxKey.danmakuGamerSource,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuDanDanSource = SettingKey<bool>(
-    _SettingBoxKey.danmakuDanDanSource,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuFontWeight = SettingKey<int>(
-    _SettingBoxKey.danmakuFontWeight,
-    4,
-    group: SettingGroup.danmaku,
-  );
-  static const danmakuFollowSpeed = SettingKey<bool>(
-    _SettingBoxKey.danmakuFollowSpeed,
-    true,
-    group: SettingGroup.danmaku,
-  );
-  static const themeMode = SettingKey<String>(
-    _SettingBoxKey.themeMode,
-    'system',
-    group: SettingGroup.theme,
-  );
-  static const themeColor = SettingKey<String>(
-    _SettingBoxKey.themeColor,
-    'default',
-    group: SettingGroup.theme,
-  );
-  static const privateMode = SettingKey<bool>(
-    _SettingBoxKey.privateMode,
-    false,
-    group: SettingGroup.player,
-  );
-  static const autoPlay = SettingKey<bool>(
-    _SettingBoxKey.autoPlay,
-    true,
-    group: SettingGroup.player,
-  );
-  static const autoPlayNext = SettingKey<bool>(
-    _SettingBoxKey.autoPlayNext,
-    true,
-    group: SettingGroup.player,
-  );
-  static const playResume = SettingKey<bool>(
-    _SettingBoxKey.playResume,
-    true,
-    group: SettingGroup.player,
-  );
-  static const showPlayerError = SettingKey<bool>(
-    _SettingBoxKey.showPlayerError,
-    true,
-    group: SettingGroup.player,
-  );
-  static const oledEnhance = SettingKey<bool>(
-    _SettingBoxKey.oledEnhance,
-    false,
-    group: SettingGroup.theme,
-  );
-  static const displayMode = SettingKey<String?>(
-    _SettingBoxKey.displayMode,
-    null,
-    group: SettingGroup.interface,
-  );
-  static const enableGitProxy = SettingKey<bool>(
-    _SettingBoxKey.enableGitProxy,
-    false,
-    group: SettingGroup.proxy,
-  );
-  static const enableBangumiProxy = SettingKey<bool>(
-    _SettingBoxKey.enableBangumiProxy,
-    false,
-    group: SettingGroup.proxy,
-  );
-  static const enableSystemProxy = SettingKey<bool>(
-    _SettingBoxKey.enableSystemProxy,
-    false,
-    group: SettingGroup.proxy,
-  );
-  static const defaultStartupPage = SettingKey<String>(
-    _SettingBoxKey.defaultStartupPage,
-    '/tab/popular/',
-    group: SettingGroup.interface,
-  );
-  static const isWideScreen = SettingKey<bool>(
-    _SettingBoxKey.isWideScreen,
-    false,
-    group: SettingGroup.interface,
-  );
-  static const webDavEnable = SettingKey<bool>(
-    _SettingBoxKey.webDavEnable,
-    false,
-    group: SettingGroup.webdav,
-  );
-  static const webDavEnableHistory = SettingKey<bool>(
-    _SettingBoxKey.webDavEnableHistory,
-    false,
-    group: SettingGroup.webdav,
-  );
-  static const webDavEnableCollect = SettingKey<bool>(
-    _SettingBoxKey.webDavEnableCollect,
-    false,
-    group: SettingGroup.webdav,
-  );
-  static const webDavURL = SettingKey<String>(
-    _SettingBoxKey.webDavURL,
-    '',
-    group: SettingGroup.webdav,
-  );
-  static const webDavUsername = SettingKey<String>(
-    _SettingBoxKey.webDavUsername,
-    '',
-    group: SettingGroup.webdav,
-  );
-  static const webDavPassword = SettingKey<String>(
-    _SettingBoxKey.webDavPassword,
-    '',
-    group: SettingGroup.webdav,
-  );
-  static const lowMemoryMode = SettingKey<bool>(
-    _SettingBoxKey.lowMemoryMode,
-    false,
-    group: SettingGroup.player,
-  );
-  static const showWindowButton = SettingKey<bool>(
-    _SettingBoxKey.showWindowButton,
-    false,
-    group: SettingGroup.theme,
-  );
-  static const useDynamicColor = SettingKey<bool>(
-    _SettingBoxKey.useDynamicColor,
-    false,
-    group: SettingGroup.theme,
-  );
-  static const exitBehavior = SettingKey<int>(
-    _SettingBoxKey.exitBehavior,
-    2,
-    group: SettingGroup.interface,
-  );
-  static const playerDebugMode = SettingKey<bool>(
-    _SettingBoxKey.playerDebugMode,
-    false,
-    group: SettingGroup.player,
-  );
-  static const syncPlayEndPoint = SettingKey<String>(
-    _SettingBoxKey.syncPlayEndPoint,
-    '127.0.0.1:8999',
-    group: SettingGroup.player,
-  );
-  static const androidEnableOpenSLES = SettingKey<bool>(
-    _SettingBoxKey.androidEnableOpenSLES,
-    true,
-    group: SettingGroup.player,
-  );
-  static const androidVideoRenderer = SettingKey<String>(
-    _SettingBoxKey.androidVideoRenderer,
-    'auto',
-    group: SettingGroup.player,
-  );
-  static const androidAutoEnterPIP = SettingKey<bool>(
-    _SettingBoxKey.androidAutoEnterPIP,
-    false,
-    group: SettingGroup.player,
-  );
-  static const defaultSuperResolutionType = SettingKey<int>(
-    _SettingBoxKey.defaultSuperResolutionType,
-    1,
-    group: SettingGroup.player,
-  );
-  static const superResolutionWarn = SettingKey<bool>(
-    _SettingBoxKey.superResolutionWarn,
-    false,
-    group: SettingGroup.player,
-  );
-  static const playerDisableAnimations = SettingKey<bool>(
-    _SettingBoxKey.playerDisableAnimations,
-    false,
-    group: SettingGroup.player,
-  );
-  static const playerLogLevel = SettingKey<int>(
-    _SettingBoxKey.playerLogLevel,
-    2,
-    group: SettingGroup.player,
-  );
-  static const searchNotShowWatchedBangumis = SettingKey<bool>(
-    _SettingBoxKey.searchNotShowWatchedBangumis,
-    false,
-    group: SettingGroup.collect,
-  );
-  static const searchNotShowAbandonedBangumis = SettingKey<bool>(
-    _SettingBoxKey.searchNotShowAbandonedBangumis,
-    false,
-    group: SettingGroup.collect,
-  );
-  static const timelineNotShowAbandonedBangumis = SettingKey<bool>(
-    _SettingBoxKey.timelineNotShowAbandonedBangumis,
-    false,
-    group: SettingGroup.collect,
-  );
-  static const timelineNotShowWatchedBangumis = SettingKey<bool>(
-    _SettingBoxKey.timelineNotShowWatchedBangumis,
-    false,
-    group: SettingGroup.collect,
-  );
-  static const timelineOnlyShowWatchingBangumis = SettingKey<bool>(
-    _SettingBoxKey.timelineOnlyShowWatchingBangumis,
-    false,
-    group: SettingGroup.collect,
-  );
-  static const useSystemFont = SettingKey<bool>(
-    _SettingBoxKey.useSystemFont,
-    false,
-    group: SettingGroup.theme,
-  );
-  static const forceAdBlocker = SettingKey<bool>(
-    _SettingBoxKey.forceAdBlocker,
-    false,
-    group: SettingGroup.player,
-  );
-  static const backgroundPlayback = SettingKey<bool>(
-    _SettingBoxKey.backgroundPlayback,
-    false,
-    group: SettingGroup.player,
-  );
-  static const proxyEnable = SettingKey<bool>(
-    _SettingBoxKey.proxyEnable,
-    false,
-    group: SettingGroup.proxy,
-  );
-  static const proxyConfigured = SettingKey<bool>(
-    _SettingBoxKey.proxyConfigured,
-    false,
-    group: SettingGroup.proxy,
-  );
-  static const proxyUrl = SettingKey<String>(
-    _SettingBoxKey.proxyUrl,
-    '',
-    group: SettingGroup.proxy,
-  );
-  static const proxyTestUrl = SettingKey<String>(
-    _SettingBoxKey.proxyTestUrl,
-    '',
-    group: SettingGroup.proxy,
-  );
-  static const showRating = SettingKey<bool>(
-    _SettingBoxKey.showRating,
-    true,
-    group: SettingGroup.interface,
-  );
-  static const downloadParallelEpisodes = SettingKey<int>(
-    _SettingBoxKey.downloadParallelEpisodes,
-    2,
-    group: SettingGroup.download,
-  );
-  static const downloadParallelSegments = SettingKey<int>(
-    _SettingBoxKey.downloadParallelSegments,
-    3,
-    group: SettingGroup.download,
-  );
-  static const downloadDanmaku = SettingKey<bool>(
-    _SettingBoxKey.downloadDanmaku,
-    true,
-    group: SettingGroup.download,
-  );
-  static const shortcutDialogShown = SettingKey<bool>(
-    _SettingBoxKey.shortcutDialogShown,
-    false,
-    group: SettingGroup.misc,
-  );
-  static const bangumiSyncEnable = SettingKey<bool>(
-    _SettingBoxKey.bangumiSyncEnable,
-    false,
-    group: SettingGroup.bangumi,
-  );
-  static const bangumiAccessToken = SettingKey<String>(
-    _SettingBoxKey.bangumiAccessToken,
-    '',
-    group: SettingGroup.bangumi,
-  );
-  static const bangumiSyncPriority = SettingKey<int>(
-    _SettingBoxKey.bangumiSyncPriority,
-    0,
-    group: SettingGroup.bangumi,
-  );
-  static const bangumiImmediateSyncToastEnable = SettingKey<bool>(
-    _SettingBoxKey.bangumiImmediateSyncToastEnable,
-    true,
-    group: SettingGroup.bangumi,
-  );
-  static const brightnessVolumeGesture = SettingKey<bool>(
-    _SettingBoxKey.brightnessVolumeGesture,
-    true,
-    group: SettingGroup.player,
-  );
-  static const historySyncDeviceId = SettingKey<String>(
-    _SettingBoxKey.historySyncDeviceId,
-    '',
-    group: SettingGroup.sync,
-  );
-  static const historySyncSequence = SettingKey<int>(
-    _SettingBoxKey.historySyncSequence,
-    0,
-    group: SettingGroup.sync,
-  );
-  static const historySyncSnapshotInitialized = SettingKey<bool>(
-    _SettingBoxKey.historySyncSnapshotInitialized,
-    false,
-    group: SettingGroup.sync,
-  );
-
-  static final List<SettingKey<Object?>> all = [
-    hAenable,
-    hardwareDecoder,
-    searchEnhanceEnable,
-    autoUpdate,
-    alwaysOntop,
-    defaultPlaySpeed,
-    defaultShortcutForwardPlaySpeed,
-    defaultAspectRatioType,
-    buttonSkipTime,
-    arrowKeySkipTime,
-    danmakuEnhance,
-    danmakuBorder,
-    danmakuBorderSize,
-    danmakuOpacity,
-    danmakuFontSize,
-    danmakuTop,
-    danmakuScroll,
-    danmakuBottom,
-    danmakuMassive,
-    danmakuDeduplication,
-    danmakuArea,
-    danmakuColor,
-    danmakuDuration,
-    danmakuLineHeight,
-    danmakuTimeOffset,
-    danmakuEnabledByDefault,
-    danmakuBiliBiliSource,
-    danmakuGamerSource,
-    danmakuDanDanSource,
-    danmakuFontWeight,
-    danmakuFollowSpeed,
-    themeMode,
-    themeColor,
-    privateMode,
-    autoPlay,
-    autoPlayNext,
-    playResume,
-    showPlayerError,
-    oledEnhance,
-    displayMode,
-    enableGitProxy,
-    enableBangumiProxy,
-    enableSystemProxy,
-    defaultStartupPage,
-    isWideScreen,
-    webDavEnable,
-    webDavEnableHistory,
-    webDavEnableCollect,
-    webDavURL,
-    webDavUsername,
-    webDavPassword,
-    lowMemoryMode,
-    showWindowButton,
-    useDynamicColor,
-    exitBehavior,
-    playerDebugMode,
-    syncPlayEndPoint,
-    androidEnableOpenSLES,
-    androidVideoRenderer,
-    androidAutoEnterPIP,
-    defaultSuperResolutionType,
-    superResolutionWarn,
-    playerDisableAnimations,
-    playerLogLevel,
-    searchNotShowWatchedBangumis,
-    searchNotShowAbandonedBangumis,
-    timelineNotShowAbandonedBangumis,
-    timelineNotShowWatchedBangumis,
-    timelineOnlyShowWatchingBangumis,
-    useSystemFont,
-    forceAdBlocker,
-    backgroundPlayback,
-    proxyEnable,
-    proxyConfigured,
-    proxyUrl,
-    proxyTestUrl,
-    showRating,
-    downloadParallelEpisodes,
-    downloadParallelSegments,
-    downloadDanmaku,
-    shortcutDialogShown,
-    bangumiSyncEnable,
-    bangumiAccessToken,
-    bangumiSyncPriority,
-    bangumiImmediateSyncToastEnable,
-    brightnessVolumeGesture,
-    historySyncDeviceId,
-    historySyncSequence,
-    historySyncSnapshotInitialized,
-  ];
-
-  static List<SettingKey<Object?>> byGroup(SettingGroup group) {
-    return [
-      for (final key in all)
-        if (key.group == group) key
-    ];
-  }
-
-  SettingsKeys._();
-}
+export 'package:kazumi/services/storage/settings_keys.dart';
 
 class GStorage {
   /// Don't use favorites box, it's replaced by collectibles.
@@ -613,6 +26,19 @@ class GStorage {
   static late final Box<dynamic> _setting;
   static late Box<SearchHistory> searchHistory;
   static late Box<DownloadRecord> downloads;
+
+  /// Secure storage for sensitive values (tokens, passwords).
+  /// Initialized during init(); reads are cached in [_secureCache]
+  /// so [getSetting] can remain synchronous.
+  static late final FlutterSecureStorage _secureStorage;
+  static final Map<String, String> _secureCache = {};
+
+  /// Setting keys that must be stored encrypted via FlutterSecureStorage
+  /// instead of the plaintext Hive box.
+  static const _secureKeys = {
+    'bangumiAccessToken',
+    'webDavPassword',
+  };
 
   /// Hive directory path, initialized during init()
   static String? _hivePath;
@@ -753,6 +179,27 @@ class GStorage {
     shieldList = await _openBoxSafe<String>('shieldList');
     searchHistory = await _openBoxSafe<SearchHistory>('searchHistory');
     downloads = await _openBoxSafe<DownloadRecord>('downloads');
+
+    // Initialize secure storage and migrate sensitive keys from plaintext
+    // Hive to FlutterSecureStorage (one-time, backward-compatible).
+    _secureStorage = const FlutterSecureStorage();
+    _secureCache.clear();
+    for (final key in _secureKeys) {
+      final hiveValue = _setting.get(key);
+      if (hiveValue != null) {
+        final existingSecure = await _secureStorage.read(key: key);
+        if (existingSecure == null) {
+          await _secureStorage.write(key: key, value: hiveValue.toString());
+        }
+        _secureCache[key] = hiveValue.toString();
+        await _setting.delete(key);
+      } else {
+        final secureValue = await _secureStorage.read(key: key);
+        if (secureValue != null) {
+          _secureCache[key] = secureValue;
+        }
+      }
+    }
   }
 
   /// Open a Hive box with automatic recovery on corruption.
@@ -809,9 +256,9 @@ class GStorage {
     final hiveBoxFile = File('${appDocumentDir.path}/hive/$boxName.hive');
     if (await hiveBoxFile.exists()) {
       await hiveBoxFile.copy(backupFilePath);
-      print('Backup success: $backupFilePath');
+      KazumiLogger().i('Backup success: $backupFilePath');
     } else {
-      print('Hive box not exists');
+      KazumiLogger().w('Hive box not exists');
     }
   }
 
@@ -923,6 +370,13 @@ class GStorage {
     SettingContext context = const SettingContext(),
   }) {
     final defaultValue = key.resolveDefault(context);
+    if (_secureKeys.contains(key.name)) {
+      final cached = _secureCache[key.name];
+      if (cached != null) {
+        return cached as T;
+      }
+      return defaultValue;
+    }
     final storedValue = _setting.get(key.name);
     if (storedValue is T) {
       return storedValue;
@@ -931,6 +385,12 @@ class GStorage {
   }
 
   static Future<void> putSetting<T>(SettingKey<T> key, T value) async {
+    if (_secureKeys.contains(key.name)) {
+      final str = value.toString();
+      await _secureStorage.write(key: key.name, value: str);
+      _secureCache[key.name] = str;
+      return;
+    }
     await _setting.put(key.name, value);
   }
 
@@ -953,6 +413,12 @@ class GStorage {
   }
 
   static Future<void> resetSettings(Iterable<SettingKey<Object?>> keys) async {
+    for (final key in keys) {
+      if (_secureKeys.contains(key.name)) {
+        await _secureStorage.delete(key: key.name);
+        _secureCache.remove(key.name);
+      }
+    }
     await _setting.deleteAll(keys.map((key) => key.name));
     await _setting.flush();
   }
@@ -966,102 +432,4 @@ class GStorage {
   }
 
   GStorage._();
-}
-
-// Historical Hive key names used by settings created before the typed registry.
-// Keep these strings stable so existing users keep their saved settings.
-// New settings do not need to be added here unless they intentionally reuse an
-// existing persisted key.
-class _SettingBoxKey {
-  static const String hAenable = 'hAenable',
-      hardwareDecoder = 'hardwareDecoder',
-      searchEnhanceEnable = 'searchEnhanceEnable',
-      autoUpdate = 'autoUpdate',
-      alwaysOntop = 'alwaysOntop',
-      defaultPlaySpeed = 'defaultPlaySpeed',
-      defaultShortcutForwardPlaySpeed = 'defaultShortcutForwardPlaySpeed',
-      defaultAspectRatioType = 'defaultAspectRatioType',
-      buttonSkipTime = 'buttonSkipTime',
-      arrowKeySkipTime = 'arrowKeySkipTime',
-      danmakuEnhance = 'danmakuEnhance',
-      danmakuBorder = 'danmakuBorder',
-      danmakuBorderSize = 'danmakuBorderSize',
-      danmakuOpacity = 'danmakuOpacity',
-      danmakuFontSize = 'danmakuFontSize',
-      danmakuTop = 'danmakuTop',
-      danmakuScroll = 'danmakuScroll',
-      danmakuBottom = 'danmakuBottom',
-      danmakuMassive = 'danmakuMassive',
-      danmakuDeduplication = 'danmakuDeduplication',
-      danmakuArea = 'danmakuArea',
-      danmakuColor = 'danmakuColor',
-      danmakuDuration = 'danmakuDuration',
-      danmakuLineHeight = 'danmakuLineHeight',
-      danmakuTimeOffset = 'danmakuTimeOffset',
-      danmakuEnabledByDefault = 'danmakuEnabledByDefault',
-      danmakuBiliBiliSource = 'danmakuBiliBiliSource',
-      danmakuGamerSource = 'danmakuGamerSource',
-      danmakuDanDanSource = 'danmakuDanDanSource',
-      danmakuFontWeight = 'danmakuFontWeight',
-      danmakuFollowSpeed = 'danmakuFollowSpeed',
-      themeMode = 'themeMode',
-      themeColor = 'themeColor',
-      privateMode = 'privateMode',
-      autoPlay = 'autoPlay',
-      autoPlayNext = 'autoPlayNext',
-      playResume = 'playResume',
-      showPlayerError = 'showPlayerError',
-      oledEnhance = 'oledEnhance',
-      displayMode = 'displayMode',
-      enableGitProxy = 'enableGitProxy',
-      enableBangumiProxy = 'enableBangumiProxy',
-      enableSystemProxy = 'enableSystemProxy',
-      defaultStartupPage = 'defaultStartupPage',
-
-      /// Deprecated
-      isWideScreen = 'isWideScreen',
-      webDavEnable = 'webDavEnable',
-      webDavEnableHistory = 'webDavEnableHistory',
-      webDavEnableCollect = 'webDavEnableCollect',
-      webDavURL = 'webDavURL',
-      webDavUsername = 'webDavUsername',
-      webDavPassword = 'webDavPasswd',
-      lowMemoryMode = 'lowMemoryMode',
-      showWindowButton = 'showWindowButton',
-      useDynamicColor = 'useDynamicColor',
-      exitBehavior = 'exitBehavior',
-      playerDebugMode = 'playerDebugMode',
-      syncPlayEndPoint = 'syncPlayEndPoint',
-      androidEnableOpenSLES = 'androidEnableOpenSLES',
-      androidVideoRenderer = 'androidVideoRenderer',
-      androidAutoEnterPIP = 'androidAutoEnterPIP',
-      defaultSuperResolutionType = 'defaultSuperResolutionType',
-      superResolutionWarn = 'superResolutionWarn',
-      playerDisableAnimations = 'playerDisableAnimations',
-      playerLogLevel = 'playerLogLevel',
-      searchNotShowWatchedBangumis = 'searchNotShowWatchedBangumis',
-      searchNotShowAbandonedBangumis = 'searchNotShowAbandonedBangumis',
-      timelineNotShowAbandonedBangumis = 'timelineNotShowAbandonedBangumis',
-      timelineNotShowWatchedBangumis = 'timelineNotShowWatchedBangumis',
-      timelineOnlyShowWatchingBangumis = 'timelineOnlyShowWatchingBangumis',
-      useSystemFont = 'useSystemFont',
-      forceAdBlocker = 'forceAdBlocker',
-      backgroundPlayback = 'backgroundPlayback',
-      proxyEnable = 'proxyEnable',
-      proxyConfigured = 'proxyConfigured',
-      proxyUrl = 'proxyUrl',
-      proxyTestUrl = 'proxyTestUrl',
-      showRating = 'showRating',
-      downloadParallelEpisodes = 'downloadParallelEpisodes',
-      downloadParallelSegments = 'downloadParallelSegments',
-      downloadDanmaku = 'downloadDanmaku',
-      shortcutDialogShown = 'shortcutDialogShown',
-      bangumiSyncEnable = 'bangumiSyncEnable',
-      bangumiAccessToken = 'bangumiAccessToken',
-      bangumiSyncPriority = 'bangumiSyncPriority',
-      bangumiImmediateSyncToastEnable = 'bangumiImmediateSyncToastEnable',
-      brightnessVolumeGesture = 'brightnessVolumeGesture',
-      historySyncDeviceId = 'historySyncDeviceId',
-      historySyncSequence = 'historySyncSequence',
-      historySyncSnapshotInitialized = 'historySyncSnapshotInitialized';
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <flutter_volume_controller/flutter_volume_controller_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
@@ -27,6 +28,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_volume_controller_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterVolumeControllerPlugin");
   flutter_volume_controller_plugin_register_with_registrar(flutter_volume_controller_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
   dynamic_color
   file_selector_linux
+  flutter_secure_storage_linux
   flutter_volume_controller
   media_kit_libs_linux
   media_kit_video

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import connectivity_plus
 import dynamic_color
 import file_selector_macos
 import flutter_inappwebview_macos
+import flutter_secure_storage_darwin
 import flutter_volume_controller
 import media_kit_libs_macos_video
 import media_kit_video
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterVolumeControllerPlugin.register(with: registry.registrar(forPlugin: "FlutterVolumeControllerPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -614,6 +614,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -1041,6 +1089,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.7"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   modular_core:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
   antlr4: ^4.13.2
   fl_chart: ^1.1.1
   flutter_foreground_task: ^9.0.0
+  flutter_secure_storage: ^10.3.1
   skeletonizer: ^2.1.2
   flutter_inappwebview_platform_interface: ^1.3.0+1
   flutter_inappwebview_ios: ^1.1.2
@@ -179,6 +180,7 @@ dev_dependencies:
   flutter_launcher_icons: ^0.14.3
   flutter_native_splash: ^2.4.3
   msix: ^3.16.12
+  mocktail: ^1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_volume_controller/flutter_volume_controller_plugin_c_api.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterVolumeControllerPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterVolumeControllerPluginCApi"));
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   dynamic_color
   file_selector_windows
+  flutter_secure_storage_windows
   flutter_volume_controller
   media_kit_libs_windows_video
   media_kit_video


### PR DESCRIPTION
## Summary

- Replace all print() calls with KazumiLogger in syncplay_client
- Add log rotation to KazumiLogOutput (5 MB cap, keep 3 rotated files)
- Enable avoid_print lint rule in analysis_options.yaml

## Why

print() leaks to stdout in release builds. Log file had unbounded growth.

## Test plan

- [x] flutter analyze passes with 0 errors/warnings
- [x] flutter test all 60 tests pass