### PR TITLE
[refactor] PR2-统一播放集数身份模型

### DIFF
--- a/lib/pages/player/controller/player_models.dart
+++ b/lib/pages/player/controller/player_models.dart
@@ -7,6 +7,8 @@ class PlaybackInitParams {
   final int episode;
   final int danmakuEpisodeNumber;
   final String pageUrl;
+
+  /// 集数排序号，语义同 EpisodeRef.sortNumber（在线解析自标题、离线为 episodeNumber）。
   final int? sortNumber;
   final Map<String, String> httpHeaders;
   final bool adBlockerEnabled;

--- a/lib/pages/player/controller/player_models.dart
+++ b/lib/pages/player/controller/player_models.dart
@@ -6,6 +6,8 @@ class PlaybackInitParams {
   final String pluginName;
   final int episode;
   final int danmakuEpisodeNumber;
+  final String pageUrl;
+  final int? sortNumber;
   final Map<String, String> httpHeaders;
   final bool adBlockerEnabled;
   final String episodeTitle;
@@ -27,6 +29,8 @@ class PlaybackInitParams {
     required this.episodeTitle,
     required this.referer,
     required this.currentRoad,
+    this.pageUrl = '',
+    this.sortNumber,
     this.coverUrl,
     this.bangumiName,
   });

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -339,9 +339,16 @@ class _PlayerItemState extends State<PlayerItem>
       return;
     }
 
-    final identifier =
-        videoPageController.roadList[currentRoad].identifier[targetEpisode - 1];
-    KazumiDialog.showToast(message: '正在加载$identifier');
+    final targetSelection = VideoEpisodeSelection(
+      episode: targetEpisode,
+      road: currentRoad,
+    );
+    final targetRef = videoPageController.resolveEpisode(targetSelection);
+    if (targetRef == null) {
+      KazumiDialog.showToast(message: '集数解析失败');
+      return;
+    }
+    KazumiDialog.showToast(message: '正在加载${targetRef.displayTitle}');
     widget.changeEpisode(targetEpisode, currentRoad: currentRoad);
   }
 
@@ -566,9 +573,10 @@ class _PlayerItemState extends State<PlayerItem>
         return;
       }
       final currentRoadData = videoPageController.roadList[currentRoad];
-      if (currentEpisode <= 0 || currentRoadData.identifier.isEmpty) return;
-      final safeEpisodeIndex = currentEpisode - 1;
-      if (safeEpisodeIndex >= currentRoadData.identifier.length) return;
+      if (currentEpisode <= 0 || currentRoadData.data.isEmpty) return;
+      final episodeRef = videoPageController.resolveEpisode(selection);
+      if (episodeRef == null) return;
+      final queueIndex = episodeRef.listIndex - 1;
 
       if (playerController.playback.duration <= Duration.zero) return;
 
@@ -577,7 +585,6 @@ class _PlayerItemState extends State<PlayerItem>
       final bangumiTitle = videoPageController.bangumiItem.nameCn.isNotEmpty
           ? videoPageController.bangumiItem.nameCn
           : videoPageController.bangumiItem.name;
-      final episodeTitle = currentRoadData.identifier[safeEpisodeIndex];
       final artworkUrl = videoPageController.bangumiItem.images['large'];
       final artworkUri = (artworkUrl == null || artworkUrl.isEmpty)
           ? null
@@ -591,7 +598,7 @@ class _PlayerItemState extends State<PlayerItem>
           album: videoPageController.isOfflineMode
               ? videoPageController.offlinePluginName
               : videoPageController.currentPlugin.name,
-          artist: episodeTitle,
+          artist: episodeRef.displayTitle,
           artUri: artworkUri,
           duration: playerController.playback.duration,
           playing: playerController.playback.playing,
@@ -601,7 +608,7 @@ class _PlayerItemState extends State<PlayerItem>
           updatePosition: playerController.playback.currentPosition,
           bufferedPosition: playerController.playback.buffer,
           speed: playerController.playback.playerSpeed,
-          queueIndex: safeEpisodeIndex,
+          queueIndex: queueIndex,
           canSkipToNext: canSkipToNext,
           canSkipToPrevious: canSkipToPrevious,
         ),
@@ -1029,14 +1036,21 @@ class _PlayerItemState extends State<PlayerItem>
       }
       // 自动播放下一集
       final playingSelection = videoPageController.playbackEpisode;
+      final playingRoadData =
+          videoPageController.roadList[playingSelection.road];
       if (playerController.playback.completed &&
-          playingSelection.episode <
-              videoPageController.roadList[playingSelection.road].data.length &&
+          playingSelection.episode < playingRoadData.data.length &&
           !videoPageController.loading &&
           autoPlayNext) {
-        KazumiDialog.showToast(
-            message:
-                '正在加载${videoPageController.roadList[playingSelection.road].identifier[playingSelection.episode]}');
+        final nextSelection = VideoEpisodeSelection(
+          episode: playingSelection.episode + 1,
+          road: playingSelection.road,
+        );
+        final nextRef = videoPageController.resolveEpisode(nextSelection);
+        if (nextRef == null) {
+          return;
+        }
+        KazumiDialog.showToast(message: '正在加载${nextRef.displayTitle}');
         try {
           playerTimer!.cancel();
         } catch (_) {}

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -300,7 +300,7 @@ abstract class _VideoPageController with Store {
         0;
   }
 
-  void _setOnlineHistoryIdentity(ResolvedEpisode episode) {
+  void _setOnlineHistoryIdentity(EpisodeRef episode) {
     _playbackHistoryIdentity = PlaybackHistoryIdentity.online(
       bangumiItem: bangumiItem,
       pluginName: currentPlugin.name,
@@ -308,22 +308,22 @@ abstract class _VideoPageController with Store {
       episodeTitle: episode.displayTitle,
       road: episode.originalRoadIndex,
       onlineBangumiSrc: src,
-      episodePageUrl: episode.episodePageUrl,
+      episodePageUrl: episode.pageUrl,
     );
   }
 
-  void _setOfflineHistoryIdentity(ResolvedEpisode episode) {
+  void _setOfflineHistoryIdentity(EpisodeRef episode) {
     _playbackHistoryIdentity = PlaybackHistoryIdentity.offline(
       bangumiItem: bangumiItem,
       pluginName: _offlinePluginName,
       episodeNumber: episode.historyEpisodeNumber,
       episodeTitle: episode.displayTitle,
       road: episode.originalRoadIndex,
-      episodePageUrl: episode.episodePageUrl,
+      episodePageUrl: episode.pageUrl,
     );
   }
 
-  ResolvedEpisode? _resolveOnlineEpisode(int episode, {int? road}) {
+  EpisodeRef? _resolveOnlineEpisode(int episode, {int? road}) {
     final targetRoad = road ?? selectedEpisode.road;
     if (roadList.isEmpty || targetRoad < 0 || targetRoad >= roadList.length) {
       return null;
@@ -336,15 +336,15 @@ abstract class _VideoPageController with Store {
       return null;
     }
     final displayTitle = roadData.identifier[index];
-    return ResolvedEpisode.online(
+    return EpisodeRef.online(
       listIndex: episode,
       roadIndex: targetRoad,
       displayTitle: displayTitle,
-      episodePageUrl: roadData.data[index],
+      pageUrl: roadData.data[index],
     );
   }
 
-  ResolvedEpisode? _resolveOfflineEpisode(int episode, {int? road}) {
+  EpisodeRef? _resolveOfflineEpisode(int episode, {int? road}) {
     final targetRoad = road ?? selectedEpisode.road;
     if (roadList.isEmpty || targetRoad < 0 || targetRoad >= roadList.length) {
       return null;
@@ -364,11 +364,11 @@ abstract class _VideoPageController with Store {
     final episodeTitle = downloadEpisode?.episodeName.isNotEmpty == true
         ? downloadEpisode!.episodeName
         : (titleFromRoad.isNotEmpty ? titleFromRoad : '第$episodeNumber集');
-    return ResolvedEpisode.offline(
+    return EpisodeRef.offline(
       listIndex: episode,
       roadIndex: targetRoad,
       displayTitle: episodeTitle,
-      episodePageUrl: downloadEpisode?.episodePageUrl ?? '',
+      pageUrl: downloadEpisode?.episodePageUrl ?? '',
       episodeNumber: episodeNumber,
       originalRoadIndex: downloadEpisode?.road ??
           _offlineDisplayRoadToOriginalRoad[targetRoad] ??
@@ -376,10 +376,14 @@ abstract class _VideoPageController with Store {
     );
   }
 
-  int commentEpisodeForSelection(VideoEpisodeSelection selection) {
-    final resolvedEpisode = isOfflineMode
+  EpisodeRef? resolveEpisode(VideoEpisodeSelection selection) {
+    return isOfflineMode
         ? _resolveOfflineEpisode(selection.episode, road: selection.road)
         : _resolveOnlineEpisode(selection.episode, road: selection.road);
+  }
+
+  int commentEpisodeForSelection(VideoEpisodeSelection selection) {
+    final resolvedEpisode = resolveEpisode(selection);
     return resolvedEpisode?.danmakuEpisodeNumber ?? selection.episode;
   }
 
@@ -439,7 +443,7 @@ abstract class _VideoPageController with Store {
         .i('VideoPageController: changed to ${resolvedEpisode.displayTitle}');
     final urlItem = normalizeEpisodeUrl(
       currentPlugin.baseUrl,
-      resolvedEpisode.episodePageUrl,
+      resolvedEpisode.pageUrl,
     );
 
     await _resolveWithVideoSourceService(
@@ -501,6 +505,8 @@ abstract class _VideoPageController with Store {
       pluginName: _offlinePluginName,
       episode: resolvedEpisode.listIndex,
       danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
+      pageUrl: resolvedEpisode.pageUrl,
+      sortNumber: resolvedEpisode.sortNumber,
       httpHeaders: {},
       adBlockerEnabled: false,
       episodeTitle: resolvedEpisode.displayTitle,
@@ -575,7 +581,7 @@ abstract class _VideoPageController with Store {
   Future<void> _resolveWithVideoSourceService(
     String url,
     int offset, {
-    required ResolvedEpisode resolvedEpisode,
+    required EpisodeRef resolvedEpisode,
     required _AsyncSession session,
     required PlayerController playerController,
   }) async {
@@ -613,6 +619,8 @@ abstract class _VideoPageController with Store {
         pluginName: currentPlugin.name,
         episode: resolvedEpisode.listIndex,
         danmakuEpisodeNumber: resolvedEpisode.danmakuEpisodeNumber,
+        pageUrl: resolvedEpisode.pageUrl,
+        sortNumber: resolvedEpisode.sortNumber,
         httpHeaders: {
           'user-agent': currentPlugin.userAgent.isEmpty
               ? getRandomUA()
@@ -845,12 +853,13 @@ OfflineRoadListSnapshot buildOfflineRoadListSnapshot(
   );
 }
 
-class ResolvedEpisode {
-  const ResolvedEpisode({
+class EpisodeRef {
+  const EpisodeRef({
     required this.listIndex,
     required this.roadIndex,
     required this.displayTitle,
-    required this.episodePageUrl,
+    required this.pageUrl,
+    required this.sortNumber,
     required this.historyEpisodeNumber,
     required this.danmakuEpisodeNumber,
     required this.originalRoadIndex,
@@ -859,23 +868,25 @@ class ResolvedEpisode {
   final int listIndex;
   final int roadIndex;
   final String displayTitle;
-  final String episodePageUrl;
+  final String pageUrl;
+  final int? sortNumber;
   final int historyEpisodeNumber;
   final int danmakuEpisodeNumber;
   final int originalRoadIndex;
 
-  factory ResolvedEpisode.online({
+  factory EpisodeRef.online({
     required int listIndex,
     required int roadIndex,
     required String displayTitle,
-    required String episodePageUrl,
+    required String pageUrl,
   }) {
     final parsedEpisodeNumber = extractEpisodeNumber(displayTitle);
-    return ResolvedEpisode(
+    return EpisodeRef(
       listIndex: listIndex,
       roadIndex: roadIndex,
       displayTitle: displayTitle,
-      episodePageUrl: episodePageUrl,
+      pageUrl: pageUrl,
+      sortNumber: parsedEpisodeNumber > 0 ? parsedEpisodeNumber : null,
       historyEpisodeNumber: listIndex,
       danmakuEpisodeNumber:
           parsedEpisodeNumber > 0 ? parsedEpisodeNumber : listIndex,
@@ -883,25 +894,26 @@ class ResolvedEpisode {
     );
   }
 
-  const factory ResolvedEpisode.offline({
+  const factory EpisodeRef.offline({
     required int listIndex,
     required int roadIndex,
     required String displayTitle,
-    required String episodePageUrl,
+    required String pageUrl,
     required int episodeNumber,
     required int originalRoadIndex,
-  }) = _OfflineResolvedEpisode;
+  }) = _OfflineEpisodeRef;
 }
 
-class _OfflineResolvedEpisode extends ResolvedEpisode {
-  const _OfflineResolvedEpisode({
+class _OfflineEpisodeRef extends EpisodeRef {
+  const _OfflineEpisodeRef({
     required super.listIndex,
     required super.roadIndex,
     required super.displayTitle,
-    required super.episodePageUrl,
+    required super.pageUrl,
     required int episodeNumber,
     required super.originalRoadIndex,
   }) : super(
+          sortNumber: episodeNumber,
           historyEpisodeNumber: episodeNumber,
           danmakuEpisodeNumber: episodeNumber,
         );

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -351,7 +351,9 @@ abstract class _VideoPageController with Store {
     }
     final roadData = roadList[targetRoad];
     final index = episode - 1;
-    if (index < 0 || index >= roadData.data.length) {
+    if (index < 0 ||
+        index >= roadData.data.length ||
+        index >= roadData.identifier.length) {
       return null;
     }
     final episodeNumber = int.tryParse(roadData.data[index]);
@@ -359,8 +361,7 @@ abstract class _VideoPageController with Store {
       return null;
     }
     final downloadEpisode = _offlineEpisodesByNumber[episodeNumber];
-    final titleFromRoad =
-        index < roadData.identifier.length ? roadData.identifier[index] : '';
+    final titleFromRoad = roadData.identifier[index];
     final episodeTitle = downloadEpisode?.episodeName.isNotEmpty == true
         ? downloadEpisode!.episodeName
         : (titleFromRoad.isNotEmpty ? titleFromRoad : '第$episodeNumber集');
@@ -869,6 +870,10 @@ class EpisodeRef {
   final int roadIndex;
   final String displayTitle;
   final String pageUrl;
+
+  /// 集数排序号。
+  /// - 在线：从 [displayTitle] 解析（[extractEpisodeNumber]），无法解析时为 null。
+  /// - 离线：恒等于下载数据的 episodeNumber。
   final int? sortNumber;
   final int historyEpisodeNumber;
   final int danmakuEpisodeNumber;

--- a/test/episode_ref_test.dart
+++ b/test/episode_ref_test.dart
@@ -4,50 +4,54 @@ import 'package:kazumi/pages/player/controller/player_models.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 
 void main() {
-  group('ResolvedEpisode', () {
+  group('EpisodeRef', () {
     test('online keeps list index for history and parses title for danmaku',
         () {
-      final episode = ResolvedEpisode.online(
+      final episode = EpisodeRef.online(
         listIndex: 1,
         roadIndex: 0,
         displayTitle: '第13话',
-        episodePageUrl: '/episode/13',
+        pageUrl: '/episode/13',
       );
 
       expect(episode.historyEpisodeNumber, 1);
       expect(episode.danmakuEpisodeNumber, 13);
+      expect(episode.sortNumber, 13);
       expect(episode.originalRoadIndex, 0);
-      expect(episode.episodePageUrl, '/episode/13');
+      expect(episode.pageUrl, '/episode/13');
     });
 
     test('online falls back to list index when title has no episode number',
         () {
-      final episode = ResolvedEpisode.online(
+      final episode = EpisodeRef.online(
         listIndex: 2,
         roadIndex: 1,
         displayTitle: 'OVA',
-        episodePageUrl: '/ova',
+        pageUrl: '/ova',
       );
 
       expect(episode.historyEpisodeNumber, 2);
       expect(episode.danmakuEpisodeNumber, 2);
+      expect(episode.sortNumber, isNull);
       expect(episode.originalRoadIndex, 1);
     });
 
     test('offline uses downloaded episode number for history and danmaku', () {
-      const episode = ResolvedEpisode.offline(
+      const episode = EpisodeRef.offline(
         listIndex: 1,
         roadIndex: 0,
         displayTitle: '第13话',
-        episodePageUrl: '/episode/13',
+        pageUrl: '/episode/13',
         episodeNumber: 13,
         originalRoadIndex: 2,
       );
 
       expect(episode.historyEpisodeNumber, 13);
       expect(episode.danmakuEpisodeNumber, 13);
+      expect(episode.sortNumber, 13);
       expect(episode.originalRoadIndex, 2);
       expect(episode.listIndex, 1);
+      expect(episode.pageUrl, '/episode/13');
     });
   });
 


### PR DESCRIPTION
## 原因

播放流程之前把集数列表位置、显示标题、视频源页面地址、弹幕集数和离线集数身份分散在不同路径中传递。在线播放和下载播放在切集、写入播放历史、更新系统媒体队列时，容易使用不一致的集数身份数据。

## 变更

- 将 `ResolvedEpisode` 重命名为 `EpisodeRef`，并在统一集数身份中补充 `pageUrl` 和 `sortNumber`。
- 暴露 `resolveEpisode()`，让播放器 UI 路径复用同一套在线/离线集数解析逻辑。
- 在线播放和离线播放创建 `PlaybackInitParams` 时，都传入解析后的页面地址和排序号。
- 手动切集、自动播放下一集、系统媒体队列元数据统一使用 `EpisodeRef`。
- 将相关单元测试从 `resolved_episode_test.dart` 重命名并更新为 `episode_ref_test.dart`。

## 验证

- `dart format --set-exit-if-changed lib/pages/player/controller/player_models.dart lib/pages/player/player_item.dart lib/pages/video/video_controller.dart test/episode_ref_test.dart`
- `flutter test test/episode_ref_test.dart`
- `flutter analyze --no-fatal-infos --fatal-warnings` 通过；仅输出项目中已有的 info 级 analyzer 提示。

## 平台

- Windows
- Flutter 3.44.3 / Dart 3.12.2

---

## 补充变更（review 跟进）

* 为 `EpisodeRef.sortNumber` 与 `PlaybackInitParams.sortNumber` 补充文档注释，明确语义：在线播放时从显示标题解析（`extractEpisodeNumber`），无法解析时为 `null`；离线播放时恒等于下载数据的 `episodeNumber`。
* 统一在线/离线集数解析的越界防御：`_resolveOfflineEpisode` 现在与 `_resolveOnlineEpisode` 一致，同时校验 `data` 与 `identifier` 长度，越界即返回 `null`，避免两条路径防御不对称在后续改动中埋下隐患。正常数据（`identifier`/`data` 等长，由 `buildOfflineRoadListSnapshot` 保证）不受影响。

### 验证
* `flutter test test/episode_ref_test.dart`（5 项全部通过）
* `flutter analyze --no-fatal-infos --fatal-warnings`（仅项目已有 info 级提示）