### PR TITLE
统一集数 URL 归一化

### DIFF
--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -22,6 +22,7 @@ import 'package:kazumi/request/apis/bangumi_api.dart';
 import 'package:dio/dio.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/utils/device.dart';
+import 'package:kazumi/utils/episode_url.dart';
 import 'package:kazumi/utils/http_headers.dart';
 import 'package:kazumi/utils/media.dart';
 import 'package:kazumi/services/platform/display_mode_service.dart';
@@ -436,11 +437,10 @@ abstract class _VideoPageController with Store {
 
     KazumiLogger()
         .i('VideoPageController: changed to ${resolvedEpisode.displayTitle}');
-    String urlItem = resolvedEpisode.episodePageUrl;
-    if (!urlItem.contains(currentPlugin.baseUrl) &&
-        !urlItem.contains(currentPlugin.baseUrl.replaceAll('https', 'http'))) {
-      urlItem = currentPlugin.baseUrl + urlItem;
-    }
+    final urlItem = normalizeEpisodeUrl(
+      currentPlugin.baseUrl,
+      resolvedEpisode.episodePageUrl,
+    );
 
     await _resolveWithVideoSourceService(
       urlItem,

--- a/lib/plugins/plugins.dart
+++ b/lib/plugins/plugins.dart
@@ -9,6 +9,7 @@ import 'package:kazumi/services/logging/logger.dart';
 import 'package:xpath_selector_html_parser/xpath_selector_html_parser.dart';
 import 'package:kazumi/plugins/anti_crawler_config.dart';
 import 'package:kazumi/services/plugin/plugin_cookie_manager.dart';
+import 'package:kazumi/utils/episode_url.dart';
 import 'package:kazumi/utils/http_headers.dart';
 
 /// Thrown by [Plugin.queryBangumi] when the response contains a CAPTCHA challenge
@@ -274,7 +275,7 @@ class Plugin {
           element.queryXPath(chapterResult).nodes.forEach((item) {
             String itemUrl = item.node.attributes['href'] ?? '';
             String itemName = item.node.text ?? '';
-            chapterUrlList.add(itemUrl);
+            chapterUrlList.add(normalizeEpisodeUrl(baseUrl, itemUrl));
             chapterNameList.add(itemName.replaceAll(RegExp(r'\s+'), ''));
           });
           if (chapterUrlList.isNotEmpty && chapterNameList.isNotEmpty) {

--- a/lib/utils/episode_url.dart
+++ b/lib/utils/episode_url.dart
@@ -1,0 +1,70 @@
+/// 集数源站 URL 归一化。
+///
+/// 把插件抓取到的原始 `href`（可能是相对路径、缺协议、带尾斜杠或多余噪声）
+/// 转换为一个稳定一致的绝对 URL，使"同一集"在播放、下载、历史回填等不同入口
+/// 始终得到同一个字符串，可作为身份匹配的主键（`pageUrl`）。
+///
+/// 归一化规则：
+/// - 去除首尾空白；空输入返回空串（调用方据此判断"无 URL"）。
+/// - 相对路径基于 [baseUrl] 补全为绝对 URL。
+/// - 统一协议口径到 `https`，避免 `http`/`https` 造成的失配
+///   （与既有抓取逻辑一致：源页抓取时本就强制 https）。
+/// - 去除 path 多余尾斜杠（根路径 `/` 保留）。
+/// - 去除空 query。
+/// - 幂等：`normalizeEpisodeUrl(b, normalizeEpisodeUrl(b, x))` 等于
+///   `normalizeEpisodeUrl(b, x)`。
+///
+/// 归一化结果同时作为"身份 key"与可访问的"请求 URL"使用。由于既有抓取逻辑
+/// 已强制将源页 URL 升级为 https，这里统一到 https 不会改变实际可访问性。
+String normalizeEpisodeUrl(String baseUrl, String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return '';
+
+  final rawUri = Uri.tryParse(trimmed);
+
+  Uri? resolved;
+  if (rawUri != null && rawUri.hasScheme && rawUri.host.isNotEmpty) {
+    // 已是绝对 URL。
+    resolved = rawUri;
+  } else {
+    final baseUri = Uri.tryParse(baseUrl.trim());
+    if (baseUri != null && baseUri.hasScheme && baseUri.host.isNotEmpty) {
+      try {
+        resolved = baseUri.resolve(trimmed);
+      } catch (_) {
+        resolved = null;
+      }
+    }
+  }
+
+  // 无法解析为绝对 URL（baseUrl 缺失/非法），原样返回去空白后的输入。
+  if (resolved == null || resolved.host.isEmpty) {
+    return trimmed;
+  }
+
+  // 统一协议到 https。
+  if (resolved.scheme == 'http') {
+    resolved = resolved.replace(scheme: 'https');
+  }
+
+  // 去除 path 尾斜杠（根路径除外）。
+  String path = resolved.path;
+  while (path.length > 1 && path.endsWith('/')) {
+    path = path.substring(0, path.length - 1);
+  }
+
+  final bool hasQuery = resolved.hasQuery && resolved.query.isNotEmpty;
+  final bool hasFragment =
+      resolved.hasFragment && resolved.fragment.isNotEmpty;
+
+  final normalized = Uri(
+    scheme: resolved.scheme,
+    host: resolved.host,
+    port: resolved.hasPort ? resolved.port : null,
+    path: path,
+    query: hasQuery ? resolved.query : null,
+    fragment: hasFragment ? resolved.fragment : null,
+  );
+
+  return normalized.toString();
+}

--- a/test/episode_url_test.dart
+++ b/test/episode_url_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/utils/episode_url.dart';
+
+void main() {
+  group('normalizeEpisodeUrl', () {
+    const baseUrl = 'https://www.example.com';
+
+    test('相对路径 + baseUrl → 绝对 URL', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, '/play/123.html'),
+        'https://www.example.com/play/123.html',
+      );
+    });
+
+    test('相对路径（无前导斜杠）基于 baseUrl 补全', () {
+      expect(
+        normalizeEpisodeUrl('https://www.example.com/', 'play/123.html'),
+        'https://www.example.com/play/123.html',
+      );
+    });
+
+    test('绝对路径原样（幂等）', () {
+      const absolute = 'https://www.example.com/play/123.html';
+      expect(normalizeEpisodeUrl(baseUrl, absolute), absolute);
+    });
+
+    test('http 与 https 同站归一到同一 key', () {
+      final viaHttp =
+          normalizeEpisodeUrl(baseUrl, 'http://www.example.com/play/123.html');
+      final viaHttps =
+          normalizeEpisodeUrl(baseUrl, 'https://www.example.com/play/123.html');
+      expect(viaHttp, viaHttps);
+      expect(viaHttp, 'https://www.example.com/play/123.html');
+    });
+
+    test('http baseUrl 下相对路径也归一到 https', () {
+      expect(
+        normalizeEpisodeUrl('http://www.example.com', '/play/123.html'),
+        'https://www.example.com/play/123.html',
+      );
+    });
+
+    test('保留显式端口', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, 'https://www.example.com:8080/play/123'),
+        'https://www.example.com:8080/play/123',
+      );
+    });
+
+    test('protocol-relative URL 基于 baseUrl 补全协议', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, '//cdn.example.com/play/123'),
+        'https://cdn.example.com/play/123',
+      );
+    });
+
+    test('去除多余尾斜杠', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, '/play/123/'),
+        'https://www.example.com/play/123',
+      );
+      expect(
+        normalizeEpisodeUrl(baseUrl, 'https://www.example.com/play/123///'),
+        'https://www.example.com/play/123',
+      );
+    });
+
+    test('根路径尾斜杠保留', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, 'https://www.example.com/'),
+        'https://www.example.com/',
+      );
+    });
+
+    test('去除首尾空白', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, '  /play/123.html  '),
+        'https://www.example.com/play/123.html',
+      );
+    });
+
+    test('保留有意义的 query', () {
+      expect(
+        normalizeEpisodeUrl(baseUrl, '/play?id=123&ep=4'),
+        'https://www.example.com/play?id=123&ep=4',
+      );
+    });
+
+    test('空输入返回空串', () {
+      expect(normalizeEpisodeUrl(baseUrl, ''), '');
+      expect(normalizeEpisodeUrl(baseUrl, '   '), '');
+    });
+
+    test('baseUrl 缺失且为相对路径时原样返回去空白输入', () {
+      expect(normalizeEpisodeUrl('', '/play/123.html'), '/play/123.html');
+    });
+
+    test('幂等性: normalize(normalize(x)) == normalize(x)', () {
+      final cases = <String>[
+        '/play/123.html',
+        'play/123.html',
+        'http://www.example.com/play/123/',
+        'https://www.example.com/play/123.html',
+        '  /play/123/  ',
+        '/play?id=123&ep=4',
+        'https://www.example.com/',
+        '',
+      ];
+      for (final raw in cases) {
+        final once = normalizeEpisodeUrl(baseUrl, raw);
+        final twice = normalizeEpisodeUrl(baseUrl, once);
+        expect(twice, once, reason: 'not idempotent for: "$raw"');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Cause
同一集的源站 URL 在播放、下载、历史回填等入口可能表现为相对路径、缺协议、`http/https` 不一致、尾斜杠不一致，或在端口、protocol-relative URL 形态上存在差异。后续以 URL 作为 `pageUrl` 主键匹配时，这些形态差异会导致同一集失配。

## Fix
- 新增 `normalizeEpisodeUrl`，统一集数源站 URL 归一化口径。
- 在线路生产端 `Plugin.querychapterRoads` 写入 `Road.data` 前归一化 URL。
- 在播放消费端解析视频源前复用同一归一化函数。
- 增加 URL 归一化单元测试，覆盖相对路径、绝对 URL、`http -> https`、显式端口保留、protocol-relative URL、尾斜杠、空白、空输入、query 保留和幂等性。

## Risk
当前归一化会把 `http` 统一为 `https`，并且归一化结果同时作为 `pageUrl` 身份 key 和实际请求 URL。项目既有章节页请求逻辑已经倾向将源站 URL 升级为 `https`，因此本 PR 暂不拆分 key URL 与请求 URL。如果回归发现存在只支持 `http` 的源站，需要再调整设计。

## Tests
- [x] `flutter test test/episode_url_test.dart`
- [x] `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（退出码 0；仓库现有 32 条 info 级提示）
- [x] Windows 人工验证在线播放能进入并解析视频源
- [x] Windows 人工验证同一插件/番剧可触发下载解析或进入下载流程