### PR TITLE
[feature] add a new player controller settings option

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -118,6 +118,9 @@ class _PlayerItemState extends State<PlayerItem>
   late bool backgroundPlayback;
   late bool brightnessVolumeGesture;
 
+  // 播放器控制面板无交互后自动隐藏所需时间 （单位：毫秒）
+  late int playerControllerLayerDisappearTime;
+
   Timer? hideTimer;
   Timer? playerTimer;
   Timer? mouseScrollerTimer;
@@ -892,7 +895,8 @@ class _PlayerItemState extends State<PlayerItem>
     if (!_canHidePlayerPanel) {
       return;
     }
-    hideTimer = Timer(const Duration(seconds: 4), () {
+    
+    hideTimer = Timer(Duration(milliseconds: playerControllerLayerDisappearTime), () {
       if (mounted) {
         hideVideoController();
       }
@@ -1688,6 +1692,7 @@ class _PlayerItemState extends State<PlayerItem>
     backgroundPlayback = GStorage.getSetting(SettingsKeys.backgroundPlayback);
     brightnessVolumeGesture =
         GStorage.getSetting(SettingsKeys.brightnessVolumeGesture);
+    playerControllerLayerDisappearTime = GStorage.getSetting(SettingsKeys.playerControllerLayerDisappearTime);
     unawaited(_bindAudioService());
     playerTimer = getPlayerTimer();
     windowManager.addListener(this);

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -895,8 +895,8 @@ class _PlayerItemState extends State<PlayerItem>
     if (!_canHidePlayerPanel) {
       return;
     }
-    
-    hideTimer = Timer(Duration(milliseconds: playerControllerLayerDisappearTime), () {
+    hideTimer =
+        Timer(Duration(milliseconds: playerControllerLayerDisappearTime), () {
       if (mounted) {
         hideVideoController();
       }
@@ -1692,7 +1692,8 @@ class _PlayerItemState extends State<PlayerItem>
     backgroundPlayback = GStorage.getSetting(SettingsKeys.backgroundPlayback);
     brightnessVolumeGesture =
         GStorage.getSetting(SettingsKeys.brightnessVolumeGesture);
-    playerControllerLayerDisappearTime = GStorage.getSetting(SettingsKeys.playerControllerLayerDisappearTime);
+    playerControllerLayerDisappearTime =
+        GStorage.getSetting(SettingsKeys.playerControllerLayerDisappearTime);
     unawaited(_bindAudioService());
     playerTimer = getPlayerTimer();
     windowManager.addListener(this);

--- a/lib/pages/settings/player_settings.dart
+++ b/lib/pages/settings/player_settings.dart
@@ -18,6 +18,10 @@ class PlayerSettingsPage extends StatefulWidget {
 }
 
 class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
+  static const double _minPlayerControllerLayerDisappearSeconds = 1;
+  static const double _maxPlayerControllerLayerDisappearSeconds = 10;
+  static const int _playerControllerLayerDisappearDivisions = 18;
+
   late double defaultPlaySpeed;
   late double defaultShortcutForwardPlaySpeed;
   late int defaultAspectRatioType;
@@ -80,7 +84,8 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
     playerArrowKeySkipTime =
         GStorage.getSetting<int>(SettingsKeys.arrowKeySkipTime);
 
-    playerControllerLayerDisappearTime = GStorage.getSetting<int>(SettingsKeys.playerControllerLayerDisappearTime);
+    playerControllerLayerDisappearTime = GStorage.getSetting<int>(
+        SettingsKeys.playerControllerLayerDisappearTime);
   }
 
   Future<void> resetPlayerSettings() async {
@@ -214,59 +219,29 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
     });
   }
 
-  Future<void> updateButtonPlayerControllerLayerDisappearTime() async {
-    final int? newDisappearTime = await _showPlayerControllerLayerDisappearTimeChangeDialog(
-      title: '控制层消失时间', initialValue: playerControllerLayerDisappearTime.toString()
-    );
+  double get playerControllerLayerDisappearSeconds =>
+      (playerControllerLayerDisappearTime / Duration.millisecondsPerSecond)
+          .clamp(_minPlayerControllerLayerDisappearSeconds,
+              _maxPlayerControllerLayerDisappearSeconds)
+          .toDouble();
 
-    if (newDisappearTime != null && newDisappearTime != playerControllerLayerDisappearTime) {
-      GStorage.putSetting<int>(SettingsKeys.playerControllerLayerDisappearTime, newDisappearTime);
-      setState(() {
-        playerControllerLayerDisappearTime = newDisappearTime;
-      });
+  String formatPlayerControllerLayerDisappearSeconds(double seconds) {
+    if (seconds == seconds.roundToDouble()) {
+      return '${seconds.toInt()} 秒';
     }
+    return '${seconds.toStringAsFixed(1)} 秒';
   }
 
-  Future<int?> _showPlayerControllerLayerDisappearTimeChangeDialog({required String title, required String initialValue}) async {
-    return KazumiDialog.show<int>(builder: (context) {
-      String input = "";
-      return AlertDialog(
-        title: Text(title),
-        content: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return TextField(
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly, // 只允许输入数字
-              ],
-              decoration: InputDecoration(
-                floatingLabelBehavior: FloatingLabelBehavior.never, // 控制label的显示方式
-                labelText: initialValue,
-              ),
-              onChanged: (value) => input = value,
-            );
-          }
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () async {
-              final int? newValue = int.tryParse(input);
-
-              if (newValue == null) {
-                KazumiDialog.showToast(message: '请输入数字');
-                return;
-              }
-
-              if (newValue <= 0) {
-                KazumiDialog.showToast(message: '请输入大于0的数字');
-                return;
-              }
-
-              KazumiDialog.dismiss(popWith: newValue);
-            },
-            child: const Text('确定'),
-          ),
-        ],
-      );
+  void updatePlayerControllerLayerDisappearSeconds(double seconds) {
+    final int newDisappearTime =
+        (seconds * Duration.millisecondsPerSecond).round();
+    if (newDisappearTime == playerControllerLayerDisappearTime) {
+      return;
+    }
+    GStorage.putSetting<int>(
+        SettingsKeys.playerControllerLayerDisappearTime, newDisappearTime);
+    setState(() {
+      playerControllerLayerDisappearTime = newDisappearTime;
     });
   }
 
@@ -596,16 +571,19 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                   value: Text('$playerButtonSkipTime 秒',
                       style: TextStyle(fontFamily: fontFamily)),
                 ),
-                SettingsTile.navigation(
-                  onPressed: (_) async {
-                    await updateButtonPlayerControllerLayerDisappearTime();
-                  },
-                  title: Text('播放控制器消失时间',
+                SettingsTile(
+                  title: Text(
+                      '播放控制器消失时间：${formatPlayerControllerLayerDisappearSeconds(playerControllerLayerDisappearSeconds)}',
                       style: TextStyle(fontFamily: fontFamily)),
-                  description: Text('播放器控制器在没有交互后自动消失的时间 (毫秒)',
-                      style: TextStyle(fontFamily: fontFamily)),
-                  value: Text('$playerControllerLayerDisappearTime 毫秒',
-                      style: TextStyle(fontFamily: fontFamily)),
+                  description: Slider(
+                    value: playerControllerLayerDisappearSeconds,
+                    min: _minPlayerControllerLayerDisappearSeconds,
+                    max: _maxPlayerControllerLayerDisappearSeconds,
+                    divisions: _playerControllerLayerDisappearDivisions,
+                    label: formatPlayerControllerLayerDisappearSeconds(
+                        playerControllerLayerDisappearSeconds),
+                    onChanged: updatePlayerControllerLayerDisappearSeconds,
+                  ),
                 ),
                 SettingsTile.navigation(
                   onPressed: (_) async {

--- a/lib/pages/settings/player_settings.dart
+++ b/lib/pages/settings/player_settings.dart
@@ -37,6 +37,7 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
   late int playerButtonSkipTime;
   late int playerArrowKeySkipTime;
   late int playerLogLevel;
+  late int playerControllerLayerDisappearTime;
   final MenuController playerAspectRatioMenuController = MenuController();
   final MenuController playerLogLevelMenuController = MenuController();
 
@@ -78,6 +79,8 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
         GStorage.getSetting<int>(SettingsKeys.buttonSkipTime);
     playerArrowKeySkipTime =
         GStorage.getSetting<int>(SettingsKeys.arrowKeySkipTime);
+
+    playerControllerLayerDisappearTime = GStorage.getSetting<int>(SettingsKeys.playerControllerLayerDisappearTime);
   }
 
   Future<void> resetPlayerSettings() async {
@@ -202,6 +205,62 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                 return;
               }
               // 以新设置的值弹出
+              KazumiDialog.dismiss(popWith: newValue);
+            },
+            child: const Text('确定'),
+          ),
+        ],
+      );
+    });
+  }
+
+  Future<void> updateButtonPlayerControllerLayerDisappearTime() async {
+    final int? newDisappearTime = await _showPlayerControllerLayerDisappearTimeChangeDialog(
+      title: '控制层消失时间', initialValue: playerControllerLayerDisappearTime.toString()
+    );
+
+    if (newDisappearTime != null && newDisappearTime != playerControllerLayerDisappearTime) {
+      GStorage.putSetting<int>(SettingsKeys.playerControllerLayerDisappearTime, newDisappearTime);
+      setState(() {
+        playerControllerLayerDisappearTime = newDisappearTime;
+      });
+    }
+  }
+
+  Future<int?> _showPlayerControllerLayerDisappearTimeChangeDialog({required String title, required String initialValue}) async {
+    return KazumiDialog.show<int>(builder: (context) {
+      String input = "";
+      return AlertDialog(
+        title: Text(title),
+        content: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return TextField(
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly, // 只允许输入数字
+              ],
+              decoration: InputDecoration(
+                floatingLabelBehavior: FloatingLabelBehavior.never, // 控制label的显示方式
+                labelText: initialValue,
+              ),
+              onChanged: (value) => input = value,
+            );
+          }
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () async {
+              final int? newValue = int.tryParse(input);
+
+              if (newValue == null) {
+                KazumiDialog.showToast(message: '请输入数字');
+                return;
+              }
+
+              if (newValue <= 0) {
+                KazumiDialog.showToast(message: '请输入大于0的数字');
+                return;
+              }
+
               KazumiDialog.dismiss(popWith: newValue);
             },
             child: const Text('确定'),
@@ -535,6 +594,17 @@ class _PlayerSettingsPageState extends State<PlayerSettingsPage> {
                   description: Text('顶栏跳过按钮的秒数',
                       style: TextStyle(fontFamily: fontFamily)),
                   value: Text('$playerButtonSkipTime 秒',
+                      style: TextStyle(fontFamily: fontFamily)),
+                ),
+                SettingsTile.navigation(
+                  onPressed: (_) async {
+                    await updateButtonPlayerControllerLayerDisappearTime();
+                  },
+                  title: Text('播放控制器消失时间',
+                      style: TextStyle(fontFamily: fontFamily)),
+                  description: Text('播放器控制器在没有交互后自动消失的时间 (毫秒)',
+                      style: TextStyle(fontFamily: fontFamily)),
+                  value: Text('$playerControllerLayerDisappearTime 毫秒',
                       style: TextStyle(fontFamily: fontFamily)),
                 ),
                 SettingsTile.navigation(

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -488,7 +488,7 @@ class SettingsKeys {
   );
   static const playerControllerLayerDisappearTime = SettingKey<int>(
     'playerControllerLayerDisappearTime',
-    3000,
+    4000,
     group: SettingGroup.player,
   );
 
@@ -594,6 +594,7 @@ class SettingsKeys {
 
   SettingsKeys._();
 }
+
 // Historical Hive key names used by settings created before the typed registry.
 // Keep these strings stable so existing users keep their saved settings.
 // New settings do not need to be added here unless they intentionally reuse an

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -486,6 +486,11 @@ class SettingsKeys {
     false,
     group: SettingGroup.sync,
   );
+  static const playerControllerLayerDisappearTime = SettingKey<int>(
+    'playerControllerLayerDisappearTime',
+    3000,
+    group: SettingGroup.player,
+  );
 
   static final List<SettingKey<Object?>> all = [
     hAenable,
@@ -577,6 +582,7 @@ class SettingsKeys {
     historySyncDeviceId,
     historySyncSequence,
     historySyncSnapshotInitialized,
+    playerControllerLayerDisappearTime,
   ];
 
   static List<SettingKey<Object?>> byGroup(SettingGroup group) {


### PR DESCRIPTION
Add configuration 'playerControllerLayerDisappearTime' to set the interval of controller layer disappearing after no operation.

<img width="1258" height="854" alt="image" src="https://github.com/user-attachments/assets/f14dbb62-d3e7-487d-aef6-0acd63272377" />

<img width="1259" height="842" alt="image" src="https://github.com/user-attachments/assets/a2589b05-3524-4fea-95fd-6ecf6415edbc" />
