### PR TITLE
修复在线/离线播放历史记录

### DIFF
--- a/lib/bean/card/bangumi_history_card.dart
+++ b/lib/bean/card/bangumi_history_card.dart
@@ -15,6 +15,78 @@ import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/utils/device.dart';
 import 'package:kazumi/utils/date_time.dart';
 
+String historySourceBadgeText(String entryKind) {
+  return HistoryEntryKind.normalize(entryKind) == HistoryEntryKind.offline
+      ? '缓存'
+      : '在线';
+}
+
+Future<HistoryPlaybackOpenResult> openHistoryPlaybackForEntry({
+  required String entryKind,
+  required Future<bool> Function() openOnlinePlayback,
+  required Future<bool> Function() openOfflinePlayback,
+}) async {
+  if (HistoryEntryKind.normalize(entryKind) == HistoryEntryKind.offline) {
+    final opened = await openOfflinePlayback();
+    return HistoryPlaybackOpenResult(
+      opened: opened,
+      failureMessage: opened ? null : '未找到可用缓存',
+    );
+  }
+
+  final opened = await openOnlinePlayback();
+  return HistoryPlaybackOpenResult(
+    opened: opened,
+    failureMessage: opened ? null : '在线源不可用，请重新选择播放源',
+  );
+}
+
+class HistoryPlaybackOpenResult {
+  const HistoryPlaybackOpenResult({
+    required this.opened,
+    required this.failureMessage,
+  });
+
+  final bool opened;
+  final String? failureMessage;
+}
+
+class _HistorySourceBadge extends StatelessWidget {
+  const _HistorySourceBadge({required this.entryKind});
+
+  final String entryKind;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isOffline =
+        HistoryEntryKind.normalize(entryKind) == HistoryEntryKind.offline;
+    final backgroundColor = isOffline
+        ? colorScheme.secondaryContainer
+        : colorScheme.primaryContainer;
+    final foregroundColor = isOffline
+        ? colorScheme.onSecondaryContainer
+        : colorScheme.onPrimaryContainer;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        child: Text(
+          historySourceBadgeText(entryKind),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: foregroundColor,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
 // 视频历史记录卡片 - 水平布局
 class BangumiHistoryCardV extends StatefulWidget {
   const BangumiHistoryCardV({
@@ -52,21 +124,17 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
         videoPageController.cancelQueryRoads();
       },
     );
-    bool opened = false;
-    if (widget.historyItem.entryKind == HistoryEntryKind.offline) {
-      opened = await _openOfflinePlayback();
-    } else {
-      opened = await _openOnlinePlayback();
-      if (!opened) {
-        opened = await _openOfflinePlayback();
-      }
-    }
+    final result = await openHistoryPlaybackForEntry(
+      entryKind: widget.historyItem.entryKind,
+      openOnlinePlayback: _openOnlinePlayback,
+      openOfflinePlayback: _openOfflinePlayback,
+    );
     KazumiDialog.dismiss();
-    if (opened) {
+    if (result.opened) {
       Modular.to.pushNamed('/video/');
       return;
     }
-    KazumiDialog.showToast(message: '未找到可用播放入口');
+    KazumiDialog.showToast(message: result.failureMessage ?? '未找到可用播放入口');
   }
 
   Future<bool> _openOnlinePlayback() async {
@@ -220,14 +288,24 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          title,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            color: colorScheme.onSurface,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 1,
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                title,
+                                style: theme.textTheme.titleSmall?.copyWith(
+                                  color: colorScheme.onSurface,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                                maxLines: 1,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            _HistorySourceBadge(
+                              entryKind: widget.historyItem.entryKind,
+                            ),
+                          ],
                         ),
                         const SizedBox(height: 6),
                         Row(

--- a/lib/bean/card/bangumi_history_card.dart
+++ b/lib/bean/card/bangumi_history_card.dart
@@ -4,9 +4,10 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/widget/collect_button.dart';
+import 'package:kazumi/modules/download/download_module.dart';
 import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/pages/collect/collect_controller.dart';
-import 'package:kazumi/pages/history/history_controller.dart';
+import 'package:kazumi/pages/download/download_controller.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 import 'package:kazumi/plugins/plugins.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
@@ -35,8 +36,9 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
   final VideoPageController videoPageController =
       Modular.get<VideoPageController>();
   final PluginsController pluginsController = Modular.get<PluginsController>();
-  final HistoryController historyController = Modular.get<HistoryController>();
   final CollectController collectController = Modular.get<CollectController>();
+  final DownloadController downloadController =
+      Modular.get<DownloadController>();
 
   Future<void> _onTap() async {
     if (widget.showDelete) {
@@ -50,33 +52,110 @@ class _BangumiHistoryCardVState extends State<BangumiHistoryCardV> {
         videoPageController.cancelQueryRoads();
       },
     );
-    bool flag = false;
+    bool opened = false;
+    if (widget.historyItem.entryKind == HistoryEntryKind.offline) {
+      opened = await _openOfflinePlayback();
+    } else {
+      opened = await _openOnlinePlayback();
+      if (!opened) {
+        opened = await _openOfflinePlayback();
+      }
+    }
+    KazumiDialog.dismiss();
+    if (opened) {
+      Modular.to.pushNamed('/video/');
+      return;
+    }
+    KazumiDialog.showToast(message: '未找到可用播放入口');
+  }
+
+  Future<bool> _openOnlinePlayback() async {
+    if (widget.historyItem.lastSrc.isEmpty) {
+      return false;
+    }
+    Plugin? targetPlugin;
     for (Plugin plugin in pluginsController.pluginList) {
       if (plugin.name == widget.historyItem.adapterName) {
-        videoPageController.currentPlugin = plugin;
-        flag = true;
+        targetPlugin = plugin;
         break;
       }
     }
-    if (!flag) {
-      KazumiDialog.dismiss();
-      KazumiDialog.showToast(message: '未找到关联番剧源');
-      return;
+    if (targetPlugin == null) {
+      return false;
     }
     videoPageController.bangumiItem = widget.historyItem.bangumiItem;
+    videoPageController.currentPlugin = targetPlugin;
     videoPageController.title = widget.historyItem.bangumiItem.nameCn == ''
         ? widget.historyItem.bangumiItem.name
         : widget.historyItem.bangumiItem.nameCn;
     videoPageController.src = widget.historyItem.lastSrc;
     try {
       await videoPageController.queryRoads(
-          widget.historyItem.lastSrc, videoPageController.currentPlugin.name);
-      KazumiDialog.dismiss();
-      Modular.to.pushNamed('/video/');
+        widget.historyItem.lastSrc,
+        targetPlugin.name,
+      );
+      return true;
     } catch (_) {
-      KazumiLogger().w("PluginSearchService: failed to query roads");
-      KazumiDialog.dismiss();
+      KazumiLogger().w("QueryManager: failed to query roads");
+      return false;
     }
+  }
+
+  Future<bool> _openOfflinePlayback() async {
+    final downloadedEpisodes = downloadController.getCompletedEpisodes(
+      widget.historyItem.bangumiItem.id,
+      widget.historyItem.adapterName,
+    );
+    if (downloadedEpisodes.isEmpty) {
+      return false;
+    }
+
+    DownloadEpisode? targetEpisode;
+    if (widget.historyItem.episodePageUrl.isNotEmpty) {
+      for (final episode in downloadedEpisodes) {
+        if (episode.episodePageUrl == widget.historyItem.episodePageUrl) {
+          targetEpisode = episode;
+          break;
+        }
+      }
+    }
+    targetEpisode ??= _episodeByNumber(
+      downloadedEpisodes,
+      widget.historyItem.lastWatchEpisode,
+    );
+    if (targetEpisode == null) {
+      return false;
+    }
+
+    final localPath = downloadController.getLocalVideoPath(
+      widget.historyItem.bangumiItem.id,
+      widget.historyItem.adapterName,
+      targetEpisode.episodeNumber,
+    );
+    if (localPath == null) {
+      return false;
+    }
+
+    videoPageController.initForOfflinePlayback(
+      bangumiItem: widget.historyItem.bangumiItem,
+      pluginName: widget.historyItem.adapterName,
+      episodeNumber: targetEpisode.episodeNumber,
+      road: targetEpisode.road,
+      downloadedEpisodes: downloadedEpisodes,
+    );
+    return true;
+  }
+
+  DownloadEpisode? _episodeByNumber(
+    List<DownloadEpisode> episodes,
+    int episodeNumber,
+  ) {
+    for (final episode in episodes) {
+      if (episode.episodeNumber == episodeNumber) {
+        return episode;
+      }
+    }
+    return null;
   }
 
   @override

--- a/lib/modules/history/history_module.dart
+++ b/lib/modules/history/history_module.dart
@@ -3,6 +3,81 @@ import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 
 part 'history_module.g.dart';
 
+class HistoryEntryKind {
+  static const String online = 'online';
+  static const String offline = 'offline';
+
+  static String normalize(String value) {
+    return value == offline ? offline : online;
+  }
+
+  HistoryEntryKind._();
+}
+
+class PlaybackHistoryIdentity {
+  const PlaybackHistoryIdentity({
+    required this.bangumiItem,
+    required this.pluginName,
+    required this.episodeNumber,
+    required this.episodeTitle,
+    required this.road,
+    required this.entryKind,
+    this.onlineBangumiSrc = '',
+    this.episodePageUrl = '',
+  });
+
+  final BangumiItem bangumiItem;
+  final String pluginName;
+  final int episodeNumber;
+  final String episodeTitle;
+  final int road;
+  final String entryKind;
+  final String onlineBangumiSrc;
+  final String episodePageUrl;
+
+  bool get canRecord => pluginName.isNotEmpty && episodeNumber > 0;
+
+  factory PlaybackHistoryIdentity.online({
+    required BangumiItem bangumiItem,
+    required String pluginName,
+    required int episodeNumber,
+    required String episodeTitle,
+    required int road,
+    required String onlineBangumiSrc,
+    required String episodePageUrl,
+  }) {
+    return PlaybackHistoryIdentity(
+      bangumiItem: bangumiItem,
+      pluginName: pluginName,
+      episodeNumber: episodeNumber,
+      episodeTitle: episodeTitle,
+      road: road,
+      entryKind: HistoryEntryKind.online,
+      onlineBangumiSrc: onlineBangumiSrc,
+      episodePageUrl: episodePageUrl,
+    );
+  }
+
+  factory PlaybackHistoryIdentity.offline({
+    required BangumiItem bangumiItem,
+    required String pluginName,
+    required int episodeNumber,
+    required String episodeTitle,
+    required int road,
+    required String episodePageUrl,
+  }) {
+    return PlaybackHistoryIdentity(
+      bangumiItem: bangumiItem,
+      pluginName: pluginName,
+      episodeNumber: episodeNumber,
+      episodeTitle: episodeTitle,
+      road: road,
+      entryKind: HistoryEntryKind.offline,
+      episodePageUrl: episodePageUrl,
+    );
+  }
+}
+
 @HiveType(typeId: 1)
 class History {
   @HiveField(0)
@@ -26,12 +101,38 @@ class History {
   @HiveField(6, defaultValue: '')
   String lastWatchEpisodeName;
 
-  String get key => adapterName + bangumiItem.id.toString();
+  @HiveField(7, defaultValue: HistoryEntryKind.online)
+  String entryKind;
 
-  History(this.bangumiItem, this.lastWatchEpisode, this.adapterName,
-      this.lastWatchTime, this.lastSrc, this.lastWatchEpisodeName);
+  @HiveField(8, defaultValue: '')
+  String episodePageUrl;
 
-  static String getKey(String n, BangumiItem s) => n + s.id.toString();
+  String get key => scopedKey(adapterName, bangumiItem, entryKind);
+
+  History(
+    this.bangumiItem,
+    this.lastWatchEpisode,
+    this.adapterName,
+    this.lastWatchTime,
+    this.lastSrc,
+    this.lastWatchEpisodeName, {
+    this.entryKind = HistoryEntryKind.online,
+    this.episodePageUrl = '',
+  });
+
+  static String legacyKey(String n, BangumiItem s) => n + s.id.toString();
+
+  static String scopedKey(String n, BangumiItem s, String entryKind) {
+    return '${legacyKey(n, s)}::${HistoryEntryKind.normalize(entryKind)}';
+  }
+
+  static String getKey(
+    String n,
+    BangumiItem s, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
+    return scopedKey(n, s, entryKind);
+  }
 
   @override
   String toString() {
@@ -50,11 +151,23 @@ class Progress {
   @HiveField(2)
   int _progressInMilli;
 
+  @HiveField(3, defaultValue: 0)
+  int updatedAtMs;
+
   Duration get progress => Duration(milliseconds: _progressInMilli);
 
   set progress(Duration d) => _progressInMilli = d.inMilliseconds;
 
-  Progress(this.episode, this.road, this._progressInMilli);
+  Progress(
+    this.episode,
+    this.road,
+    this._progressInMilli, {
+    this.updatedAtMs = 0,
+  });
+
+  int effectiveUpdatedAtMs(DateTime fallback) {
+    return updatedAtMs > 0 ? updatedAtMs : fallback.millisecondsSinceEpoch;
+  }
 
   @override
   String toString() {

--- a/lib/modules/history/history_module.g.dart
+++ b/lib/modules/history/history_module.g.dart
@@ -23,13 +23,17 @@ class HistoryAdapter extends TypeAdapter<History> {
       fields[4] as DateTime,
       fields[5] as String,
       fields[6] == null ? '' : fields[6] as String,
+      entryKind: fields[7] == null
+          ? HistoryEntryKind.online
+          : fields[7] as String,
+      episodePageUrl: fields[8] == null ? '' : fields[8] as String,
     )..progresses = (fields[0] as Map).cast<int, Progress>();
   }
 
   @override
   void write(BinaryWriter writer, History obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.progresses)
       ..writeByte(1)
@@ -43,7 +47,11 @@ class HistoryAdapter extends TypeAdapter<History> {
       ..writeByte(5)
       ..write(obj.lastSrc)
       ..writeByte(6)
-      ..write(obj.lastWatchEpisodeName);
+      ..write(obj.lastWatchEpisodeName)
+      ..writeByte(7)
+      ..write(obj.entryKind)
+      ..writeByte(8)
+      ..write(obj.episodePageUrl);
   }
 
   @override
@@ -71,19 +79,22 @@ class ProgressAdapter extends TypeAdapter<Progress> {
       (fields[0] as num).toInt(),
       (fields[1] as num).toInt(),
       (fields[2] as num).toInt(),
+      updatedAtMs: fields[3] == null ? 0 : (fields[3] as num).toInt(),
     );
   }
 
   @override
   void write(BinaryWriter writer, Progress obj) {
     writer
-      ..writeByte(3)
+      ..writeByte(4)
       ..writeByte(0)
       ..write(obj.episode)
       ..writeByte(1)
       ..write(obj.road)
       ..writeByte(2)
-      ..write(obj._progressInMilli);
+      ..write(obj._progressInMilli)
+      ..writeByte(3)
+      ..write(obj.updatedAtMs);
   }
 
   @override

--- a/lib/modules/history/history_sync.dart
+++ b/lib/modules/history/history_sync.dart
@@ -55,6 +55,8 @@ class HistorySyncEvent {
     this.progressMs,
     this.lastSrc,
     this.lastWatchEpisodeName,
+    this.entryKind,
+    this.episodePageUrl,
     this.carriesWatchState = false,
   });
 
@@ -71,6 +73,8 @@ class HistorySyncEvent {
   final int? progressMs;
   final String? lastSrc;
   final String? lastWatchEpisodeName;
+  final String? entryKind;
+  final String? episodePageUrl;
   final bool carriesWatchState;
 
   String get version => HistorySyncVersion.of(
@@ -99,6 +103,8 @@ class HistorySyncEvent {
       episode: episode,
       road: road,
       progressMs: progressMs,
+      entryKind: history.entryKind,
+      episodePageUrl: history.episodePageUrl,
     );
   }
 
@@ -121,6 +127,8 @@ class HistorySyncEvent {
       episode: episode,
       lastSrc: history.lastSrc,
       lastWatchEpisodeName: history.lastWatchEpisodeName,
+      entryKind: history.entryKind,
+      episodePageUrl: history.episodePageUrl,
       carriesWatchState: true,
     );
   }
@@ -174,8 +182,11 @@ class HistorySyncEvent {
       progressMs: (json['progressMs'] as num?)?.toInt(),
       lastSrc: json['lastSrc'] as String?,
       lastWatchEpisodeName: json['lastWatchEpisodeName'] as String?,
-      carriesWatchState: json.containsKey('lastSrc') ||
-          json.containsKey('lastWatchEpisodeName'),
+      entryKind: json['entryKind'] as String?,
+      episodePageUrl: json['episodePageUrl'] as String?,
+      carriesWatchState: (json['carriesWatchState'] as bool?) ??
+          (json.containsKey('lastSrc') ||
+              json.containsKey('lastWatchEpisodeName')),
     );
   }
 
@@ -196,6 +207,9 @@ class HistorySyncEvent {
       if (lastSrc != null) 'lastSrc': lastSrc,
       if (lastWatchEpisodeName != null)
         'lastWatchEpisodeName': lastWatchEpisodeName,
+      if (entryKind != null) 'entryKind': entryKind,
+      if (episodePageUrl != null) 'episodePageUrl': episodePageUrl,
+      if (carriesWatchState) 'carriesWatchState': carriesWatchState,
     };
   }
 }
@@ -231,13 +245,18 @@ class HistorySyncSnapshot {
     final itemVersions = <String, String>{};
     final progressVersions = <String, Map<int, String>>{};
     for (final history in histories) {
+      history.entryKind = HistoryEntryKind.normalize(history.entryKind);
       final version = HistorySyncVersion.of(
         updatedAt: history.lastWatchTime.millisecondsSinceEpoch,
         eventId: 'local-import:${history.key}',
       );
       itemVersions[history.key] = version;
       progressVersions[history.key] = {
-        for (final entry in history.progresses.entries) entry.key: version,
+        for (final entry in history.progresses.entries)
+          entry.key: HistorySyncVersion.of(
+            updatedAt: entry.value.effectiveUpdatedAtMs(history.lastWatchTime),
+            eventId: 'local-import:${history.key}:${entry.key}',
+          ),
       };
     }
     return HistorySyncSnapshot(
@@ -250,28 +269,49 @@ class HistorySyncSnapshot {
   }
 
   factory HistorySyncSnapshot.fromJson(Map<String, dynamic> json) {
+    final histories = ((json['histories'] as List?) ?? const [])
+        .map((item) => HistorySyncCodec.historyFromJson(
+              Map<String, dynamic>.from(item as Map),
+            ))
+        .toList();
+    final keyMap = {
+      for (final history in histories) history.key: history.key,
+      for (final history in histories)
+        if (history.entryKind == HistoryEntryKind.online)
+          History.legacyKey(history.adapterName, history.bangumiItem):
+              history.key,
+    };
+    String canonicalSnapshotKey(String key) => keyMap[key] ?? key;
     final progressJson = Map<String, dynamic>.from(
       (json['progressVersions'] as Map?) ?? const {},
+    );
+    final itemVersions = Map<String, String>.from(
+      (json['itemVersions'] as Map?) ?? const {},
+    );
+    final progressVersions = {
+      for (final entry in progressJson.entries)
+        entry.key: (Map<String, dynamic>.from(entry.value as Map)).map(
+          (episode, version) => MapEntry(int.parse(episode), '$version'),
+        ),
+    };
+    final deletedVersions = Map<String, String>.from(
+      (json['deletedVersions'] as Map?) ?? const {},
     );
     return HistorySyncSnapshot(
       generatedAt: (json['generatedAt'] as num?)?.toInt() ??
           DateTime.now().millisecondsSinceEpoch,
-      histories: ((json['histories'] as List?) ?? const [])
-          .map((item) => HistorySyncCodec.historyFromJson(
-                Map<String, dynamic>.from(item as Map),
-              ))
-          .toList(),
-      itemVersions: Map<String, String>.from(
-        (json['itemVersions'] as Map?) ?? const {},
+      histories: histories,
+      itemVersions: HistorySyncState._canonicalizeVersionMap(
+        itemVersions,
+        canonicalSnapshotKey,
       ),
-      progressVersions: {
-        for (final entry in progressJson.entries)
-          entry.key: (Map<String, dynamic>.from(entry.value as Map)).map(
-            (episode, version) => MapEntry(int.parse(episode), '$version'),
-          ),
-      },
-      deletedVersions: Map<String, String>.from(
-        (json['deletedVersions'] as Map?) ?? const {},
+      progressVersions: HistorySyncState._canonicalizeProgressVersionMap(
+        progressVersions,
+        canonicalSnapshotKey,
+      ),
+      deletedVersions: HistorySyncState._canonicalizeVersionMap(
+        deletedVersions,
+        canonicalSnapshotKey,
       ),
       clearVersion: json['clearVersion'] as String?,
     );
@@ -313,13 +353,33 @@ class HistorySyncState {
         deletedVersions = Map.of(deletedVersions);
 
   factory HistorySyncState.fromSnapshot(HistorySyncSnapshot snapshot) {
+    final histories = <String, History>{};
+    final keyMap = <String, String>{};
+    for (final history in snapshot.histories) {
+      history.entryKind = HistoryEntryKind.normalize(history.entryKind);
+      histories[history.key] = history;
+      keyMap[history.key] = history.key;
+      if (history.entryKind == HistoryEntryKind.online) {
+        keyMap[History.legacyKey(history.adapterName, history.bangumiItem)] =
+            history.key;
+      }
+    }
+    String canonicalSnapshotKey(String key) => keyMap[key] ?? key;
+
     return HistorySyncState._(
-      histories: {
-        for (final history in snapshot.histories) history.key: history
-      },
-      itemVersions: snapshot.itemVersions,
-      progressVersions: snapshot.progressVersions,
-      deletedVersions: snapshot.deletedVersions,
+      histories: histories,
+      itemVersions: _canonicalizeVersionMap(
+        snapshot.itemVersions,
+        canonicalSnapshotKey,
+      ),
+      progressVersions: _canonicalizeProgressVersionMap(
+        snapshot.progressVersions,
+        canonicalSnapshotKey,
+      ),
+      deletedVersions: _canonicalizeVersionMap(
+        snapshot.deletedVersions,
+        canonicalSnapshotKey,
+      ),
       clearVersion: snapshot.clearVersion,
     );
   }
@@ -355,14 +415,12 @@ class HistorySyncState {
   }
 
   void _applyUpsertProgress(HistorySyncEvent event) {
-    final entityKey = event.entityKey;
     final bangumiItem = event.bangumiItem;
     final adapterName = event.adapterName;
     final episode = event.episode;
     final road = event.road;
     final progressMs = event.progressMs;
-    if (entityKey == null ||
-        bangumiItem == null ||
+    if (bangumiItem == null ||
         adapterName == null ||
         episode == null ||
         road == null ||
@@ -372,7 +430,15 @@ class HistorySyncState {
     if (!_isNewerThanClear(event.version)) {
       return;
     }
-    final deletedVersion = deletedVersions[entityKey];
+    final entryKind =
+        HistoryEntryKind.normalize(event.entryKind ?? HistoryEntryKind.online);
+    final entityKey = History.scopedKey(adapterName, bangumiItem, entryKind);
+    final legacyEntityKey = History.legacyKey(adapterName, bangumiItem);
+    final deletedVersion = _deletedVersionForUpsert(
+      entityKey,
+      legacyEntityKey: legacyEntityKey,
+      entryKind: entryKind,
+    );
     if (deletedVersion != null &&
         HistorySyncVersion.compare(event.version, deletedVersion) <= 0) {
       return;
@@ -386,38 +452,51 @@ class HistorySyncState {
           DateTime.fromMillisecondsSinceEpoch(event.updatedAt),
           event.lastSrc ?? '',
           event.lastWatchEpisodeName ?? '',
+          entryKind: entryKind,
+          episodePageUrl: event.episodePageUrl ?? '',
         );
 
     final episodeVersions = progressVersions.putIfAbsent(entityKey, () => {});
     final progressVersion = episodeVersions[episode];
     if (progressVersion == null ||
         HistorySyncVersion.compare(event.version, progressVersion) >= 0) {
-      current.progresses[episode] = Progress(episode, road, progressMs);
+      current.progresses[episode] = Progress(
+        episode,
+        road,
+        progressMs,
+        updatedAtMs: event.updatedAt,
+      );
       episodeVersions[episode] = event.version;
     }
     histories[entityKey] = current;
     deletedVersions.remove(entityKey);
-
+    if (entryKind == HistoryEntryKind.online) {
+      deletedVersions.remove(legacyEntityKey);
+    }
     if (_shouldApplyLegacyWatchState(event)) {
       _applyUpsertWatchState(event);
     }
   }
 
   void _applyUpsertWatchState(HistorySyncEvent event) {
-    final entityKey = event.entityKey;
     final bangumiItem = event.bangumiItem;
     final adapterName = event.adapterName;
     final episode = event.episode;
-    if (entityKey == null ||
-        bangumiItem == null ||
-        adapterName == null ||
-        episode == null) {
+    if (bangumiItem == null || adapterName == null || episode == null) {
       throw const FormatException('Invalid upsertWatchState history event');
     }
     if (!_isNewerThanClear(event.version)) {
       return;
     }
-    final deletedVersion = deletedVersions[entityKey];
+    final entryKind =
+        HistoryEntryKind.normalize(event.entryKind ?? HistoryEntryKind.online);
+    final entityKey = History.scopedKey(adapterName, bangumiItem, entryKind);
+    final legacyEntityKey = History.legacyKey(adapterName, bangumiItem);
+    final deletedVersion = _deletedVersionForUpsert(
+      entityKey,
+      legacyEntityKey: legacyEntityKey,
+      entryKind: entryKind,
+    );
     if (deletedVersion != null &&
         HistorySyncVersion.compare(event.version, deletedVersion) <= 0) {
       return;
@@ -431,6 +510,8 @@ class HistorySyncState {
           DateTime.fromMillisecondsSinceEpoch(event.updatedAt),
           event.lastSrc ?? '',
           event.lastWatchEpisodeName ?? '',
+          entryKind: entryKind,
+          episodePageUrl: event.episodePageUrl ?? '',
         );
 
     final itemVersion = itemVersions[entityKey];
@@ -447,17 +528,25 @@ class HistorySyncState {
       if ((event.lastWatchEpisodeName ?? '').isNotEmpty) {
         current.lastWatchEpisodeName = event.lastWatchEpisodeName!;
       }
+      current.entryKind = entryKind;
+      if ((event.episodePageUrl ?? '').isNotEmpty) {
+        current.episodePageUrl = event.episodePageUrl!;
+      }
       itemVersions[entityKey] = event.version;
     }
     histories[entityKey] = current;
     deletedVersions.remove(entityKey);
+    if (entryKind == HistoryEntryKind.online) {
+      deletedVersions.remove(legacyEntityKey);
+    }
   }
 
   void _applyDelete(HistorySyncEvent event) {
-    final entityKey = event.entityKey;
-    if (entityKey == null || !_isNewerThanClear(event.version)) {
+    final rawEntityKey = event.entityKey;
+    if (rawEntityKey == null || !_isNewerThanClear(event.version)) {
       return;
     }
+    final entityKey = _canonicalExistingEntityKey(rawEntityKey);
     final itemVersion = itemVersions[entityKey];
     final deletedVersion = deletedVersions[entityKey];
     final newerThanItem = itemVersion == null ||
@@ -489,11 +578,83 @@ class HistorySyncState {
         HistorySyncVersion.compare(version, currentClearVersion) > 0;
   }
 
+  String _canonicalExistingEntityKey(String key) {
+    if (histories.containsKey(key) ||
+        itemVersions.containsKey(key) ||
+        progressVersions.containsKey(key)) {
+      return key;
+    }
+    for (final history in histories.values) {
+      if (history.entryKind == HistoryEntryKind.online &&
+          History.legacyKey(history.adapterName, history.bangumiItem) == key) {
+        return history.key;
+      }
+    }
+    return key;
+  }
+
+  String? _deletedVersionForUpsert(
+    String entityKey, {
+    required String legacyEntityKey,
+    required String entryKind,
+  }) {
+    final scopedVersion = deletedVersions[entityKey];
+    if (entryKind != HistoryEntryKind.online) {
+      return scopedVersion;
+    }
+    return _newerVersion(scopedVersion, deletedVersions[legacyEntityKey]);
+  }
+
+  String? _newerVersion(String? a, String? b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return HistorySyncVersion.compare(a, b) >= 0 ? a : b;
+  }
+
   bool _shouldApplyLegacyWatchState(HistorySyncEvent event) {
     final hasWatchStatePayload = event.carriesWatchState ||
         event.lastSrc != null ||
         event.lastWatchEpisodeName != null;
     return hasWatchStatePayload && !event.eventId.startsWith('local-state:');
+  }
+
+  static Map<String, String> _canonicalizeVersionMap(
+    Map<String, String> versions,
+    String Function(String key) canonicalKey,
+  ) {
+    final result = <String, String>{};
+    for (final entry in versions.entries) {
+      final key = canonicalKey(entry.key);
+      final existing = result[key];
+      if (existing == null ||
+          HistorySyncVersion.compare(entry.value, existing) > 0) {
+        result[key] = entry.value;
+      }
+    }
+    return result;
+  }
+
+  static Map<String, Map<int, String>> _canonicalizeProgressVersionMap(
+    Map<String, Map<int, String>> versions,
+    String Function(String key) canonicalKey,
+  ) {
+    final result = <String, Map<int, String>>{};
+    for (final entry in versions.entries) {
+      final key = canonicalKey(entry.key);
+      final target = result.putIfAbsent(key, () => {});
+      for (final episodeVersion in entry.value.entries) {
+        final existing = target[episodeVersion.key];
+        if (existing == null ||
+            HistorySyncVersion.compare(episodeVersion.value, existing) > 0) {
+          target[episodeVersion.key] = episodeVersion.value;
+        }
+      }
+    }
+    return result;
   }
 }
 
@@ -556,6 +717,8 @@ class HistorySyncCodec {
           (json['lastWatchTime'] as num).toInt()),
       json['lastSrc'] as String? ?? '',
       json['lastWatchEpisodeName'] as String? ?? '',
+      entryKind: json['entryKind'] as String? ?? HistoryEntryKind.online,
+      episodePageUrl: json['episodePageUrl'] as String? ?? '',
     );
     history.progresses = {
       for (final entry
@@ -575,6 +738,8 @@ class HistorySyncCodec {
       'lastWatchTime': history.lastWatchTime.millisecondsSinceEpoch,
       'lastSrc': history.lastSrc,
       'lastWatchEpisodeName': history.lastWatchEpisodeName,
+      'entryKind': history.entryKind,
+      'episodePageUrl': history.episodePageUrl,
       'progresses': {
         for (final entry in history.progresses.entries)
           entry.key.toString(): progressToJson(entry.value),
@@ -587,6 +752,7 @@ class HistorySyncCodec {
       (json['episode'] as num).toInt(),
       (json['road'] as num).toInt(),
       (json['progressMs'] as num).toInt(),
+      updatedAtMs: (json['updatedAtMs'] as num?)?.toInt() ?? 0,
     );
   }
 
@@ -595,6 +761,7 @@ class HistorySyncCodec {
       'episode': progress.episode,
       'road': progress.road,
       'progressMs': progress.progress.inMilliseconds,
+      'updatedAtMs': progress.updatedAtMs,
     };
   }
 

--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -21,32 +21,38 @@ abstract class _HistoryController with Store {
   }
 
   Future<void> updateHistory(
-      int episode,
-      int road,
-      String adapterName,
-      BangumiItem bangumiItem,
-      Duration progress,
-      String lastSrc,
-      String lastWatchEpisodeName) async {
+      PlaybackHistoryIdentity identity, Duration progress) async {
     await _historyRepository.updateHistory(
-      episode: episode,
-      road: road,
-      adapterName: adapterName,
-      bangumiItem: bangumiItem,
+      identity: identity,
       progress: progress,
-      lastSrc: lastSrc,
-      lastWatchEpisodeName: lastWatchEpisodeName,
     );
     init();
   }
 
-  Progress? lastWatching(BangumiItem bangumiItem, String adapterName) {
-    return _historyRepository.getLastWatchingProgress(bangumiItem, adapterName);
+  Progress? lastWatching(
+    BangumiItem bangumiItem,
+    String adapterName, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
+    return _historyRepository.getLastWatchingProgress(
+      bangumiItem,
+      adapterName,
+      entryKind: entryKind,
+    );
   }
 
   Progress? findProgress(
-      BangumiItem bangumiItem, String adapterName, int episode) {
-    return _historyRepository.findProgress(bangumiItem, adapterName, episode);
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
+    return _historyRepository.findProgress(
+      bangumiItem,
+      adapterName,
+      episode,
+      entryKind: entryKind,
+    );
   }
 
   Future<void> deleteHistory(History history) async {
@@ -55,8 +61,17 @@ abstract class _HistoryController with Store {
   }
 
   Future<void> clearProgress(
-      BangumiItem bangumiItem, String adapterName, int episode) async {
-    await _historyRepository.clearProgress(bangumiItem, adapterName, episode);
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  }) async {
+    await _historyRepository.clearProgress(
+      bangumiItem,
+      adapterName,
+      episode,
+      entryKind: entryKind,
+    );
     init();
   }
 

--- a/lib/pages/player/controller/player_models.dart
+++ b/lib/pages/player/controller/player_models.dart
@@ -4,6 +4,7 @@ class PlaybackInitParams {
   final bool isLocalPlayback;
   final int bangumiId;
   final String pluginName;
+  final int episode;
   final int danmakuEpisodeNumber;
   final Map<String, String> httpHeaders;
   final bool adBlockerEnabled;
@@ -19,6 +20,7 @@ class PlaybackInitParams {
     required this.isLocalPlayback,
     required this.bangumiId,
     required this.pluginName,
+    required this.episode,
     required this.danmakuEpisodeNumber,
     required this.httpHeaders,
     required this.adBlockerEnabled,

--- a/lib/pages/player/controller/player_models.dart
+++ b/lib/pages/player/controller/player_models.dart
@@ -4,7 +4,7 @@ class PlaybackInitParams {
   final bool isLocalPlayback;
   final int bangumiId;
   final String pluginName;
-  final int episode;
+  final int danmakuEpisodeNumber;
   final Map<String, String> httpHeaders;
   final bool adBlockerEnabled;
   final String episodeTitle;
@@ -19,7 +19,7 @@ class PlaybackInitParams {
     required this.isLocalPlayback,
     required this.bangumiId,
     required this.pluginName,
-    required this.episode,
+    required this.danmakuEpisodeNumber,
     required this.httpHeaders,
     required this.adBlockerEnabled,
     required this.episodeTitle,

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -35,7 +35,7 @@ class PlayerController {
   );
   late final PlayerSyncPlayController syncplay = PlayerSyncPlayController(
     bangumiId: () => bangumiId,
-    currentEpisode: () => currentEpisode,
+    currentEpisode: () => currentDanmakuEpisodeNumber,
     currentRoad: () => currentRoad,
     playing: () => playback.playing,
     currentPosition: () => playback.currentPosition,
@@ -52,7 +52,7 @@ class PlayerController {
   );
 
   late int bangumiId;
-  late int currentEpisode;
+  late int currentDanmakuEpisodeNumber;
   late int currentRoad;
   late String referer;
   String? coverUrl;
@@ -91,7 +91,7 @@ class PlayerController {
     videoUrl = params.videoUrl;
     isLocalPlayback = params.isLocalPlayback;
     bangumiId = params.bangumiId;
-    currentEpisode = params.episode;
+    currentDanmakuEpisodeNumber = params.danmakuEpisodeNumber;
     currentRoad = params.currentRoad;
     referer = params.referer;
 
@@ -181,7 +181,7 @@ class PlayerController {
 
     if (syncplay.syncplayController?.isConnected ?? false) {
       if (syncplay.syncplayController!.currentFileName !=
-          "$bangumiId[$currentEpisode]") {
+          "$bangumiId[$currentDanmakuEpisodeNumber]") {
         setSyncPlayPlayingBangumi(
             forceSyncPlaying: true, forceSyncPosition: 0.0);
       }

--- a/lib/pages/player/player_controller.dart
+++ b/lib/pages/player/player_controller.dart
@@ -35,7 +35,7 @@ class PlayerController {
   );
   late final PlayerSyncPlayController syncplay = PlayerSyncPlayController(
     bangumiId: () => bangumiId,
-    currentEpisode: () => currentDanmakuEpisodeNumber,
+    currentEpisode: () => currentEpisode,
     currentRoad: () => currentRoad,
     playing: () => playback.playing,
     currentPosition: () => playback.currentPosition,
@@ -52,6 +52,7 @@ class PlayerController {
   );
 
   late int bangumiId;
+  late int currentEpisode;
   late int currentDanmakuEpisodeNumber;
   late int currentRoad;
   late String referer;
@@ -91,6 +92,7 @@ class PlayerController {
     videoUrl = params.videoUrl;
     isLocalPlayback = params.isLocalPlayback;
     bangumiId = params.bangumiId;
+    currentEpisode = params.episode;
     currentDanmakuEpisodeNumber = params.danmakuEpisodeNumber;
     currentRoad = params.currentRoad;
     referer = params.referer;
@@ -181,7 +183,7 @@ class PlayerController {
 
     if (syncplay.syncplayController?.isConnected ?? false) {
       if (syncplay.syncplayController!.currentFileName !=
-          "$bangumiId[$currentDanmakuEpisodeNumber]") {
+          "$bangumiId[$currentEpisode]") {
         setSyncPlayPlayingBangumi(
             forceSyncPlaying: true, forceSyncPosition: 0.0);
       }

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -1017,22 +1017,15 @@ class _PlayerItemState extends State<PlayerItem>
         });
       }
       // 历史记录相关
+      final historyIdentity = videoPageController.currentHistoryIdentity;
       if (playerController.playback.playerPlaying &&
           !videoPageController.loading &&
-          !videoPageController.isOfflineMode) {
-        final pluginName = videoPageController.isOfflineMode
-            ? videoPageController.offlinePluginName
-            : videoPageController.currentPlugin.name;
-        final selection = videoPageController.playbackEpisode;
+          historyIdentity != null &&
+          historyIdentity.canRecord) {
         historyController.updateHistory(
-            videoPageController.playingActualEpisodeNumber,
-            selection.road,
-            pluginName,
-            videoPageController.bangumiItem,
-            playerController.playback.playerPosition,
-            videoPageController.src,
-            videoPageController
-                .roadList[selection.road].identifier[selection.episode - 1]);
+          historyIdentity,
+          playerController.playback.playerPosition,
+        );
       }
       // 自动播放下一集
       final playingSelection = videoPageController.playbackEpisode;

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -499,6 +499,7 @@ abstract class _VideoPageController with Store {
       isLocalPlayback: true,
       bangumiId: bangumiItem.id,
       pluginName: _offlinePluginName,
+      episode: resolvedEpisode.listIndex,
       danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
       httpHeaders: {},
       adBlockerEnabled: false,
@@ -610,6 +611,7 @@ abstract class _VideoPageController with Store {
         isLocalPlayback: false,
         bangumiId: bangumiItem.id,
         pluginName: currentPlugin.name,
+        episode: resolvedEpisode.listIndex,
         danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
         httpHeaders: {
           'user-agent': currentPlugin.userAgent.isEmpty

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -462,10 +462,8 @@ abstract class _VideoPageController with Store {
     KazumiLogger()
         .i('VideoPageController: changed to ${resolvedEpisode.displayTitle}');
     String urlItem = resolvedEpisode.episodePageUrl;
-    if (urlItem.contains(currentPlugin.baseUrl) ||
-        urlItem.contains(currentPlugin.baseUrl.replaceAll('https', 'http'))) {
-      urlItem = urlItem;
-    } else {
+    if (!urlItem.contains(currentPlugin.baseUrl) &&
+        !urlItem.contains(currentPlugin.baseUrl.replaceAll('https', 'http'))) {
       urlItem = currentPlugin.baseUrl + urlItem;
     }
 

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -7,6 +7,7 @@ import 'package:kazumi/pages/history/history_controller.dart';
 import 'package:kazumi/pages/player/player_controller.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/download/download_module.dart';
+import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/repositories/download_repository.dart';
 import 'package:kazumi/services/download/download_manager.dart';
 import 'package:kazumi/services/video_source/services.dart';
@@ -117,6 +118,24 @@ abstract class _VideoPageController with Store {
   VideoEpisodeSelection get playbackEpisode =>
       playingEpisode ?? selectedEpisode;
 
+  int get currentEpisode => selectedEpisode.episode;
+
+  set currentEpisode(int episode) {
+    selectedEpisode = VideoEpisodeSelection(
+      episode: episode,
+      road: selectedEpisode.road,
+    );
+  }
+
+  int get currentRoad => selectedEpisode.road;
+
+  set currentRoad(int road) {
+    selectedEpisode = VideoEpisodeSelection(
+      episode: selectedEpisode.episode,
+      road: road,
+    );
+  }
+
   @observable
   bool isFullscreen = false;
 
@@ -141,6 +160,11 @@ abstract class _VideoPageController with Store {
 
   @observable
   bool isOfflineMode = false;
+
+  PlaybackHistoryIdentity? _playbackHistoryIdentity;
+  final Map<int, DownloadEpisode> _offlineEpisodesByNumber = {};
+  final Map<int, int> _offlineDisplayRoadToOriginalRoad = {};
+  final Map<int, int> _offlineOriginalRoadToDisplayRoad = {};
 
   /// 和 bangumiItem 中的标题不同，此标题来自于视频源
   String title = '';
@@ -180,7 +204,6 @@ abstract class _VideoPageController with Store {
   }) {
     this.bangumiItem = bangumiItem;
     _offlinePluginName = pluginName;
-    var selectedRoad = road;
     title =
         bangumiItem.nameCn.isNotEmpty ? bangumiItem.nameCn : bangumiItem.name;
     isOfflineMode = true;
@@ -188,78 +211,200 @@ abstract class _VideoPageController with Store {
 
     _buildOfflineRoadList(downloadedEpisodes);
 
-    if (selectedRoad < 0 || selectedRoad >= roadList.length) {
-      selectedRoad = 0;
-    }
-
-    // Offline road data stores the real episode number, while selection uses
-    // the 1-based position shown in the playlist.
-    final index = roadList[selectedRoad].data.indexOf(episodeNumber.toString());
+    final target = _findOfflineEpisodeByNumber(
+      episodeNumber,
+      preferredOriginalRoad: road,
+    );
     final selected = VideoEpisodeSelection(
-      episode: index >= 0 ? index + 1 : 1,
-      road: selectedRoad,
+      episode: target?.listIndex ?? 1,
+      road: target?.roadIndex ?? 0,
     );
     selectedEpisode = selected;
     playingEpisode = null;
     commentsEpisode = commentEpisodeForSelection(selected);
+    final resolvedEpisode = _resolveOfflineEpisode(
+      selected.episode,
+      road: selected.road,
+    );
+    if (resolvedEpisode != null) {
+      _setOfflineHistoryIdentity(resolvedEpisode);
+    } else {
+      _playbackHistoryIdentity = null;
+    }
     KazumiLogger().i(
         'VideoPageController: initialized for offline playback, episode $episodeNumber (position: ${selected.episode})');
   }
 
   void _buildOfflineRoadList(List<DownloadEpisode> episodes) {
+    final snapshot = buildOfflineRoadListSnapshot(episodes);
     roadList.clear();
-    episodes.sort((a, b) => a.episodeNumber.compareTo(b.episodeNumber));
-    roadList.add(Road(
-      name: '播放线路1',
-      data: episodes.map((e) => e.episodeNumber.toString()).toList(),
-      identifier: episodes
-          .map((e) =>
-              e.episodeName.isNotEmpty ? e.episodeName : '第${e.episodeNumber}集')
-          .toList(),
-    ));
+    roadList.addAll(snapshot.roads);
+    _offlineEpisodesByNumber.clear();
+    _offlineEpisodesByNumber.addAll(snapshot.episodesByNumber);
+    _offlineDisplayRoadToOriginalRoad.clear();
+    _offlineDisplayRoadToOriginalRoad
+        .addAll(snapshot.displayRoadToOriginalRoad);
+    _offlineOriginalRoadToDisplayRoad.clear();
+    _offlineOriginalRoadToDisplayRoad
+        .addAll(snapshot.originalRoadToDisplayRoad);
   }
 
   void resetOfflineMode() {
     isOfflineMode = false;
     _offlinePluginName = '';
+    _offlineEpisodesByNumber.clear();
+    _offlineDisplayRoadToOriginalRoad.clear();
+    _offlineOriginalRoadToDisplayRoad.clear();
+    _playbackHistoryIdentity = null;
   }
 
   String get offlinePluginName => _offlinePluginName;
 
-  int get playingActualEpisodeNumber =>
-      actualEpisodeNumberForSelection(playbackEpisode);
+  PlaybackHistoryIdentity? get currentHistoryIdentity =>
+      _playbackHistoryIdentity;
 
-  int actualEpisodeNumberForSelection(VideoEpisodeSelection selection) {
-    if (isOfflineMode && roadList.isNotEmpty) {
-      try {
-        return int.parse(roadList[selection.road].data[selection.episode - 1]);
-      } catch (_) {
-        return selection.episode;
+  ({int listIndex, int roadIndex})? _findOfflineEpisodeByNumber(
+    int episodeNumber, {
+    required int preferredOriginalRoad,
+  }) {
+    if (episodeNumber <= 0 || roadList.isEmpty) {
+      return null;
+    }
+    final preferredDisplayRoad =
+        _offlineOriginalRoadToDisplayRoad[preferredOriginalRoad];
+    final roadIndices = <int>[
+      if (preferredDisplayRoad != null) preferredDisplayRoad,
+      for (var i = 0; i < roadList.length; i++)
+        if (i != preferredDisplayRoad) i,
+    ];
+    for (final roadIndex in roadIndices) {
+      final match = _findOfflineEpisodeInDisplayRoad(episodeNumber, roadIndex);
+      if (match != null) {
+        return match;
       }
     }
-    return selection.episode;
+    return null;
+  }
+
+  ({int listIndex, int roadIndex})? _findOfflineEpisodeInDisplayRoad(
+    int episodeNumber,
+    int roadIndex,
+  ) {
+    if (roadIndex < 0 || roadIndex >= roadList.length) {
+      return null;
+    }
+    final index = roadList[roadIndex].data.indexOf(episodeNumber.toString());
+    if (index < 0) {
+      return null;
+    }
+    return (listIndex: index + 1, roadIndex: roadIndex);
+  }
+
+  int getHistoryOffsetFor(PlaybackHistoryIdentity identity) {
+    final playResume = GStorage.getSetting(SettingsKeys.playResume);
+    if (playResume != true) {
+      return 0;
+    }
+    return historyController
+            .findProgress(
+              identity.bangumiItem,
+              identity.pluginName,
+              identity.episodeNumber,
+              entryKind: identity.entryKind,
+            )
+            ?.progress
+            .inSeconds ??
+        0;
+  }
+
+  void _setOnlineHistoryIdentity(ResolvedEpisode episode) {
+    _playbackHistoryIdentity = PlaybackHistoryIdentity.online(
+      bangumiItem: bangumiItem,
+      pluginName: currentPlugin.name,
+      episodeNumber: episode.historyEpisodeNumber,
+      episodeTitle: episode.displayTitle,
+      road: episode.originalRoadIndex,
+      onlineBangumiSrc: src,
+      episodePageUrl: episode.episodePageUrl,
+    );
+  }
+
+  void _setOfflineHistoryIdentity(ResolvedEpisode episode) {
+    _playbackHistoryIdentity = PlaybackHistoryIdentity.offline(
+      bangumiItem: bangumiItem,
+      pluginName: _offlinePluginName,
+      episodeNumber: episode.historyEpisodeNumber,
+      episodeTitle: episode.displayTitle,
+      road: episode.originalRoadIndex,
+      episodePageUrl: episode.episodePageUrl,
+    );
+  }
+
+  ResolvedEpisode? _resolveOnlineEpisode(int episode, {int? road}) {
+    final targetRoad = road ?? selectedEpisode.road;
+    if (roadList.isEmpty || targetRoad < 0 || targetRoad >= roadList.length) {
+      return null;
+    }
+    final roadData = roadList[targetRoad];
+    final index = episode - 1;
+    if (index < 0 ||
+        index >= roadData.data.length ||
+        index >= roadData.identifier.length) {
+      return null;
+    }
+    final displayTitle = roadData.identifier[index];
+    return ResolvedEpisode.online(
+      listIndex: episode,
+      roadIndex: targetRoad,
+      displayTitle: displayTitle,
+      episodePageUrl: roadData.data[index],
+    );
+  }
+
+  ResolvedEpisode? _resolveOfflineEpisode(int episode, {int? road}) {
+    final targetRoad = road ?? selectedEpisode.road;
+    if (roadList.isEmpty || targetRoad < 0 || targetRoad >= roadList.length) {
+      return null;
+    }
+    final roadData = roadList[targetRoad];
+    final index = episode - 1;
+    if (index < 0 || index >= roadData.data.length) {
+      return null;
+    }
+    final episodeNumber = int.tryParse(roadData.data[index]);
+    if (episodeNumber == null) {
+      return null;
+    }
+    final downloadEpisode = _offlineEpisodesByNumber[episodeNumber];
+    final titleFromRoad =
+        index < roadData.identifier.length ? roadData.identifier[index] : '';
+    final episodeTitle = downloadEpisode?.episodeName.isNotEmpty == true
+        ? downloadEpisode!.episodeName
+        : (titleFromRoad.isNotEmpty ? titleFromRoad : '第$episodeNumber集');
+    return ResolvedEpisode.offline(
+      listIndex: episode,
+      roadIndex: targetRoad,
+      displayTitle: episodeTitle,
+      episodePageUrl: downloadEpisode?.episodePageUrl ?? '',
+      episodeNumber: episodeNumber,
+      originalRoadIndex: downloadEpisode?.road ??
+          _offlineDisplayRoadToOriginalRoad[targetRoad] ??
+          targetRoad,
+    );
+  }
+
+  int actualEpisodeNumberForSelection(VideoEpisodeSelection selection) {
+    final resolvedEpisode = isOfflineMode
+        ? _resolveOfflineEpisode(selection.episode, road: selection.road)
+        : _resolveOnlineEpisode(selection.episode, road: selection.road);
+    return resolvedEpisode?.historyEpisodeNumber ?? selection.episode;
   }
 
   int commentEpisodeForSelection(VideoEpisodeSelection selection) {
-    if (roadList.isEmpty ||
-        selection.road < 0 ||
-        selection.road >= roadList.length) {
-      return selection.episode;
-    }
-    final road = roadList[selection.road];
-    final index = selection.episode - 1;
-    if (index < 0 || index >= road.identifier.length) {
-      return selection.episode;
-    }
-
-    final extractedEpisode = extractEpisodeNumber(road.identifier[index]);
-    if (extractedEpisode == 0 ||
-        (!isOfflineMode && extractedEpisode > road.identifier.length)) {
-      return isOfflineMode
-          ? actualEpisodeNumberForSelection(selection)
-          : selection.episode;
-    }
-    return extractedEpisode;
+    final resolvedEpisode = isOfflineMode
+        ? _resolveOfflineEpisode(selection.episode, road: selection.road)
+        : _resolveOnlineEpisode(selection.episode, road: selection.road);
+    return resolvedEpisode?.danmakuEpisodeNumber ?? selection.episode;
   }
 
   Future<void> changeEpisode(
@@ -298,19 +443,36 @@ abstract class _VideoPageController with Store {
       return;
     }
 
-    String chapterName =
-        roadList[selection.road].identifier[selection.episode - 1];
-    KazumiLogger().i('VideoPageController: changed to $chapterName');
-    String urlItem = roadList[selection.road].data[selection.episode - 1];
-    if (!urlItem.contains(currentPlugin.baseUrl) &&
-        !urlItem.contains(currentPlugin.baseUrl.replaceAll('https', 'http'))) {
+    final resolvedEpisode = _resolveOnlineEpisode(episode, road: currentRoad);
+    if (resolvedEpisode == null) {
+      loading = false;
+      KazumiLogger().e(
+          'VideoPageController: failed to resolve online episode. road=$currentRoad, episode=$episode');
+      KazumiDialog.showToast(message: '集数解析失败');
+      return;
+    }
+
+    selectedEpisode = VideoEpisodeSelection(
+      episode: resolvedEpisode.listIndex,
+      road: resolvedEpisode.roadIndex,
+    );
+    commentsEpisode = commentEpisodeForSelection(selectedEpisode);
+    _setOnlineHistoryIdentity(resolvedEpisode);
+
+    KazumiLogger()
+        .i('VideoPageController: changed to ${resolvedEpisode.displayTitle}');
+    String urlItem = resolvedEpisode.episodePageUrl;
+    if (urlItem.contains(currentPlugin.baseUrl) ||
+        urlItem.contains(currentPlugin.baseUrl.replaceAll('https', 'http'))) {
+      urlItem = urlItem;
+    } else {
       urlItem = currentPlugin.baseUrl + urlItem;
     }
 
     await _resolveWithVideoSourceService(
       urlItem,
       offset,
-      selection: selection,
+      resolvedEpisode: resolvedEpisode,
       session: session,
       playerController: playerController,
     );
@@ -322,11 +484,12 @@ abstract class _VideoPageController with Store {
     required _AsyncSession session,
     required PlayerController playerController,
   }) async {
-    final actualEpisodeNumber =
-        int.tryParse(roadList[selection.road].data[selection.episode - 1]);
-    if (actualEpisodeNumber == null) {
+    final resolvedEpisode =
+        _resolveOfflineEpisode(selection.episode, road: selection.road);
+    if (resolvedEpisode == null) {
+      loading = false;
       KazumiLogger().e(
-          'VideoPageController: failed to parse episode number from roadList data: ${roadList[selection.road].data[selection.episode - 1]}');
+          'VideoPageController: failed to resolve offline episode. road=${selection.road}, episode=${selection.episode}');
       KazumiDialog.showToast(message: '集数解析失败');
       return;
     }
@@ -334,32 +497,41 @@ abstract class _VideoPageController with Store {
     final localPath = _getLocalVideoPath(
       bangumiItem.id,
       _offlinePluginName,
-      actualEpisodeNumber,
+      resolvedEpisode.historyEpisodeNumber,
     );
     if (localPath == null) {
+      loading = false;
       KazumiDialog.showToast(message: '该集数未下载');
       return;
     }
+    selectedEpisode = VideoEpisodeSelection(
+      episode: resolvedEpisode.listIndex,
+      road: resolvedEpisode.roadIndex,
+    );
+    commentsEpisode = commentEpisodeForSelection(selectedEpisode);
+    _setOfflineHistoryIdentity(resolvedEpisode);
     if (session.isStale) {
       return;
     }
     loading = false;
+    final resolvedOffset =
+        offset > 0 ? offset : getHistoryOffsetFor(_playbackHistoryIdentity!);
 
     KazumiLogger().i(
-        'VideoPageController: offline episode changed to $actualEpisodeNumber (index: ${selection.episode}), path: $localPath');
+        'VideoPageController: offline episode changed to ${resolvedEpisode.historyEpisodeNumber} (index: ${selection.episode}), path: $localPath');
 
     final params = PlaybackInitParams(
       videoUrl: localPath,
-      offset: offset,
+      offset: resolvedOffset,
       isLocalPlayback: true,
       bangumiId: bangumiItem.id,
       pluginName: _offlinePluginName,
-      episode: actualEpisodeNumber,
+      danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
       httpHeaders: {},
       adBlockerEnabled: false,
-      episodeTitle: roadList[selection.road].identifier[selection.episode - 1],
+      episodeTitle: resolvedEpisode.displayTitle,
       referer: '',
-      currentRoad: selection.road,
+      currentRoad: resolvedEpisode.roadIndex,
       coverUrl: bangumiItem.images['large'],
       bangumiName:
           bangumiItem.nameCn.isNotEmpty ? bangumiItem.nameCn : bangumiItem.name,
@@ -375,18 +547,7 @@ abstract class _VideoPageController with Store {
   }
 
   int _danmakuEpisodeForPlayback(PlaybackInitParams params) {
-    try {
-      final episodeFromTitle = extractEpisodeNumber(params.episodeTitle);
-      if (episodeFromTitle != 0) {
-        return episodeFromTitle;
-      }
-    } catch (e) {
-      KazumiLogger().e(
-        'VideoPageController: failed to extract episode number from title',
-        error: e,
-      );
-    }
-    return params.episode;
+    return params.danmakuEpisodeNumber;
   }
 
   Future<void> _loadPlaybackDanmaku(
@@ -440,7 +601,7 @@ abstract class _VideoPageController with Store {
   Future<void> _resolveWithVideoSourceService(
     String url,
     int offset, {
-    required VideoEpisodeSelection selection,
+    required ResolvedEpisode resolvedEpisode,
     required _AsyncSession session,
     required PlayerController playerController,
   }) async {
@@ -476,7 +637,7 @@ abstract class _VideoPageController with Store {
         isLocalPlayback: false,
         bangumiId: bangumiItem.id,
         pluginName: currentPlugin.name,
-        episode: selection.episode,
+        danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
         httpHeaders: {
           'user-agent': currentPlugin.userAgent.isEmpty
               ? getRandomUA()
@@ -485,10 +646,9 @@ abstract class _VideoPageController with Store {
             'referer': currentPlugin.referer,
         },
         adBlockerEnabled: forceAdBlocker || currentPlugin.adBlocker,
-        episodeTitle:
-            roadList[selection.road].identifier[selection.episode - 1],
+        episodeTitle: resolvedEpisode.displayTitle,
         referer: currentPlugin.referer,
-        currentRoad: selection.road,
+        currentRoad: resolvedEpisode.roadIndex,
         coverUrl: bangumiItem.images['large'],
         bangumiName: bangumiItem.nameCn.isNotEmpty
             ? bangumiItem.nameCn
@@ -497,7 +657,10 @@ abstract class _VideoPageController with Store {
 
       final initialized = await playerController.init(params);
       if (session.isActive && initialized) {
-        playingEpisode = selection;
+        playingEpisode = VideoEpisodeSelection(
+          episode: resolvedEpisode.listIndex,
+          road: resolvedEpisode.roadIndex,
+        );
         unawaited(_loadPlaybackDanmaku(playerController, params, session));
       } else if (session.isActive) {
         _playbackSessions.cancel();
@@ -649,4 +812,122 @@ abstract class _VideoPageController with Store {
   void handleOnExitFullScreen() async {
     isFullscreen = false;
   }
+}
+
+class OfflineRoadListSnapshot {
+  const OfflineRoadListSnapshot({
+    required this.roads,
+    required this.episodesByNumber,
+    required this.displayRoadToOriginalRoad,
+    required this.originalRoadToDisplayRoad,
+  });
+
+  final List<Road> roads;
+  final Map<int, DownloadEpisode> episodesByNumber;
+  final Map<int, int> displayRoadToOriginalRoad;
+  final Map<int, int> originalRoadToDisplayRoad;
+}
+
+OfflineRoadListSnapshot buildOfflineRoadListSnapshot(
+  List<DownloadEpisode> episodes,
+) {
+  final groupedEpisodes = <int, List<DownloadEpisode>>{};
+  final episodesByNumber = <int, DownloadEpisode>{};
+
+  for (final episode in episodes) {
+    episodesByNumber[episode.episodeNumber] = episode;
+    groupedEpisodes.putIfAbsent(episode.road, () => []).add(episode);
+  }
+
+  final originalRoads = groupedEpisodes.keys.toList()..sort();
+  final roads = <Road>[];
+  final displayRoadToOriginalRoad = <int, int>{};
+  final originalRoadToDisplayRoad = <int, int>{};
+
+  for (final originalRoad in originalRoads) {
+    final roadEpisodes = groupedEpisodes[originalRoad]!
+      ..sort((a, b) => a.episodeNumber.compareTo(b.episodeNumber));
+    final displayRoad = roads.length;
+    displayRoadToOriginalRoad[displayRoad] = originalRoad;
+    originalRoadToDisplayRoad[originalRoad] = displayRoad;
+    roads.add(Road(
+      name: originalRoad >= 0
+          ? '播放列表${originalRoad + 1}'
+          : '播放列表${displayRoad + 1}',
+      data: roadEpisodes.map((e) => e.episodeNumber.toString()).toList(),
+      identifier: roadEpisodes
+          .map((e) =>
+              e.episodeName.isNotEmpty ? e.episodeName : '第${e.episodeNumber}集')
+          .toList(),
+    ));
+  }
+
+  return OfflineRoadListSnapshot(
+    roads: roads,
+    episodesByNumber: episodesByNumber,
+    displayRoadToOriginalRoad: displayRoadToOriginalRoad,
+    originalRoadToDisplayRoad: originalRoadToDisplayRoad,
+  );
+}
+
+class ResolvedEpisode {
+  const ResolvedEpisode({
+    required this.listIndex,
+    required this.roadIndex,
+    required this.displayTitle,
+    required this.episodePageUrl,
+    required this.historyEpisodeNumber,
+    required this.danmakuEpisodeNumber,
+    required this.originalRoadIndex,
+  });
+
+  final int listIndex;
+  final int roadIndex;
+  final String displayTitle;
+  final String episodePageUrl;
+  final int historyEpisodeNumber;
+  final int danmakuEpisodeNumber;
+  final int originalRoadIndex;
+
+  factory ResolvedEpisode.online({
+    required int listIndex,
+    required int roadIndex,
+    required String displayTitle,
+    required String episodePageUrl,
+  }) {
+    final parsedEpisodeNumber = extractEpisodeNumber(displayTitle);
+    return ResolvedEpisode(
+      listIndex: listIndex,
+      roadIndex: roadIndex,
+      displayTitle: displayTitle,
+      episodePageUrl: episodePageUrl,
+      historyEpisodeNumber: listIndex,
+      danmakuEpisodeNumber:
+          parsedEpisodeNumber > 0 ? parsedEpisodeNumber : listIndex,
+      originalRoadIndex: roadIndex,
+    );
+  }
+
+  const factory ResolvedEpisode.offline({
+    required int listIndex,
+    required int roadIndex,
+    required String displayTitle,
+    required String episodePageUrl,
+    required int episodeNumber,
+    required int originalRoadIndex,
+  }) = _OfflineResolvedEpisode;
+}
+
+class _OfflineResolvedEpisode extends ResolvedEpisode {
+  const _OfflineResolvedEpisode({
+    required super.listIndex,
+    required super.roadIndex,
+    required super.displayTitle,
+    required super.episodePageUrl,
+    required int episodeNumber,
+    required super.originalRoadIndex,
+  }) : super(
+          historyEpisodeNumber: episodeNumber,
+          danmakuEpisodeNumber: episodeNumber,
+        );
 }

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -118,24 +118,6 @@ abstract class _VideoPageController with Store {
   VideoEpisodeSelection get playbackEpisode =>
       playingEpisode ?? selectedEpisode;
 
-  int get currentEpisode => selectedEpisode.episode;
-
-  set currentEpisode(int episode) {
-    selectedEpisode = VideoEpisodeSelection(
-      episode: episode,
-      road: selectedEpisode.road,
-    );
-  }
-
-  int get currentRoad => selectedEpisode.road;
-
-  set currentRoad(int road) {
-    selectedEpisode = VideoEpisodeSelection(
-      episode: selectedEpisode.episode,
-      road: road,
-    );
-  }
-
   @observable
   bool isFullscreen = false;
 
@@ -391,13 +373,6 @@ abstract class _VideoPageController with Store {
           _offlineDisplayRoadToOriginalRoad[targetRoad] ??
           targetRoad,
     );
-  }
-
-  int actualEpisodeNumberForSelection(VideoEpisodeSelection selection) {
-    final resolvedEpisode = isOfflineMode
-        ? _resolveOfflineEpisode(selection.episode, road: selection.road)
-        : _resolveOnlineEpisode(selection.episode, road: selection.road);
-    return resolvedEpisode?.historyEpisodeNumber ?? selection.episode;
   }
 
   int commentEpisodeForSelection(VideoEpisodeSelection selection) {

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -157,7 +157,10 @@ class _VideoPageState extends State<VideoPage>
 
   void _initOfflineMode(PlayerController playerController) {
     _showTabBodyImmediately(locateEpisode: false);
-    videoPageController.historyOffset = 0;
+    final identity = videoPageController.currentHistoryIdentity;
+    videoPageController.historyOffset = identity == null
+        ? 0
+        : videoPageController.getHistoryOffsetFor(identity);
     visibleRoad = videoPageController.selectedEpisode.road;
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -930,7 +933,10 @@ class _VideoPageState extends State<VideoPage>
                     }
                   },
                   child: Text(
-                    '播放线路${visibleRoad + 1} ',
+                    visibleRoad >= 0 &&
+                            visibleRoad < videoPageController.roadList.length
+                        ? '${videoPageController.roadList[visibleRoad].name} '
+                        : '播放线路${visibleRoad + 1} ',
                     style: const TextStyle(fontSize: 13),
                   ),
                 ),
@@ -950,7 +956,7 @@ class _VideoPageState extends State<VideoPage>
                   child: Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      '播放线路${i + 1}',
+                      videoPageController.roadList[i].name,
                       style: TextStyle(
                         color: i == visibleRoad
                             ? Theme.of(context).colorScheme.primary
@@ -1033,6 +1039,9 @@ class _VideoPageState extends State<VideoPage>
           int count = 1;
           for (var urlItem in road.data) {
             int count0 = count;
+            final episodeName = count0 - 1 < road.identifier.length
+                ? road.identifier[count0 - 1]
+                : '第$count0集';
             cardList.add(Container(
               margin: const EdgeInsets.only(bottom: 4),
               child: Material(
@@ -1074,7 +1083,7 @@ class _VideoPageState extends State<VideoPage>
                             ],
                             Expanded(
                                 child: Text(
-                              road.identifier[count0 - 1],
+                              episodeName,
                               maxLines: 2,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(

--- a/lib/repositories/history_repository.dart
+++ b/lib/repositories/history_repository.dart
@@ -1,8 +1,21 @@
+import 'package:hive_ce/hive.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/services/sync/history_sync_service.dart';
 import 'package:kazumi/services/logging/logger.dart';
+
+typedef HistoryProgressSyncAppender = Future<void> Function({
+  required History history,
+  required int episode,
+  required int road,
+  required int progressMs,
+  required int updatedAt,
+});
+
+typedef HistoryDeleteSyncAppender = Future<void> Function(History history);
+
+typedef HistoryClearSyncAppender = Future<void> Function();
 
 /// 历史记录数据访问接口
 ///
@@ -16,25 +29,19 @@ abstract class IHistoryRepository {
   /// [adapterName] 适配器名称
   /// [bangumiItem] 番剧信息
   /// 返回历史记录，不存在返回null
-  History? getHistory(String adapterName, BangumiItem bangumiItem);
+  History? getHistory(
+    String adapterName,
+    BangumiItem bangumiItem, {
+    String entryKind = HistoryEntryKind.online,
+  });
 
   /// 更新或创建历史记录
   ///
-  /// [episode] 集数
-  /// [road] 线路
-  /// [adapterName] 适配器名称
-  /// [bangumiItem] 番剧信息
+  /// [identity] 播放历史身份
   /// [progress] 观看进度
-  /// [lastSrc] 最后观看源
-  /// [lastWatchEpisodeName] 最后观看集名称
   Future<void> updateHistory({
-    required int episode,
-    required int road,
-    required String adapterName,
-    required BangumiItem bangumiItem,
+    required PlaybackHistoryIdentity identity,
     required Duration progress,
-    required String lastSrc,
-    required String lastWatchEpisodeName,
   });
 
   /// 获取上次观看的进度
@@ -43,7 +50,10 @@ abstract class IHistoryRepository {
   /// [adapterName] 适配器名称
   /// 返回观看进度，不存在返回null
   Progress? getLastWatchingProgress(
-      BangumiItem bangumiItem, String adapterName);
+    BangumiItem bangumiItem,
+    String adapterName, {
+    String entryKind = HistoryEntryKind.online,
+  });
 
   /// 查找特定集数的观看进度
   ///
@@ -52,7 +62,11 @@ abstract class IHistoryRepository {
   /// [episode] 集数
   /// 返回观看进度，不存在返回null
   Progress? findProgress(
-      BangumiItem bangumiItem, String adapterName, int episode);
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  });
 
   /// 删除历史记录
   ///
@@ -65,7 +79,11 @@ abstract class IHistoryRepository {
   /// [adapterName] 适配器名称
   /// [episode] 集数
   Future<void> clearProgress(
-      BangumiItem bangumiItem, String adapterName, int episode);
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  });
 
   /// 清空所有历史记录
   Future<void> clearAllHistories();
@@ -78,12 +96,71 @@ abstract class IHistoryRepository {
 ///
 /// 基于Hive实现的历史记录数据访问层
 class HistoryRepository implements IHistoryRepository {
-  final _historiesBox = GStorage.histories;
+  HistoryRepository({
+    Box<History>? historiesBox,
+    bool Function()? privateModeReader,
+    HistoryProgressSyncAppender? progressSyncAppender,
+    HistoryDeleteSyncAppender? deleteSyncAppender,
+    HistoryClearSyncAppender? clearSyncAppender,
+  })  : _historiesBox = historiesBox ?? GStorage.histories,
+        _privateModeReader = privateModeReader ??
+            (() => GStorage.getSetting(SettingsKeys.privateMode)),
+        _progressSyncAppender = progressSyncAppender ?? _appendProgressSync,
+        _deleteSyncAppender = deleteSyncAppender ?? _appendDeleteSync,
+        _clearSyncAppender = clearSyncAppender ?? _appendClearSync;
+
+  final Box<History> _historiesBox;
+  final bool Function() _privateModeReader;
+  final HistoryProgressSyncAppender _progressSyncAppender;
+  final HistoryDeleteSyncAppender _deleteSyncAppender;
+  final HistoryClearSyncAppender _clearSyncAppender;
+
+  static Future<void> _appendProgressSync({
+    required History history,
+    required int episode,
+    required int road,
+    required int progressMs,
+    required int updatedAt,
+  }) async {
+    final historySyncService = HistorySyncService();
+    await historySyncService.appendSafely(
+      () => historySyncService.appendUpsertProgress(
+        history: history,
+        episode: episode,
+        road: road,
+        progressMs: progressMs,
+        updatedAt: updatedAt,
+      ),
+    );
+  }
+
+  static Future<void> _appendDeleteSync(History history) async {
+    final historySyncService = HistorySyncService();
+    await historySyncService.appendSafely(
+      () => historySyncService.appendDeleteHistory(history),
+    );
+  }
+
+  static Future<void> _appendClearSync() async {
+    final historySyncService = HistorySyncService();
+    await historySyncService.appendSafely(
+      () => historySyncService.appendClearAll(),
+    );
+  }
 
   @override
   List<History> getAllHistories() {
     try {
-      var histories = _historiesBox.values.toList();
+      final byKey = <String, History>{};
+      for (final history in _historiesBox.values) {
+        history.entryKind = HistoryEntryKind.normalize(history.entryKind);
+        final existing = byKey[history.key];
+        if (existing == null ||
+            existing.lastWatchTime.isBefore(history.lastWatchTime)) {
+          byKey[history.key] = history;
+        }
+      }
+      var histories = byKey.values.toList();
       histories.sort(
         (a, b) =>
             b.lastWatchTime.millisecondsSinceEpoch -
@@ -101,9 +178,13 @@ class HistoryRepository implements IHistoryRepository {
   }
 
   @override
-  History? getHistory(String adapterName, BangumiItem bangumiItem) {
+  History? getHistory(
+    String adapterName,
+    BangumiItem bangumiItem, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
     try {
-      return _historiesBox.get(History.getKey(adapterName, bangumiItem));
+      return _findHistory(adapterName, bangumiItem, entryKind);
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: get history failed. bangumi=${bangumiItem.name}',
@@ -116,58 +197,90 @@ class HistoryRepository implements IHistoryRepository {
 
   @override
   Future<void> updateHistory({
-    required int episode,
-    required int road,
-    required String adapterName,
-    required BangumiItem bangumiItem,
+    required PlaybackHistoryIdentity identity,
     required Duration progress,
-    required String lastSrc,
-    required String lastWatchEpisodeName,
   }) async {
     try {
+      if (!identity.canRecord) {
+        return;
+      }
       // 检查隐私模式
       if (getPrivateMode()) {
         return;
       }
 
+      final episode = identity.episodeNumber;
+      final adapterName = identity.pluginName;
+      final bangumiItem = identity.bangumiItem;
+
+      final now = DateTime.now();
+      final nowMs = now.millisecondsSinceEpoch;
+      final legacyKey = History.legacyKey(adapterName, bangumiItem);
+      final shouldMigrateLegacy =
+          HistoryEntryKind.normalize(identity.entryKind) ==
+              HistoryEntryKind.online;
+
       // 获取或创建历史记录
-      var history =
-          _historiesBox.get(History.getKey(adapterName, bangumiItem)) ??
-              History(bangumiItem, episode, adapterName, DateTime.now(),
-                  lastSrc, lastWatchEpisodeName);
+      var history = _findHistory(
+            adapterName,
+            bangumiItem,
+            identity.entryKind,
+          ) ??
+          History(
+            bangumiItem,
+            episode,
+            adapterName,
+            now,
+            identity.onlineBangumiSrc,
+            identity.episodeTitle,
+            entryKind: identity.entryKind,
+            episodePageUrl: identity.episodePageUrl,
+          );
 
       // 更新历史记录
       history.lastWatchEpisode = episode;
-      history.lastWatchTime = DateTime.now();
-      if (lastSrc.isNotEmpty) {
-        history.lastSrc = lastSrc;
+      history.lastWatchTime = now;
+      history.entryKind = HistoryEntryKind.normalize(identity.entryKind);
+      if (identity.onlineBangumiSrc.isNotEmpty) {
+        history.lastSrc = identity.onlineBangumiSrc;
       }
-      if (lastWatchEpisodeName.isNotEmpty) {
-        history.lastWatchEpisodeName = lastWatchEpisodeName;
+      if (identity.episodeTitle.isNotEmpty) {
+        history.lastWatchEpisodeName = identity.episodeTitle;
+      }
+      if (identity.episodePageUrl.isNotEmpty) {
+        history.episodePageUrl = identity.episodePageUrl;
       }
 
       // 更新观看进度
       var prog = history.progresses[episode];
       if (prog == null) {
-        history.progresses[episode] =
-            Progress(episode, road, progress.inMilliseconds);
+        history.progresses[episode] = Progress(
+          episode,
+          identity.road,
+          progress.inMilliseconds,
+          updatedAtMs: nowMs,
+        );
       } else {
+        prog.road = identity.road;
         prog.progress = progress;
+        prog.updatedAtMs = nowMs;
       }
 
       // 保存到存储
       await _historiesBox.put(history.key, history);
-      await HistorySyncService().appendSafely(
-        () => HistorySyncService().appendUpsertProgress(
-          history: history,
-          episode: episode,
-          road: road,
-          progressMs: progress.inMilliseconds,
-        ),
+      if (shouldMigrateLegacy && legacyKey != history.key) {
+        await _historiesBox.delete(legacyKey);
+      }
+      await _progressSyncAppender(
+        history: history,
+        episode: episode,
+        road: identity.road,
+        progressMs: progress.inMilliseconds,
+        updatedAt: nowMs,
       );
     } catch (e, stackTrace) {
       KazumiLogger().e(
-        'GStorage: update history failed. bangumi=${bangumiItem.name}, episode=$episode',
+        'GStorage: update history failed. bangumi=${identity.bangumiItem.name}, episode=${identity.episodeNumber}',
         error: e,
         stackTrace: stackTrace,
       );
@@ -176,9 +289,12 @@ class HistoryRepository implements IHistoryRepository {
 
   @override
   Progress? getLastWatchingProgress(
-      BangumiItem bangumiItem, String adapterName) {
+    BangumiItem bangumiItem,
+    String adapterName, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
     try {
-      var history = _historiesBox.get(History.getKey(adapterName, bangumiItem));
+      var history = _findHistory(adapterName, bangumiItem, entryKind);
       return history?.progresses[history.lastWatchEpisode];
     } catch (e, stackTrace) {
       KazumiLogger().e(
@@ -192,9 +308,13 @@ class HistoryRepository implements IHistoryRepository {
 
   @override
   Progress? findProgress(
-      BangumiItem bangumiItem, String adapterName, int episode) {
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
     try {
-      var history = _historiesBox.get(History.getKey(adapterName, bangumiItem));
+      var history = _findHistory(adapterName, bangumiItem, entryKind);
       return history?.progresses[episode];
     } catch (e, stackTrace) {
       KazumiLogger().e(
@@ -210,9 +330,13 @@ class HistoryRepository implements IHistoryRepository {
   Future<void> deleteHistory(History history) async {
     try {
       await _historiesBox.delete(history.key);
-      await HistorySyncService().appendSafely(
-        () => HistorySyncService().appendDeleteHistory(history),
-      );
+      if (HistoryEntryKind.normalize(history.entryKind) ==
+          HistoryEntryKind.online) {
+        await _historiesBox.delete(
+          History.legacyKey(history.adapterName, history.bangumiItem),
+        );
+      }
+      await _deleteSyncAppender(history);
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: delete history failed. bangumi=${history.bangumiItem.name}',
@@ -224,20 +348,24 @@ class HistoryRepository implements IHistoryRepository {
 
   @override
   Future<void> clearProgress(
-      BangumiItem bangumiItem, String adapterName, int episode) async {
+    BangumiItem bangumiItem,
+    String adapterName,
+    int episode, {
+    String entryKind = HistoryEntryKind.online,
+  }) async {
     try {
-      var history = _historiesBox.get(History.getKey(adapterName, bangumiItem));
+      var history = _findHistory(adapterName, bangumiItem, entryKind);
       if (history != null && history.progresses[episode] != null) {
+        final nowMs = DateTime.now().millisecondsSinceEpoch;
         history.progresses[episode]!.progress = Duration.zero;
+        history.progresses[episode]!.updatedAtMs = nowMs;
         await _historiesBox.put(history.key, history);
-        await HistorySyncService().appendSafely(
-          () => HistorySyncService().appendUpsertProgress(
-            history: history,
-            episode: episode,
-            road: history.progresses[episode]!.road,
-            progressMs: 0,
-            updatedAt: DateTime.now().millisecondsSinceEpoch,
-          ),
+        await _progressSyncAppender(
+          history: history,
+          episode: episode,
+          road: history.progresses[episode]!.road,
+          progressMs: 0,
+          updatedAt: nowMs,
         );
       }
     } catch (e, stackTrace) {
@@ -253,9 +381,7 @@ class HistoryRepository implements IHistoryRepository {
   Future<void> clearAllHistories() async {
     try {
       await _historiesBox.clear();
-      await HistorySyncService().appendSafely(
-        () => HistorySyncService().appendClearAll(),
-      );
+      await _clearSyncAppender();
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: clear all histories failed',
@@ -268,8 +394,7 @@ class HistoryRepository implements IHistoryRepository {
   @override
   bool getPrivateMode() {
     try {
-      final value = GStorage.getSetting(SettingsKeys.privateMode);
-      return value;
+      return _privateModeReader();
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: get private mode setting failed, using default false',
@@ -278,5 +403,23 @@ class HistoryRepository implements IHistoryRepository {
       );
       return false;
     }
+  }
+
+  History? _findHistory(
+    String adapterName,
+    BangumiItem bangumiItem,
+    String entryKind,
+  ) {
+    final normalizedEntryKind = HistoryEntryKind.normalize(entryKind);
+    return _historiesBox.get(
+          History.getKey(
+            adapterName,
+            bangumiItem,
+            entryKind: normalizedEntryKind,
+          ),
+        ) ??
+        (normalizedEntryKind == HistoryEntryKind.online
+            ? _historiesBox.get(History.legacyKey(adapterName, bangumiItem))
+            : null);
   }
 }

--- a/lib/services/storage/storage.dart
+++ b/lib/services/storage/storage.dart
@@ -12,7 +12,6 @@ import 'package:kazumi/modules/collect/collect_sync_merger.dart';
 import 'package:kazumi/modules/search/search_history_module.dart';
 import 'package:kazumi/modules/download/download_module.dart';
 
-
 import 'package:kazumi/services/storage/settings_keys.dart';
 export 'package:kazumi/services/storage/settings_keys.dart';
 
@@ -227,16 +226,19 @@ class GStorage {
     final tempBoxItems = tempBox.toMap().entries;
 
     for (var tempBoxItem in tempBoxItems) {
-      if (histories.get(tempBoxItem.key) != null) {
+      final tempHistory = tempBoxItem.value as History;
+      tempHistory.entryKind = HistoryEntryKind.normalize(tempHistory.entryKind);
+      final targetKey = tempHistory.key;
+      if (histories.get(targetKey) != null) {
         if (histories
-            .get(tempBoxItem.key)!
+            .get(targetKey)!
             .lastWatchTime
-            .isBefore(tempBoxItem.value.lastWatchTime)) {
-          await histories.delete(tempBoxItem.key);
-          await histories.put(tempBoxItem.key, tempBoxItem.value);
+            .isBefore(tempHistory.lastWatchTime)) {
+          await histories.delete(targetKey);
+          await histories.put(targetKey, tempHistory);
         }
       } else {
-        await histories.put(tempBoxItem.key, tempBoxItem.value);
+        await histories.put(targetKey, tempHistory);
       }
     }
     await tempBox.close();

--- a/lib/services/sync/history_sync_service.dart
+++ b/lib/services/sync/history_sync_service.dart
@@ -130,6 +130,57 @@ class HistorySyncService {
         GStorage.histories.values.toList());
   }
 
+  static List<HistorySyncEvent> buildStateEventsFromHistories(
+    Iterable<History> histories,
+  ) {
+    final events = <HistorySyncEvent>[];
+    for (final history in histories) {
+      history.entryKind = HistoryEntryKind.normalize(history.entryKind);
+      for (final progress in history.progresses.values) {
+        final updatedAt = progress.effectiveUpdatedAtMs(history.lastWatchTime);
+        events.add(
+          HistorySyncEvent(
+            eventId:
+                'local-state:${history.key}:${progress.episode}:${progress.road}',
+            deviceId: 'local-state',
+            seq: 0,
+            op: HistorySyncOp.upsertProgress,
+            updatedAt: updatedAt,
+            entityKey: history.key,
+            bangumiItem: history.bangumiItem,
+            adapterName: history.adapterName,
+            episode: progress.episode,
+            road: progress.road,
+            progressMs: progress.progress.inMilliseconds,
+            lastSrc: history.lastSrc,
+            lastWatchEpisodeName: history.lastWatchEpisodeName,
+            entryKind: history.entryKind,
+            episodePageUrl: history.episodePageUrl,
+          ),
+        );
+      }
+      events.add(
+        HistorySyncEvent(
+          eventId: 'local-state:${history.key}:watch-state',
+          deviceId: 'local-state',
+          seq: 0,
+          op: HistorySyncOp.upsertWatchState,
+          updatedAt: history.lastWatchTime.millisecondsSinceEpoch,
+          entityKey: history.key,
+          bangumiItem: history.bangumiItem,
+          adapterName: history.adapterName,
+          episode: history.lastWatchEpisode,
+          lastSrc: history.lastSrc,
+          lastWatchEpisodeName: history.lastWatchEpisodeName,
+          entryKind: history.entryKind,
+          episodePageUrl: history.episodePageUrl,
+          carriesWatchState: true,
+        ),
+      );
+    }
+    return events;
+  }
+
   Future<void> applySnapshotToLocal(HistorySyncSnapshot snapshot) async {
     await GStorage.histories.clear();
     for (final history in snapshot.histories) {

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -313,44 +313,9 @@ class WebDav {
   }
 
   Future<List<HistorySyncEvent>> _eventsFromLocalHistories() async {
-    final events = <HistorySyncEvent>[];
-    for (final history in GStorage.histories.values) {
-      for (final progress in history.progresses.values) {
-        events.add(
-          HistorySyncEvent(
-            eventId:
-                'local-state:${history.key}:${progress.episode}:${progress.road}',
-            deviceId: 'local-state',
-            seq: 0,
-            op: HistorySyncOp.upsertProgress,
-            updatedAt: history.lastWatchTime.millisecondsSinceEpoch,
-            entityKey: history.key,
-            bangumiItem: history.bangumiItem,
-            adapterName: history.adapterName,
-            episode: progress.episode,
-            road: progress.road,
-            progressMs: progress.progress.inMilliseconds,
-          ),
-        );
-      }
-      events.add(
-        HistorySyncEvent(
-          eventId: 'local-state:${history.key}:watch-state',
-          deviceId: 'local-state',
-          seq: 0,
-          op: HistorySyncOp.upsertWatchState,
-          updatedAt: history.lastWatchTime.millisecondsSinceEpoch,
-          entityKey: history.key,
-          bangumiItem: history.bangumiItem,
-          adapterName: history.adapterName,
-          episode: history.lastWatchEpisode,
-          lastSrc: history.lastSrc,
-          lastWatchEpisodeName: history.lastWatchEpisodeName,
-          carriesWatchState: true,
-        ),
-      );
-    }
-    return events;
+    return HistorySyncService.buildStateEventsFromHistories(
+      GStorage.histories.values,
+    );
   }
 
   Future<bool> _tryImportLegacyHistory() async {

--- a/test/history_repository_test.dart
+++ b/test/history_repository_test.dart
@@ -1,0 +1,232 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/bangumi_tag.dart';
+import 'package:kazumi/modules/history/history_module.dart';
+import 'package:kazumi/repositories/history_repository.dart';
+
+void main() {
+  late Directory tempDir;
+  late Box<History> historiesBox;
+  late bool privateMode;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('kazumi_history_test_');
+    Hive.init(tempDir.path);
+    _registerAdapters();
+    historiesBox = await Hive.openBox<History>('histories');
+  });
+
+  setUp(() async {
+    privateMode = false;
+    await historiesBox.clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('HistoryRepository source metadata', () {
+    test('keeps online source isolated from offline history', () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(1);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.offline(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1 local',
+          road: 0,
+          episodePageUrl: '/offline/1',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      final online = repository.getHistory(
+        'plugin',
+        item,
+        entryKind: HistoryEntryKind.online,
+      );
+      final offline = repository.getHistory(
+        'plugin',
+        item,
+        entryKind: HistoryEntryKind.offline,
+      );
+
+      expect(online, isNotNull);
+      expect(offline, isNotNull);
+      expect(online!.lastSrc, 'https://example.com/source');
+      expect(online.episodePageUrl, '/online/1');
+      expect(online.progresses[1]!.progress.inSeconds, 10);
+      expect(offline!.lastSrc, isEmpty);
+      expect(offline.episodePageUrl, '/offline/1');
+      expect(offline.progresses[1]!.progress.inSeconds, 20);
+      expect(online.key, History.getKey('plugin', item));
+      expect(
+        offline.key,
+        History.getKey(
+          'plugin',
+          item,
+          entryKind: HistoryEntryKind.offline,
+        ),
+      );
+    });
+
+    test('does not overwrite existing online source with an empty value',
+        () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(2);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 1,
+          onlineBangumiSrc: '',
+          episodePageUrl: '/online/2',
+        ),
+        progress: const Duration(seconds: 30),
+      );
+
+      final history = repository.getHistory(
+        'plugin',
+        item,
+        entryKind: HistoryEntryKind.online,
+      );
+
+      expect(history, isNotNull);
+      expect(history!.lastSrc, 'https://example.com/source');
+      expect(history.lastWatchEpisode, 2);
+      expect(history.lastWatchEpisodeName, 'EP2');
+      expect(history.episodePageUrl, '/online/2');
+      expect(history.progresses[2]!.progress.inSeconds, 30);
+    });
+
+    test('does not record history when private mode is enabled', () async {
+      privateMode = true;
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(3);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+
+      expect(historiesBox.values, isEmpty);
+      expect(repository.getHistory('plugin', item), isNull);
+    });
+  });
+}
+
+Future<void> _noopHistorySync({
+  required History history,
+  required int episode,
+  required int road,
+  required int progressMs,
+  required int updatedAt,
+}) async {}
+
+Future<void> _noopDeleteSync(History history) async {}
+
+Future<void> _noopClearSync() async {}
+
+void _registerAdapters() {
+  if (!Hive.isAdapterRegistered(1)) {
+    Hive.registerAdapter(HistoryAdapter());
+  }
+  if (!Hive.isAdapterRegistered(2)) {
+    Hive.registerAdapter(ProgressAdapter());
+  }
+  if (!Hive.isAdapterRegistered(3)) {
+    Hive.registerAdapter(BangumiItemAdapter());
+  }
+  if (!Hive.isAdapterRegistered(6)) {
+    Hive.registerAdapter(BangumiTagAdapter());
+  }
+}
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'subject $id',
+    nameCn: '条目 $id',
+    summary: '',
+    airDate: '2026-01-01',
+    airWeekday: 4,
+    rank: 0,
+    images: const {
+      'large': '',
+      'common': '',
+      'medium': '',
+      'small': '',
+      'grid': '',
+    },
+    tags: const <BangumiTag>[],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}

--- a/test/history_sync_test.dart
+++ b/test/history_sync_test.dart
@@ -3,6 +3,7 @@ import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/bangumi/bangumi_tag.dart';
 import 'package:kazumi/modules/history/history_module.dart';
 import 'package:kazumi/modules/history/history_sync.dart';
+import 'package:kazumi/services/sync/history_sync_service.dart';
 
 void main() {
   group('HistorySyncDevice', () {
@@ -127,6 +128,199 @@ void main() {
       expect(merged.deletedVersions, isEmpty);
     });
 
+    test('legacy delete tombstone blocks older online upserts from snapshot',
+        () {
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final deleteVersion = HistorySyncVersion.of(
+        updatedAt: 2000,
+        eventId: 'legacy-delete',
+      );
+      final snapshot = HistorySyncSnapshot.fromJson({
+        'generatedAt': 2000,
+        'histories': [],
+        'itemVersions': {},
+        'progressVersions': {},
+        'deletedVersions': {legacyKey: deleteVersion},
+      });
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: snapshot,
+        events: [
+          _legacyUpsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1500,
+            episode: 1,
+            progressMs: 10,
+          ),
+        ],
+      );
+
+      expect(merged.histories, isEmpty);
+      expect(merged.deletedVersions, containsPair(legacyKey, deleteVersion));
+    });
+
+    test('newer online upsert clears legacy delete tombstone', () {
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final scopedKey = History.getKey('plugin', _item(1));
+      final deleteVersion = HistorySyncVersion.of(
+        updatedAt: 2000,
+        eventId: 'legacy-delete',
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot(
+          generatedAt: 2000,
+          histories: const [],
+          itemVersions: const {},
+          progressVersions: const {},
+          deletedVersions: {legacyKey: deleteVersion},
+        ),
+        events: [
+          _legacyUpsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 2500,
+            episode: 2,
+            progressMs: 20,
+          ),
+        ],
+      );
+
+      expect(merged.histories, hasLength(1));
+      expect(merged.histories.single.key, scopedKey);
+      expect(merged.histories.single.lastWatchEpisode, 2);
+      expect(merged.deletedVersions, isEmpty);
+    });
+
+    test('legacy delete tombstone does not block offline upserts', () {
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final deleteVersion = HistorySyncVersion.of(
+        updatedAt: 2000,
+        eventId: 'legacy-delete',
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot(
+          generatedAt: 2000,
+          histories: const [],
+          itemVersions: const {},
+          progressVersions: const {},
+          deletedVersions: {legacyKey: deleteVersion},
+        ),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1500,
+            episode: 1,
+            progressMs: 10,
+            entryKind: HistoryEntryKind.offline,
+            episodePageUrl: '/offline/1',
+          ),
+        ],
+      );
+
+      expect(merged.histories, hasLength(1));
+      expect(merged.histories.single.entryKind, HistoryEntryKind.offline);
+      expect(merged.deletedVersions, containsPair(legacyKey, deleteVersion));
+    });
+
+    test('legacy tombstone is not canonicalized onto offline snapshot history',
+        () {
+      final offlineHistory = History(
+        _item(1),
+        1,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        '',
+        'EP1',
+        entryKind: HistoryEntryKind.offline,
+        episodePageUrl: '/offline/1',
+      );
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final offlineKey = History.getKey(
+        'plugin',
+        _item(1),
+        entryKind: HistoryEntryKind.offline,
+      );
+      final deleteVersion = HistorySyncVersion.of(
+        updatedAt: 2000,
+        eventId: 'legacy-delete',
+      );
+      final snapshot = HistorySyncSnapshot.fromJson({
+        'generatedAt': 2000,
+        'histories': [HistorySyncCodec.historyToJson(offlineHistory)],
+        'itemVersions': {},
+        'progressVersions': {},
+        'deletedVersions': {legacyKey: deleteVersion},
+      });
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: snapshot,
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1500,
+            episode: 1,
+            progressMs: 10,
+            entryKind: HistoryEntryKind.offline,
+            episodePageUrl: '/offline/1',
+          ),
+        ],
+      );
+
+      expect(merged.histories, hasLength(1));
+      expect(merged.histories.single.key, offlineKey);
+      expect(
+          merged.histories.single.progresses[1]!.progress.inMilliseconds, 10);
+      expect(merged.deletedVersions, containsPair(legacyKey, deleteVersion));
+      expect(merged.deletedVersions.containsKey(offlineKey), isFalse);
+    });
+
+    test('legacy delete event does not delete an existing offline history', () {
+      final offlineHistory = History(
+        _item(1),
+        1,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        '',
+        'EP1',
+        entryKind: HistoryEntryKind.offline,
+        episodePageUrl: '/offline/1',
+      );
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final offlineKey = History.getKey(
+        'plugin',
+        _item(1),
+        entryKind: HistoryEntryKind.offline,
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot(
+          generatedAt: 1000,
+          histories: [offlineHistory],
+          itemVersions: const {},
+          progressVersions: const {},
+          deletedVersions: const {},
+        ),
+        events: [
+          HistorySyncEvent.deleteHistory(
+            deviceId: 'device-a',
+            seq: 1,
+            entityKey: legacyKey,
+            updatedAt: 2000,
+          ),
+        ],
+      );
+
+      expect(merged.histories, hasLength(1));
+      expect(merged.histories.single.key, offlineKey);
+      expect(merged.deletedVersions, contains(legacyKey));
+      expect(merged.deletedVersions.containsKey(offlineKey), isFalse);
+    });
+
     test('uses deterministic tie-breakers when timestamps are equal', () {
       final merged = HistorySyncMerger.merge(
         snapshot: HistorySyncSnapshot.empty(),
@@ -150,6 +344,121 @@ void main() {
 
       expect(
           merged.histories.single.progresses[1]!.progress.inMilliseconds, 20);
+    });
+
+    test('preserves playback entry metadata when merging progress', () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 1,
+            progressMs: 10 * 1000,
+            entryKind: HistoryEntryKind.offline,
+            episodePageUrl: '/episode/1',
+          ),
+        ],
+      );
+
+      final history = merged.histories.single;
+      expect(history.entryKind, HistoryEntryKind.offline);
+      expect(history.episodePageUrl, '/episode/1');
+    });
+
+    test('keeps online and offline progress separate for the same episode', () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 1,
+            progressMs: 10 * 1000,
+            entryKind: HistoryEntryKind.online,
+            episodePageUrl: '/online/1',
+          ),
+          _upsert(
+            deviceId: 'device-b',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 1,
+            progressMs: 20 * 1000,
+            entryKind: HistoryEntryKind.offline,
+            episodePageUrl: '/offline/1',
+          ),
+        ],
+      );
+
+      expect(merged.histories, hasLength(2));
+      final online = merged.histories.singleWhere(
+        (history) => history.entryKind == HistoryEntryKind.online,
+      );
+      final offline = merged.histories.singleWhere(
+        (history) => history.entryKind == HistoryEntryKind.offline,
+      );
+      expect(online.key, History.getKey('plugin', _item(1)));
+      expect(
+        offline.key,
+        History.getKey(
+          'plugin',
+          _item(1),
+          entryKind: HistoryEntryKind.offline,
+        ),
+      );
+      expect(online.progresses[1]!.progress.inSeconds, 10);
+      expect(offline.progresses[1]!.progress.inSeconds, 20);
+    });
+
+    test('canonicalizes legacy snapshot keys to online scoped keys', () {
+      final history = History(
+        _item(1),
+        1,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        'https://example.com/video',
+        'EP1',
+      );
+      history.progresses[1] = Progress(
+        1,
+        0,
+        10 * 1000,
+        updatedAtMs: 1500,
+      );
+      final legacyKey = History.legacyKey('plugin', _item(1));
+      final scopedKey = History.getKey('plugin', _item(1));
+      final legacyVersion = HistorySyncVersion.of(
+        updatedAt: 1000,
+        eventId: 'legacy',
+      );
+      final progressVersion = HistorySyncVersion.of(
+        updatedAt: 1500,
+        eventId: 'legacy-progress',
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot(
+          generatedAt: 2000,
+          histories: [history],
+          itemVersions: {legacyKey: legacyVersion},
+          progressVersions: {
+            legacyKey: {1: progressVersion},
+          },
+          deletedVersions: const {},
+        ),
+        events: const [],
+      );
+
+      expect(merged.histories.single.key, scopedKey);
+      expect(merged.itemVersions, containsPair(scopedKey, legacyVersion));
+      expect(
+        merged.progressVersions[scopedKey],
+        containsPair(1, progressVersion),
+      );
+      expect(merged.itemVersions.containsKey(legacyKey), isFalse);
+      expect(merged.progressVersions.containsKey(legacyKey), isFalse);
     });
 
     test('keeps watch state when local-state progress events share a timestamp',
@@ -308,6 +617,46 @@ void main() {
       expect(restored.first.bangumiItem!.id, 1);
     });
   });
+
+  group('HistorySyncService', () {
+    test('builds local state events with entry metadata and progress time', () {
+      final history = History(
+        _item(1),
+        1,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        '',
+        'EP1',
+        entryKind: HistoryEntryKind.offline,
+        episodePageUrl: '/offline/1',
+      );
+      history.progresses[1] = Progress(
+        1,
+        2,
+        20 * 1000,
+        updatedAtMs: 2500,
+      );
+
+      final events =
+          HistorySyncService.buildStateEventsFromHistories([history]);
+
+      expect(events, hasLength(2));
+      final progressEvent = events.singleWhere(
+        (event) => event.op == HistorySyncOp.upsertProgress,
+      );
+      final watchStateEvent = events.singleWhere(
+        (event) => event.op == HistorySyncOp.upsertWatchState,
+      );
+      expect(progressEvent.entityKey, history.key);
+      expect(progressEvent.entryKind, HistoryEntryKind.offline);
+      expect(progressEvent.episodePageUrl, '/offline/1');
+      expect(progressEvent.updatedAt, 2500);
+      expect(progressEvent.progressMs, 20 * 1000);
+      expect(watchStateEvent.entryKind, HistoryEntryKind.offline);
+      expect(watchStateEvent.episodePageUrl, '/offline/1');
+      expect(watchStateEvent.carriesWatchState, isTrue);
+    });
+  });
 }
 
 HistorySyncEvent _localStateUpsert({
@@ -338,6 +687,8 @@ HistorySyncEvent _upsert({
   required int updatedAt,
   required int episode,
   required int progressMs,
+  String entryKind = HistoryEntryKind.online,
+  String episodePageUrl = '',
 }) {
   final history = History(
     _item(1),
@@ -346,8 +697,15 @@ HistorySyncEvent _upsert({
     DateTime.fromMillisecondsSinceEpoch(updatedAt),
     'https://example.com/video',
     'EP$episode',
+    entryKind: entryKind,
+    episodePageUrl: episodePageUrl,
   );
-  history.progresses[episode] = Progress(episode, 0, progressMs);
+  history.progresses[episode] = Progress(
+    episode,
+    0,
+    progressMs,
+    updatedAtMs: updatedAt,
+  );
   return HistorySyncEvent.upsertProgress(
     deviceId: deviceId,
     seq: seq,
@@ -366,28 +724,20 @@ HistorySyncEvent _legacyUpsert({
   required int episode,
   required int progressMs,
 }) {
-  final history = History(
-    _item(1),
-    episode,
-    'plugin',
-    DateTime.fromMillisecondsSinceEpoch(updatedAt),
-    'https://example.com/video',
-    'EP$episode',
-  );
   return HistorySyncEvent(
     eventId: '$deviceId:$seq',
     deviceId: deviceId,
     seq: seq,
     op: HistorySyncOp.upsertProgress,
     updatedAt: updatedAt,
-    entityKey: history.key,
-    bangumiItem: history.bangumiItem,
-    adapterName: history.adapterName,
+    entityKey: History.legacyKey('plugin', _item(1)),
+    bangumiItem: _item(1),
+    adapterName: 'plugin',
     episode: episode,
     road: 0,
     progressMs: progressMs,
-    lastSrc: history.lastSrc,
-    lastWatchEpisodeName: history.lastWatchEpisodeName,
+    lastSrc: 'https://example.com/video',
+    lastWatchEpisodeName: 'EP$episode',
   );
 }
 

--- a/test/resolved_episode_test.dart
+++ b/test/resolved_episode_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/download/download_module.dart';
+import 'package:kazumi/pages/player/controller/player_models.dart';
+import 'package:kazumi/pages/video/video_controller.dart';
+
+void main() {
+  group('ResolvedEpisode', () {
+    test('online keeps list index for history and parses title for danmaku',
+        () {
+      final episode = ResolvedEpisode.online(
+        listIndex: 1,
+        roadIndex: 0,
+        displayTitle: '第13话',
+        episodePageUrl: '/episode/13',
+      );
+
+      expect(episode.historyEpisodeNumber, 1);
+      expect(episode.danmakuEpisodeNumber, 13);
+      expect(episode.originalRoadIndex, 0);
+      expect(episode.episodePageUrl, '/episode/13');
+    });
+
+    test('online falls back to list index when title has no episode number',
+        () {
+      final episode = ResolvedEpisode.online(
+        listIndex: 2,
+        roadIndex: 1,
+        displayTitle: 'OVA',
+        episodePageUrl: '/ova',
+      );
+
+      expect(episode.historyEpisodeNumber, 2);
+      expect(episode.danmakuEpisodeNumber, 2);
+      expect(episode.originalRoadIndex, 1);
+    });
+
+    test('offline uses downloaded episode number for history and danmaku', () {
+      const episode = ResolvedEpisode.offline(
+        listIndex: 1,
+        roadIndex: 0,
+        displayTitle: '第13话',
+        episodePageUrl: '/episode/13',
+        episodeNumber: 13,
+        originalRoadIndex: 2,
+      );
+
+      expect(episode.historyEpisodeNumber, 13);
+      expect(episode.danmakuEpisodeNumber, 13);
+      expect(episode.originalRoadIndex, 2);
+      expect(episode.listIndex, 1);
+    });
+  });
+
+  test('PlaybackInitParams carries danmaku episode independently', () {
+    const params = PlaybackInitParams(
+      videoUrl: 'file:///tmp/video.mp4',
+      offset: 0,
+      isLocalPlayback: true,
+      bangumiId: 1,
+      pluginName: 'plugin',
+      danmakuEpisodeNumber: 13,
+      httpHeaders: {},
+      adBlockerEnabled: false,
+      episodeTitle: '第13话',
+      referer: '',
+      currentRoad: 0,
+    );
+
+    expect(params.danmakuEpisodeNumber, 13);
+  });
+
+  group('OfflineRoadListSnapshot', () {
+    test('groups downloaded episodes by original road', () {
+      final snapshot = buildOfflineRoadListSnapshot([
+        _episode(2, '第二话', 2),
+        _episode(1, '第一话', 0),
+        _episode(4, '第四话', 2),
+        _episode(3, '第三话', 0),
+      ]);
+
+      expect(snapshot.roads.length, 2);
+      expect(snapshot.roads[0].name, '播放列表1');
+      expect(snapshot.roads[0].data, ['1', '3']);
+      expect(snapshot.roads[0].identifier, ['第一话', '第三话']);
+      expect(snapshot.roads[1].name, '播放列表3');
+      expect(snapshot.roads[1].data, ['2', '4']);
+      expect(snapshot.displayRoadToOriginalRoad, {0: 0, 1: 2});
+      expect(snapshot.originalRoadToDisplayRoad, {0: 0, 2: 1});
+    });
+  });
+}
+
+DownloadEpisode _episode(int episodeNumber, String name, int road) {
+  return DownloadEpisode(
+    episodeNumber,
+    name,
+    road,
+    DownloadStatus.completed,
+    1.0,
+    0,
+    0,
+    '',
+    '',
+    '',
+    DateTime(2026),
+    '',
+    0,
+    '/episode/$episodeNumber',
+  );
+}

--- a/test/resolved_episode_test.dart
+++ b/test/resolved_episode_test.dart
@@ -58,6 +58,7 @@ void main() {
       isLocalPlayback: true,
       bangumiId: 1,
       pluginName: 'plugin',
+      episode: 1,
       danmakuEpisodeNumber: 13,
       httpHeaders: {},
       adBlockerEnabled: false,
@@ -66,6 +67,7 @@ void main() {
       currentRoad: 0,
     );
 
+    expect(params.episode, 1);
     expect(params.danmakuEpisodeNumber, 13);
   });
 


### PR DESCRIPTION
https://github.com/Predidit/Kazumi/pull/2261 的mini版本，仅针对 修复在线/离线播放历史记录 做的最小修复，同时考虑了后续统一数据模型的考量

后续约 3 ~ 4 个 PR

## 摘要

* 将播放历史身份拆分为在线记录和离线记录，并使用带作用域的历史 key。
* 将在线来源元数据与离线下载播放元数据分开保存。
* 在 WebDAV 历史同步中传递 `entryKind`、剧集页面 URL，以及每集的播放进度时间戳。
* 更新播放续播、历史卡片重新打开、离线路径映射、SyncPlay 弹幕剧集处理，以及回归测试。

## 根因

在线播放和已下载播放使用了相同的历史身份结构，因此本地存储和同步时，可能会将同一个 Bangumi 条目和插件下的记录合并或覆盖。

这也导致在在线历史和离线历史同时存在时，旧版 WebDAV 历史快照和删除标记变得含义不明确。

## 验证

* `git diff --cached --check`
* `git diff --check`
* `flutter test --no-pub test/history_repository_test.dart test/history_sync_test.dart test/resolved_episode_test.dart`

```bash
flutter test test/history_repository_test.dart test/history_sync_test.dart test/resolved_episode_test.dart
```

## 手动后续验证

* 验证在线历史和离线历史会显示为不同条目。
* 验证在线播放仍然可以从在线历史中继续播放。
* 验证离线播放可以重新打开已下载剧集，并从离线历史中继续播放。
* 验证设备之间通过 WebDAV 同步时，在线 / 离线历史可以保持分离。
