### PR TITLE
[refactor] PR3-按页面 URL 区分历史进度

### DIFF
--- a/lib/modules/history/history_module.dart
+++ b/lib/modules/history/history_module.dart
@@ -154,6 +154,9 @@ class Progress {
   @HiveField(3, defaultValue: 0)
   int updatedAtMs;
 
+  @HiveField(4, defaultValue: '')
+  String episodePageUrl;
+
   Duration get progress => Duration(milliseconds: _progressInMilli);
 
   set progress(Duration d) => _progressInMilli = d.inMilliseconds;
@@ -163,6 +166,7 @@ class Progress {
     this.road,
     this._progressInMilli, {
     this.updatedAtMs = 0,
+    this.episodePageUrl = '',
   });
 
   int effectiveUpdatedAtMs(DateTime fallback) {

--- a/lib/modules/history/history_module.g.dart
+++ b/lib/modules/history/history_module.g.dart
@@ -23,9 +23,7 @@ class HistoryAdapter extends TypeAdapter<History> {
       fields[4] as DateTime,
       fields[5] as String,
       fields[6] == null ? '' : fields[6] as String,
-      entryKind: fields[7] == null
-          ? HistoryEntryKind.online
-          : fields[7] as String,
+      entryKind: fields[7] == null ? 'online' : fields[7] as String,
       episodePageUrl: fields[8] == null ? '' : fields[8] as String,
     )..progresses = (fields[0] as Map).cast<int, Progress>();
   }
@@ -80,13 +78,14 @@ class ProgressAdapter extends TypeAdapter<Progress> {
       (fields[1] as num).toInt(),
       (fields[2] as num).toInt(),
       updatedAtMs: fields[3] == null ? 0 : (fields[3] as num).toInt(),
+      episodePageUrl: fields[4] == null ? '' : fields[4] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, Progress obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.episode)
       ..writeByte(1)
@@ -94,7 +93,9 @@ class ProgressAdapter extends TypeAdapter<Progress> {
       ..writeByte(2)
       ..write(obj._progressInMilli)
       ..writeByte(3)
-      ..write(obj.updatedAtMs);
+      ..write(obj.updatedAtMs)
+      ..writeByte(4)
+      ..write(obj.episodePageUrl);
   }
 
   @override

--- a/lib/modules/history/history_sync.dart
+++ b/lib/modules/history/history_sync.dart
@@ -90,6 +90,7 @@ class HistorySyncEvent {
     required int road,
     required int progressMs,
     required int updatedAt,
+    String? episodePageUrl,
   }) {
     return HistorySyncEvent(
       eventId: '$deviceId:$seq',
@@ -104,7 +105,7 @@ class HistorySyncEvent {
       road: road,
       progressMs: progressMs,
       entryKind: history.entryKind,
-      episodePageUrl: history.episodePageUrl,
+      episodePageUrl: episodePageUrl ?? history.episodePageUrl,
     );
   }
 
@@ -453,20 +454,39 @@ class HistorySyncState {
           event.lastSrc ?? '',
           event.lastWatchEpisodeName ?? '',
           entryKind: entryKind,
-          episodePageUrl: event.episodePageUrl ?? '',
         );
 
+    final episodePageUrl = event.episodePageUrl ?? '';
+    final progressMatch = _HistoryEpisodeMatcher.find(
+      current,
+      episode: episode,
+      episodePageUrl: episodePageUrl,
+    );
+    final progressBucket = progressMatch?.bucket ??
+        _HistoryEpisodeMatcher.bucketForNewProgress(
+          current,
+          episode: episode,
+          episodePageUrl: episodePageUrl,
+        );
     final episodeVersions = progressVersions.putIfAbsent(entityKey, () => {});
-    final progressVersion = episodeVersions[episode];
+    final progressVersion = episodeVersions[progressBucket];
     if (progressVersion == null ||
         HistorySyncVersion.compare(event.version, progressVersion) >= 0) {
-      current.progresses[episode] = Progress(
-        episode,
-        road,
-        progressMs,
-        updatedAtMs: event.updatedAt,
-      );
-      episodeVersions[episode] = event.version;
+      final progress = progressMatch?.progress ??
+          Progress(
+            episode,
+            road,
+            progressMs,
+            updatedAtMs: event.updatedAt,
+            episodePageUrl: episodePageUrl,
+          );
+      progress.episode = episode;
+      progress.road = road;
+      progress.progress = Duration(milliseconds: progressMs);
+      progress.updatedAtMs = event.updatedAt;
+      progress.episodePageUrl = episodePageUrl;
+      current.progresses[progressBucket] = progress;
+      episodeVersions[progressBucket] = event.version;
     }
     histories[entityKey] = current;
     deletedVersions.remove(entityKey);
@@ -529,9 +549,7 @@ class HistorySyncState {
         current.lastWatchEpisodeName = event.lastWatchEpisodeName!;
       }
       current.entryKind = entryKind;
-      if ((event.episodePageUrl ?? '').isNotEmpty) {
-        current.episodePageUrl = event.episodePageUrl!;
-      }
+      current.episodePageUrl = event.episodePageUrl ?? '';
       itemVersions[entityKey] = event.version;
     }
     histories[entityKey] = current;
@@ -658,6 +676,97 @@ class HistorySyncState {
   }
 }
 
+class _HistoryEpisodeMatch {
+  const _HistoryEpisodeMatch({
+    required this.bucket,
+    required this.progress,
+  });
+
+  final int bucket;
+  final Progress progress;
+}
+
+class _HistoryEpisodeMatcher {
+  static _HistoryEpisodeMatch? find(
+    History history, {
+    required int episode,
+    String episodePageUrl = '',
+  }) {
+    final pageUrl = episodePageUrl.trim();
+    if (pageUrl.isNotEmpty) {
+      for (final entry in history.progresses.entries) {
+        if (entry.value.episodePageUrl == pageUrl) {
+          return _HistoryEpisodeMatch(
+            bucket: entry.key,
+            progress: entry.value,
+          );
+        }
+      }
+
+      final legacyProgress = history.progresses[episode];
+      if (legacyProgress != null &&
+          legacyProgress.episode == episode &&
+          legacyProgress.episodePageUrl.isEmpty) {
+        return _HistoryEpisodeMatch(
+          bucket: episode,
+          progress: legacyProgress,
+        );
+      }
+      for (final entry in history.progresses.entries) {
+        final progress = entry.value;
+        if (progress.episode == episode && progress.episodePageUrl.isEmpty) {
+          return _HistoryEpisodeMatch(
+            bucket: entry.key,
+            progress: progress,
+          );
+        }
+      }
+      return null;
+    }
+
+    final progress = history.progresses[episode];
+    if (progress != null && progress.episode == episode) {
+      return _HistoryEpisodeMatch(bucket: episode, progress: progress);
+    }
+
+    for (final entry in history.progresses.entries) {
+      if (entry.value.episode == episode) {
+        return _HistoryEpisodeMatch(
+          bucket: entry.key,
+          progress: entry.value,
+        );
+      }
+    }
+    return null;
+  }
+
+  static int bucketForNewProgress(
+    History history, {
+    required int episode,
+    String episodePageUrl = '',
+  }) {
+    final pageUrl = episodePageUrl.trim();
+    final existing = history.progresses[episode];
+    if (existing == null) {
+      return episode;
+    }
+    if (existing.episode == episode &&
+        (pageUrl.isEmpty ||
+            existing.episodePageUrl.isEmpty ||
+            existing.episodePageUrl == pageUrl)) {
+      return episode;
+    }
+
+    var bucket = episode;
+    while (history.progresses.containsKey(bucket)) {
+      bucket++;
+    }
+    return bucket;
+  }
+
+  _HistoryEpisodeMatcher._();
+}
+
 class HistorySyncMerger {
   static HistorySyncSnapshot merge({
     required HistorySyncSnapshot snapshot,
@@ -753,6 +862,7 @@ class HistorySyncCodec {
       (json['road'] as num).toInt(),
       (json['progressMs'] as num).toInt(),
       updatedAtMs: (json['updatedAtMs'] as num?)?.toInt() ?? 0,
+      episodePageUrl: json['episodePageUrl'] as String? ?? '',
     );
   }
 
@@ -762,6 +872,7 @@ class HistorySyncCodec {
       'road': progress.road,
       'progressMs': progress.progress.inMilliseconds,
       'updatedAtMs': progress.updatedAtMs,
+      'episodePageUrl': progress.episodePageUrl,
     };
   }
 

--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -46,12 +46,14 @@ abstract class _HistoryController with Store {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   }) {
     return _historyRepository.findProgress(
       bangumiItem,
       adapterName,
       episode,
       entryKind: entryKind,
+      episodePageUrl: episodePageUrl,
     );
   }
 
@@ -65,12 +67,14 @@ abstract class _HistoryController with Store {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   }) async {
     await _historyRepository.clearProgress(
       bangumiItem,
       adapterName,
       episode,
       entryKind: entryKind,
+      episodePageUrl: episodePageUrl,
     );
     init();
   }

--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -57,6 +57,20 @@ abstract class _HistoryController with Store {
     );
   }
 
+  void migrateProgressPageUrls({
+    required BangumiItem bangumiItem,
+    required String adapterName,
+    String entryKind = HistoryEntryKind.online,
+    required String Function(int road, int episode) resolveCurrentPageUrl,
+  }) {
+    _historyRepository.migrateProgressPageUrls(
+      adapterName: adapterName,
+      bangumiItem: bangumiItem,
+      entryKind: entryKind,
+      resolveCurrentPageUrl: resolveCurrentPageUrl,
+    );
+  }
+
   Future<void> deleteHistory(History history) async {
     await _historyRepository.deleteHistory(history);
     init();

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -86,6 +86,26 @@ class VideoEpisodeSelection {
   }
 }
 
+VideoEpisodeSelection? findEpisodeSelectionByPageUrl(
+  List<Road> roadList,
+  String episodePageUrl,
+) {
+  final pageUrl = episodePageUrl.trim();
+  if (pageUrl.isEmpty) {
+    return null;
+  }
+  for (var roadIndex = 0; roadIndex < roadList.length; roadIndex++) {
+    final episodeIndex = roadList[roadIndex].data.indexOf(pageUrl);
+    if (episodeIndex >= 0) {
+      return VideoEpisodeSelection(
+        episode: episodeIndex + 1,
+        road: roadIndex,
+      );
+    }
+  }
+  return null;
+}
+
 abstract class _VideoPageController with Store {
   late BangumiItem bangumiItem;
   EpisodeInfo episodeInfo = EpisodeInfo.fromTemplate();
@@ -294,6 +314,7 @@ abstract class _VideoPageController with Store {
               identity.pluginName,
               identity.episodeNumber,
               entryKind: identity.entryKind,
+              episodePageUrl: identity.episodePageUrl,
             )
             ?.progress
             .inSeconds ??

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -321,6 +321,30 @@ abstract class _VideoPageController with Store {
         0;
   }
 
+  /// 规则 baseURL 变更后，历史进度中的 pageURL 会因旧 baseURL 归一化而失配，
+  /// 触发 fallback 播放并在写入时新建重复条目。此处在在线视频页打开时，
+  /// 依据当前 roadList 把历史里过期的 pageURL 就地迁移为最新 URL。
+  void migrateStaleOnlineEpisodePageUrls() {
+    if (isOfflineMode || roadList.isEmpty) {
+      return;
+    }
+    historyController.migrateProgressPageUrls(
+      adapterName: currentPlugin.name,
+      bangumiItem: bangumiItem,
+      resolveCurrentPageUrl: (road, episode) {
+        if (road < 0 || road >= roadList.length) {
+          return '';
+        }
+        final data = roadList[road].data;
+        final idx = episode - 1;
+        if (idx < 0 || idx >= data.length) {
+          return '';
+        }
+        return data[idx];
+      },
+    );
+  }
+
   void _setOnlineHistoryIdentity(EpisodeRef episode) {
     _playbackHistoryIdentity = PlaybackHistoryIdentity.online(
       bangumiItem: bangumiItem,

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -186,16 +186,28 @@ class _VideoPageState extends State<VideoPage>
         videoPageController.bangumiItem,
         videoPageController.currentPlugin.name);
     if (progress != null) {
-      if (videoPageController.roadList.length > progress.road) {
-        if (videoPageController.roadList[progress.road].data.length >=
-            progress.episode) {
-          videoPageController.resetEpisodeState(
-            episode: progress.episode,
-            road: progress.road,
-          );
-          if (playResume) {
-            videoPageController.historyOffset = progress.progress.inSeconds;
-          }
+      final pageUrlSelection = findEpisodeSelectionByPageUrl(
+        videoPageController.roadList,
+        progress.episodePageUrl,
+      );
+      final fallbackSelection = pageUrlSelection ??
+          ((progress.road >= 0 &&
+                  videoPageController.roadList.length > progress.road &&
+                  progress.episode > 0 &&
+                  videoPageController.roadList[progress.road].data.length >=
+                      progress.episode)
+              ? VideoEpisodeSelection(
+                  episode: progress.episode,
+                  road: progress.road,
+                )
+              : null);
+      if (fallbackSelection != null) {
+        videoPageController.resetEpisodeState(
+          episode: fallbackSelection.episode,
+          road: fallbackSelection.road,
+        );
+        if (playResume) {
+          videoPageController.historyOffset = progress.progress.inSeconds;
         }
       }
     }

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -182,6 +182,10 @@ class _VideoPageState extends State<VideoPage>
     videoPageController.historyOffset = 0;
     _showTabBodyImmediately(locateEpisode: false);
 
+    // 规则 baseURL 变更后迁移历史中过期的 pageURL，避免后续写入产生重复进度。
+    // 同步执行，保证下面 lastWatching 读取到迁移后的 URL。
+    videoPageController.migrateStaleOnlineEpisodePageUrls();
+
     var progress = historyController.lastWatching(
         videoPageController.bangumiItem,
         videoPageController.currentPlugin.name);

--- a/lib/repositories/history_repository.dart
+++ b/lib/repositories/history_repository.dart
@@ -93,6 +93,22 @@ abstract class IHistoryRepository {
   /// 清空所有历史记录
   Future<void> clearAllHistories();
 
+  /// 迁移历史进度中过期的 pageURL。
+  ///
+  /// 当规则的 baseURL 变更后，历史记录里基于旧 baseURL 归一化得到的
+  /// [Progress.episodePageUrl] 不再与当前 roadList 中的 URL 匹配，
+  /// 进而在下次写入时被当作新条目，产生重复进度。
+  ///
+  /// [resolveCurrentPageUrl] 根据存储的 `(road, episode)` 返回当前 roadList
+  /// 中对应的最新 URL（无法解析返回空串）。命中后就地把旧 URL 迁移为新 URL，
+  /// 使后续写入复用既有条目而非新建。
+  void migrateProgressPageUrls({
+    required String adapterName,
+    required BangumiItem bangumiItem,
+    String entryKind = HistoryEntryKind.online,
+    required String Function(int road, int episode) resolveCurrentPageUrl,
+  });
+
   /// 获取隐私模式设置
   bool getPrivateMode();
 }
@@ -447,6 +463,118 @@ class HistoryRepository implements IHistoryRepository {
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: clear all histories failed',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  @override
+  void migrateProgressPageUrls({
+    required String adapterName,
+    required BangumiItem bangumiItem,
+    String entryKind = HistoryEntryKind.online,
+    required String Function(int road, int episode) resolveCurrentPageUrl,
+  }) {
+    try {
+      final history = _findHistory(adapterName, bangumiItem, entryKind);
+      if (history == null) {
+        return;
+      }
+
+      // Phase 1: 解析计划重写（仅记录，不修改）。
+      // 必须使用 Progress 值的 road/episode，而非 map key，因为
+      // bucketForNewProgress 会递增寻找空桶，key 可能不等于 episode。
+      final plannedRewrites = <int, String>{};
+      for (final entry in history.progresses.entries) {
+        final progress = entry.value;
+        final currentUrl = progress.episodePageUrl.trim();
+        if (currentUrl.isEmpty) {
+          continue;
+        }
+        final newUrl =
+            resolveCurrentPageUrl(progress.road, progress.episode).trim();
+        if (newUrl.isEmpty || newUrl == currentUrl) {
+          continue;
+        }
+        plannedRewrites[entry.key] = newUrl;
+      }
+
+      if (plannedRewrites.isEmpty) {
+        return;
+      }
+
+      // 在变更前记录顶层 URL 对应的桶，便于结束后同步迁移
+      // history.episodePageUrl（getLastWatchingProgress 会优先用它匹配）。
+      final topUrl = history.episodePageUrl.trim();
+      int? topBucketKey;
+      if (topUrl.isNotEmpty) {
+        for (final entry in history.progresses.entries) {
+          if (entry.value.episodePageUrl.trim() == topUrl) {
+            topBucketKey = entry.key;
+            break;
+          }
+        }
+      }
+
+      // Phase 2: 应用重写并解决目标 URL 冲突。
+      var changed = false;
+      final removedBuckets = <int>{};
+      plannedRewrites.forEach((bucketKey, newUrl) {
+        if (removedBuckets.contains(bucketKey)) {
+          return;
+        }
+        final progress = history.progresses[bucketKey];
+        if (progress == null) {
+          return;
+        }
+
+        // 查找其它已持有 newUrl 的桶（既有真实条目或过往升级产生的重复）。
+        int? conflictKey;
+        for (final entry in history.progresses.entries) {
+          if (entry.key == bucketKey || removedBuckets.contains(entry.key)) {
+            continue;
+          }
+          if (entry.value.episodePageUrl == newUrl) {
+            conflictKey = entry.key;
+            break;
+          }
+        }
+
+        if (conflictKey == null) {
+          progress.episodePageUrl = newUrl;
+          changed = true;
+          return;
+        }
+
+        // 冲突：按 updatedAtMs 较大者为准，删除落败桶，仅向幸存桶写入。
+        final conflictProgress = history.progresses[conflictKey]!;
+        if (progress.updatedAtMs >= conflictProgress.updatedAtMs) {
+          history.progresses.remove(conflictKey);
+          removedBuckets.add(conflictKey);
+          progress.episodePageUrl = newUrl;
+        } else {
+          history.progresses.remove(bucketKey);
+          removedBuckets.add(bucketKey);
+          // 幸存桶已持有 newUrl，无需再赋值。
+        }
+        changed = true;
+      });
+
+      if (topBucketKey != null) {
+        final newTopUrl = plannedRewrites[topBucketKey];
+        if (newTopUrl != null && newTopUrl != topUrl) {
+          history.episodePageUrl = newTopUrl;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        unawaited(_historiesBox.put(history.key, history));
+      }
+    } catch (e, stackTrace) {
+      KazumiLogger().e(
+        'GStorage: migrate progress page urls failed. bangumi=${bangumiItem.name}',
         error: e,
         stackTrace: stackTrace,
       );

--- a/lib/repositories/history_repository.dart
+++ b/lib/repositories/history_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hive_ce/hive.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
@@ -11,6 +13,7 @@ typedef HistoryProgressSyncAppender = Future<void> Function({
   required int road,
   required int progressMs,
   required int updatedAt,
+  required String episodePageUrl,
 });
 
 typedef HistoryDeleteSyncAppender = Future<void> Function(History history);
@@ -66,6 +69,7 @@ abstract class IHistoryRepository {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   });
 
   /// 删除历史记录
@@ -83,6 +87,7 @@ abstract class IHistoryRepository {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   });
 
   /// 清空所有历史记录
@@ -121,6 +126,7 @@ class HistoryRepository implements IHistoryRepository {
     required int road,
     required int progressMs,
     required int updatedAt,
+    required String episodePageUrl,
   }) async {
     final historySyncService = HistorySyncService();
     await historySyncService.appendSafely(
@@ -130,6 +136,7 @@ class HistoryRepository implements IHistoryRepository {
         road: road,
         progressMs: progressMs,
         updatedAt: updatedAt,
+        episodePageUrl: episodePageUrl,
       ),
     );
   }
@@ -247,24 +254,34 @@ class HistoryRepository implements IHistoryRepository {
       if (identity.episodeTitle.isNotEmpty) {
         history.lastWatchEpisodeName = identity.episodeTitle;
       }
-      if (identity.episodePageUrl.isNotEmpty) {
-        history.episodePageUrl = identity.episodePageUrl;
-      }
+      history.episodePageUrl = identity.episodePageUrl;
 
       // 更新观看进度
-      var prog = history.progresses[episode];
-      if (prog == null) {
-        history.progresses[episode] = Progress(
-          episode,
-          identity.road,
-          progress.inMilliseconds,
-          updatedAtMs: nowMs,
-        );
-      } else {
-        prog.road = identity.road;
-        prog.progress = progress;
-        prog.updatedAtMs = nowMs;
-      }
+      final progressMatch = _HistoryEpisodeMatcher.find(
+        history,
+        episode: episode,
+        episodePageUrl: identity.episodePageUrl,
+      );
+      final progressBucket = progressMatch?.bucket ??
+          _HistoryEpisodeMatcher.bucketForNewProgress(
+            history,
+            episode: episode,
+            episodePageUrl: identity.episodePageUrl,
+          );
+      final prog = progressMatch?.progress ??
+          Progress(
+            episode,
+            identity.road,
+            progress.inMilliseconds,
+            updatedAtMs: nowMs,
+            episodePageUrl: identity.episodePageUrl,
+          );
+      prog.episode = episode;
+      prog.road = identity.road;
+      prog.progress = progress;
+      prog.updatedAtMs = nowMs;
+      prog.episodePageUrl = identity.episodePageUrl;
+      history.progresses[progressBucket] = prog;
 
       // 保存到存储
       await _historiesBox.put(history.key, history);
@@ -277,6 +294,7 @@ class HistoryRepository implements IHistoryRepository {
         road: identity.road,
         progressMs: progress.inMilliseconds,
         updatedAt: nowMs,
+        episodePageUrl: prog.episodePageUrl,
       );
     } catch (e, stackTrace) {
       KazumiLogger().e(
@@ -294,8 +312,28 @@ class HistoryRepository implements IHistoryRepository {
     String entryKind = HistoryEntryKind.online,
   }) {
     try {
-      var history = _findHistory(adapterName, bangumiItem, entryKind);
-      return history?.progresses[history.lastWatchEpisode];
+      final history = _findHistory(adapterName, bangumiItem, entryKind);
+      if (history == null) {
+        return null;
+      }
+      final progressMatch = _HistoryEpisodeMatcher.find(
+        history,
+        episode: history.lastWatchEpisode,
+        episodePageUrl: history.episodePageUrl,
+      );
+      final resolvedMatch =
+          progressMatch?.progress.episode == history.lastWatchEpisode
+              ? progressMatch
+              : _HistoryEpisodeMatcher.find(
+                  history,
+                  episode: history.lastWatchEpisode,
+                );
+      _backfillProgressPageUrl(
+        history,
+        resolvedMatch,
+        history.episodePageUrl,
+      );
+      return resolvedMatch?.progress;
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: get last watching progress failed. bangumi=${bangumiItem.name}',
@@ -312,10 +350,20 @@ class HistoryRepository implements IHistoryRepository {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   }) {
     try {
-      var history = _findHistory(adapterName, bangumiItem, entryKind);
-      return history?.progresses[episode];
+      final history = _findHistory(adapterName, bangumiItem, entryKind);
+      if (history == null) {
+        return null;
+      }
+      final progressMatch = _HistoryEpisodeMatcher.find(
+        history,
+        episode: episode,
+        episodePageUrl: episodePageUrl,
+      );
+      _backfillProgressPageUrl(history, progressMatch, episodePageUrl);
+      return progressMatch?.progress;
     } catch (e, stackTrace) {
       KazumiLogger().e(
         'GStorage: find progress failed. bangumi=${bangumiItem.name}, episode=$episode',
@@ -352,20 +400,34 @@ class HistoryRepository implements IHistoryRepository {
     String adapterName,
     int episode, {
     String entryKind = HistoryEntryKind.online,
+    String episodePageUrl = '',
   }) async {
     try {
-      var history = _findHistory(adapterName, bangumiItem, entryKind);
-      if (history != null && history.progresses[episode] != null) {
+      final history = _findHistory(adapterName, bangumiItem, entryKind);
+      final progressMatch = history == null
+          ? null
+          : _HistoryEpisodeMatcher.find(
+              history,
+              episode: episode,
+              episodePageUrl: episodePageUrl,
+            );
+      if (history != null && progressMatch != null) {
         final nowMs = DateTime.now().millisecondsSinceEpoch;
-        history.progresses[episode]!.progress = Duration.zero;
-        history.progresses[episode]!.updatedAtMs = nowMs;
+        progressMatch.progress.progress = Duration.zero;
+        progressMatch.progress.updatedAtMs = nowMs;
+        if (episodePageUrl.isNotEmpty &&
+            progressMatch.progress.episodePageUrl.isEmpty) {
+          progressMatch.progress.episodePageUrl = episodePageUrl;
+        }
+        history.progresses[progressMatch.bucket] = progressMatch.progress;
         await _historiesBox.put(history.key, history);
         await _progressSyncAppender(
           history: history,
-          episode: episode,
-          road: history.progresses[episode]!.road,
+          episode: progressMatch.progress.episode,
+          road: progressMatch.progress.road,
           progressMs: 0,
           updatedAt: nowMs,
+          episodePageUrl: progressMatch.progress.episodePageUrl,
         );
       }
     } catch (e, stackTrace) {
@@ -422,4 +484,110 @@ class HistoryRepository implements IHistoryRepository {
             ? _historiesBox.get(History.legacyKey(adapterName, bangumiItem))
             : null);
   }
+
+  void _backfillProgressPageUrl(
+    History history,
+    _HistoryEpisodeMatch? progressMatch,
+    String episodePageUrl,
+  ) {
+    if (progressMatch == null ||
+        episodePageUrl.isEmpty ||
+        progressMatch.progress.episodePageUrl.isNotEmpty) {
+      return;
+    }
+    progressMatch.progress.episodePageUrl = episodePageUrl;
+    history.progresses[progressMatch.bucket] = progressMatch.progress;
+    unawaited(_historiesBox.put(history.key, history));
+  }
+}
+
+class _HistoryEpisodeMatch {
+  const _HistoryEpisodeMatch({
+    required this.bucket,
+    required this.progress,
+  });
+
+  final int bucket;
+  final Progress progress;
+}
+
+class _HistoryEpisodeMatcher {
+  static _HistoryEpisodeMatch? find(
+    History history, {
+    required int episode,
+    String episodePageUrl = '',
+  }) {
+    final pageUrl = episodePageUrl.trim();
+    if (pageUrl.isNotEmpty) {
+      for (final entry in history.progresses.entries) {
+        if (entry.value.episodePageUrl == pageUrl) {
+          return _HistoryEpisodeMatch(
+            bucket: entry.key,
+            progress: entry.value,
+          );
+        }
+      }
+
+      final legacyProgress = history.progresses[episode];
+      if (legacyProgress != null &&
+          legacyProgress.episode == episode &&
+          legacyProgress.episodePageUrl.isEmpty) {
+        return _HistoryEpisodeMatch(
+          bucket: episode,
+          progress: legacyProgress,
+        );
+      }
+      for (final entry in history.progresses.entries) {
+        final progress = entry.value;
+        if (progress.episode == episode && progress.episodePageUrl.isEmpty) {
+          return _HistoryEpisodeMatch(
+            bucket: entry.key,
+            progress: progress,
+          );
+        }
+      }
+      return null;
+    }
+
+    final progress = history.progresses[episode];
+    if (progress != null && progress.episode == episode) {
+      return _HistoryEpisodeMatch(bucket: episode, progress: progress);
+    }
+
+    for (final entry in history.progresses.entries) {
+      if (entry.value.episode == episode) {
+        return _HistoryEpisodeMatch(
+          bucket: entry.key,
+          progress: entry.value,
+        );
+      }
+    }
+    return null;
+  }
+
+  static int bucketForNewProgress(
+    History history, {
+    required int episode,
+    String episodePageUrl = '',
+  }) {
+    final pageUrl = episodePageUrl.trim();
+    final existing = history.progresses[episode];
+    if (existing == null) {
+      return episode;
+    }
+    if (existing.episode == episode &&
+        (pageUrl.isEmpty ||
+            existing.episodePageUrl.isEmpty ||
+            existing.episodePageUrl == pageUrl)) {
+      return episode;
+    }
+
+    var bucket = episode;
+    while (history.progresses.containsKey(bucket)) {
+      bucket++;
+    }
+    return bucket;
+  }
+
+  _HistoryEpisodeMatcher._();
 }

--- a/lib/services/sync/history_sync_service.dart
+++ b/lib/services/sync/history_sync_service.dart
@@ -30,6 +30,7 @@ class HistorySyncService {
     required int episode,
     required int road,
     required int progressMs,
+    required String episodePageUrl,
     int? updatedAt,
   }) async {
     final deviceId = await getDeviceId();
@@ -46,6 +47,7 @@ class HistorySyncService {
         road: road,
         progressMs: progressMs,
         updatedAt: effectiveUpdatedAt,
+        episodePageUrl: episodePageUrl,
       ),
       HistorySyncEvent.upsertWatchState(
         deviceId: deviceId,
@@ -136,12 +138,13 @@ class HistorySyncService {
     final events = <HistorySyncEvent>[];
     for (final history in histories) {
       history.entryKind = HistoryEntryKind.normalize(history.entryKind);
-      for (final progress in history.progresses.values) {
+      for (final entry in history.progresses.entries) {
+        final progress = entry.value;
         final updatedAt = progress.effectiveUpdatedAtMs(history.lastWatchTime);
         events.add(
           HistorySyncEvent(
             eventId:
-                'local-state:${history.key}:${progress.episode}:${progress.road}',
+                'local-state:${history.key}:${entry.key}:${progress.episode}:${progress.road}',
             deviceId: 'local-state',
             seq: 0,
             op: HistorySyncOp.upsertProgress,
@@ -155,7 +158,7 @@ class HistorySyncService {
             lastSrc: history.lastSrc,
             lastWatchEpisodeName: history.lastWatchEpisodeName,
             entryKind: history.entryKind,
-            episodePageUrl: history.episodePageUrl,
+            episodePageUrl: progress.episodePageUrl,
           ),
         );
       }

--- a/test/episode_ref_test.dart
+++ b/test/episode_ref_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kazumi/modules/download/download_module.dart';
+import 'package:kazumi/modules/roads/road_module.dart';
 import 'package:kazumi/pages/player/controller/player_models.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 
@@ -52,6 +53,31 @@ void main() {
       expect(episode.originalRoadIndex, 2);
       expect(episode.listIndex, 1);
       expect(episode.pageUrl, '/episode/13');
+    });
+  });
+
+  group('findEpisodeSelectionByPageUrl', () {
+    test('locates the current road position after source reorder', () {
+      final roads = [
+        Road(
+          name: '播放线路1',
+          data: const ['/episode/3', '/episode/1'],
+          identifier: const ['第三话', '第一话'],
+        ),
+        Road(
+          name: '播放线路2',
+          data: const ['/episode/2'],
+          identifier: const ['第二话'],
+        ),
+      ];
+
+      final selection = findEpisodeSelectionByPageUrl(roads, '/episode/1');
+
+      expect(selection, isNotNull);
+      expect(selection!.road, 0);
+      expect(selection.episode, 2);
+      expect(findEpisodeSelectionByPageUrl(roads, ''), isNull);
+      expect(findEpisodeSelectionByPageUrl(roads, '/missing'), isNull);
     });
   });
 

--- a/test/history_repository_test.dart
+++ b/test/history_repository_test.dart
@@ -145,7 +145,422 @@ void main() {
       expect(history.lastWatchEpisode, 2);
       expect(history.lastWatchEpisodeName, 'EP2');
       expect(history.episodePageUrl, '/online/2');
+      expect(history.progresses[2]!.episodePageUrl, '/online/2');
       expect(history.progresses[2]!.progress.inSeconds, 30);
+    });
+
+    test('finds progress by page url before the old episode index', () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(4);
+      final history = History(
+        item,
+        2,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        'https://example.com/source',
+        'EP2',
+        episodePageUrl: '/online/2',
+      );
+      history.progresses[1] = Progress(
+        1,
+        0,
+        10 * 1000,
+        episodePageUrl: '/online/1',
+      );
+      history.progresses[2] = Progress(
+        2,
+        0,
+        20 * 1000,
+        episodePageUrl: '/online/2',
+      );
+      await historiesBox.put(history.key, history);
+
+      final progress = repository.findProgress(
+        item,
+        'plugin',
+        1,
+        episodePageUrl: '/online/2',
+      );
+
+      expect(progress, isNotNull);
+      expect(progress!.progress.inSeconds, 20);
+      expect(progress.episodePageUrl, '/online/2');
+    });
+
+    test('falls back to legacy int progress and backfills page url', () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(5);
+      final history = History(
+        item,
+        1,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        'https://example.com/source',
+        'EP1',
+        episodePageUrl: '/online/1',
+      );
+      history.progresses[1] = Progress(1, 0, 10 * 1000);
+      await historiesBox.put(history.key, history);
+
+      final progress = repository.findProgress(
+        item,
+        'plugin',
+        1,
+        episodePageUrl: '/online/1',
+      );
+
+      expect(progress, isNotNull);
+      expect(progress!.progress.inSeconds, 10);
+      expect(progress.episodePageUrl, '/online/1');
+      expect(historiesBox.get(history.key)!.progresses[1]!.episodePageUrl,
+          '/online/1');
+    });
+
+    test('does not overwrite an existing different page url bucket', () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(6);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/a',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1 new',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/b',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      final history = repository.getHistory('plugin', item)!;
+      expect(history.progresses, hasLength(2));
+      expect(
+        history.progresses.values
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/a',
+            )
+            .progress
+            .inSeconds,
+        10,
+      );
+      expect(
+        history.progresses.values
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/b',
+            )
+            .progress
+            .inSeconds,
+        20,
+      );
+    });
+
+    test('clears the progress matched by page url', () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(7);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/a',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1 new',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/b',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      await repository.clearProgress(
+        item,
+        'plugin',
+        1,
+        episodePageUrl: '/online/b',
+      );
+
+      final history = repository.getHistory('plugin', item)!;
+      expect(
+        history.progresses.values
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/a',
+            )
+            .progress
+            .inSeconds,
+        10,
+      );
+      expect(
+        history.progresses.values
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/b',
+            )
+            .progress,
+        Duration.zero,
+      );
+    });
+
+    test('empty page url ignores synthetic buckets for other episodes',
+        () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(8);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/a',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1 alt',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/b',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      expect(repository.findProgress(item, 'plugin', 2), isNull);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '',
+        ),
+        progress: const Duration(seconds: 30),
+      );
+
+      var history = repository.getHistory('plugin', item)!;
+      final urlProgress = history.progresses.values.singleWhere(
+        (progress) => progress.episodePageUrl == '/online/b',
+      );
+      final noUrlProgress = repository.findProgress(item, 'plugin', 2);
+
+      expect(urlProgress.episode, 1);
+      expect(urlProgress.progress.inSeconds, 20);
+      expect(noUrlProgress, isNotNull);
+      expect(noUrlProgress!.episode, 2);
+      expect(noUrlProgress.episodePageUrl, isEmpty);
+      expect(noUrlProgress.progress.inSeconds, 30);
+
+      await repository.clearProgress(item, 'plugin', 2);
+
+      history = repository.getHistory('plugin', item)!;
+      expect(
+        history.progresses.values
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/b',
+            )
+            .progress
+            .inSeconds,
+        20,
+      );
+      expect(
+          repository.findProgress(item, 'plugin', 2)!.progress, Duration.zero);
+    });
+
+    test('backfills synthetic legacy progress when page url appears later',
+        () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(9);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/a',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1 alt',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/b',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '',
+        ),
+        progress: const Duration(seconds: 30),
+      );
+
+      var history = repository.getHistory('plugin', item)!;
+      expect(history.progresses, hasLength(3));
+      expect(history.progresses[2]!.episode, 1);
+      expect(history.progresses[2]!.episodePageUrl, '/online/b');
+      expect(history.progresses[3]!.episode, 2);
+      expect(history.progresses[3]!.episodePageUrl, isEmpty);
+
+      final resumed = repository.findProgress(
+        item,
+        'plugin',
+        2,
+        episodePageUrl: '/online/2',
+      );
+      expect(resumed, isNotNull);
+      expect(resumed!.episode, 2);
+      expect(resumed.progress.inSeconds, 30);
+      expect(resumed.episodePageUrl, '/online/2');
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/2',
+        ),
+        progress: const Duration(seconds: 40),
+      );
+
+      history = repository.getHistory('plugin', item)!;
+      expect(history.progresses, hasLength(3));
+      expect(history.progresses[2]!.episode, 1);
+      expect(history.progresses[2]!.episodePageUrl, '/online/b');
+      expect(history.progresses[3]!.episode, 2);
+      expect(history.progresses[3]!.episodePageUrl, '/online/2');
+      expect(history.progresses[3]!.progress.inSeconds, 40);
+    });
+
+    test(
+        'last watching falls back to episode when latest watch has no page url',
+        () async {
+      final repository = HistoryRepository(
+        historiesBox: historiesBox,
+        privateModeReader: () => privateMode,
+        progressSyncAppender: _noopHistorySync,
+        deleteSyncAppender: _noopDeleteSync,
+        clearSyncAppender: _noopClearSync,
+      );
+      final item = _item(10);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '/online/a',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      final history = repository.getHistory('plugin', item)!;
+      final progress = repository.getLastWatchingProgress(item, 'plugin');
+
+      expect(history.lastWatchEpisode, 2);
+      expect(history.episodePageUrl, isEmpty);
+      expect(progress, isNotNull);
+      expect(progress!.episode, 2);
+      expect(progress.episodePageUrl, isEmpty);
+      expect(progress.progress.inSeconds, 20);
     });
 
     test('does not record history when private mode is enabled', () async {
@@ -184,6 +599,7 @@ Future<void> _noopHistorySync({
   required int road,
   required int progressMs,
   required int updatedAt,
+  required String episodePageUrl,
 }) async {}
 
 Future<void> _noopDeleteSync(History history) async {}

--- a/test/history_repository_test.dart
+++ b/test/history_repository_test.dart
@@ -591,6 +591,247 @@ void main() {
       expect(repository.getHistory('plugin', item), isNull);
     });
   });
+
+  group('HistoryRepository migrateProgressPageUrls', () {
+    HistoryRepository buildRepository() => HistoryRepository(
+          historiesBox: historiesBox,
+          privateModeReader: () => privateMode,
+          progressSyncAppender: _noopHistorySync,
+          deleteSyncAppender: _noopDeleteSync,
+          clearSyncAppender: _noopClearSync,
+        );
+
+    test('rewrites stale page url in place and reuses bucket on next update',
+        () async {
+      final repository = buildRepository();
+      final item = _item(20);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: 'https://old.example.com/play/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+
+      repository.migrateProgressPageUrls(
+        adapterName: 'plugin',
+        bangumiItem: item,
+        resolveCurrentPageUrl: (road, episode) =>
+            road == 0 && episode == 1 ? 'https://new.example.com/play/1' : '',
+      );
+
+      var history = repository.getHistory('plugin', item)!;
+      expect(history.progresses, hasLength(1));
+      expect(
+        history.progresses[1]!.episodePageUrl,
+        'https://new.example.com/play/1',
+      );
+
+      // 后续以新 URL 写入应复用既有桶，而非新建重复条目。
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: 'https://new.example.com/play/1',
+        ),
+        progress: const Duration(seconds: 30),
+      );
+
+      history = repository.getHistory('plugin', item)!;
+      expect(history.progresses, hasLength(1));
+      expect(history.progresses[1]!.progress.inSeconds, 30);
+      expect(
+        history.progresses[1]!.episodePageUrl,
+        'https://new.example.com/play/1',
+      );
+    });
+
+    test(
+        'migrates top-level history.episodePageUrl and keeps lastWatching match',
+        () async {
+      final repository = buildRepository();
+      final item = _item(21);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: 'https://old.example.com/play/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+
+      repository.migrateProgressPageUrls(
+        adapterName: 'plugin',
+        bangumiItem: item,
+        resolveCurrentPageUrl: (road, episode) =>
+            'https://new.example.com/play/$episode',
+      );
+
+      final history = repository.getHistory('plugin', item)!;
+      expect(history.episodePageUrl, 'https://new.example.com/play/1');
+
+      final resumed = repository.getLastWatchingProgress(item, 'plugin');
+      expect(resumed, isNotNull);
+      expect(resumed!.episode, 1);
+      expect(resumed.episodePageUrl, 'https://new.example.com/play/1');
+      expect(resumed.progress.inSeconds, 10);
+    });
+
+    test('uses progress road/episode not the bucket key for synthetic buckets',
+        () async {
+      final repository = buildRepository();
+      final item = _item(22);
+
+      // 模拟 bucketForNewProgress 递增产生的 synthetic bucket：
+      // map key (3) 不等于 Progress.episode (1)。
+      final history = History(
+        item,
+        1,
+        'plugin',
+        DateTime.now(),
+        'https://example.com/source',
+        'EP1',
+        entryKind: HistoryEntryKind.online,
+        episodePageUrl: 'https://old.example.com/play/1',
+      );
+      history.progresses[3] = Progress(
+        1,
+        0,
+        10000,
+        updatedAtMs: DateTime.now().millisecondsSinceEpoch,
+        episodePageUrl: 'https://old.example.com/play/1',
+      );
+      await historiesBox.put(history.key, history);
+
+      final resolverCalls = <String>[];
+      repository.migrateProgressPageUrls(
+        adapterName: 'plugin',
+        bangumiItem: item,
+        resolveCurrentPageUrl: (road, episode) {
+          resolverCalls.add('$road:$episode');
+          if (road == 0 && episode == 1) {
+            return 'https://new.example.com/play/1';
+          }
+          return '';
+        },
+      );
+
+      final stored = repository.getHistory('plugin', item)!;
+      expect(stored.progresses.containsKey(3), isTrue);
+      expect(stored.progresses[3]!.episode, 1);
+      expect(
+        stored.progresses[3]!.episodePageUrl,
+        'https://new.example.com/play/1',
+      );
+      // resolver 必须使用 Progress 值的 road/episode（1），而非 map key（3）。
+      expect(resolverCalls, contains('0:1'));
+      expect(resolverCalls, isNot(contains('0:3')));
+    });
+
+    test('collapses duplicate buckets keeping the newer progress', () async {
+      final repository = buildRepository();
+      final item = _item(23);
+
+      // 一个旧 URL 桶 + 一个过往升级已生成的新 URL 桶，迁移后应合并为一个。
+      final history = History(
+        item,
+        1,
+        'plugin',
+        DateTime.now(),
+        'https://example.com/source',
+        'EP1',
+        entryKind: HistoryEntryKind.online,
+        episodePageUrl: 'https://new.example.com/play/1',
+      );
+      history.progresses[1] = Progress(
+        1,
+        0,
+        30000,
+        updatedAtMs: 2000,
+        episodePageUrl: 'https://old.example.com/play/1',
+      );
+      history.progresses[2] = Progress(
+        1,
+        0,
+        20000,
+        updatedAtMs: 1000,
+        episodePageUrl: 'https://new.example.com/play/1',
+      );
+      await historiesBox.put(history.key, history);
+
+      repository.migrateProgressPageUrls(
+        adapterName: 'plugin',
+        bangumiItem: item,
+        resolveCurrentPageUrl: (road, episode) =>
+            'https://new.example.com/play/1',
+      );
+
+      final stored = repository.getHistory('plugin', item)!;
+      expect(stored.progresses, hasLength(1));
+      final survivor = stored.progresses.values.single;
+      expect(survivor.episodePageUrl, 'https://new.example.com/play/1');
+      expect(survivor.progress.inSeconds, 30);
+    });
+
+    test('leaves entries untouched when resolver or stored url is empty',
+        () async {
+      final repository = buildRepository();
+      final item = _item(24);
+
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 1,
+          episodeTitle: 'EP1',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: 'https://old.example.com/play/1',
+        ),
+        progress: const Duration(seconds: 10),
+      );
+      await repository.updateHistory(
+        identity: PlaybackHistoryIdentity.online(
+          bangumiItem: item,
+          pluginName: 'plugin',
+          episodeNumber: 2,
+          episodeTitle: 'EP2',
+          road: 0,
+          onlineBangumiSrc: 'https://example.com/source',
+          episodePageUrl: '',
+        ),
+        progress: const Duration(seconds: 20),
+      );
+
+      repository.migrateProgressPageUrls(
+        adapterName: 'plugin',
+        bangumiItem: item,
+        resolveCurrentPageUrl: (road, episode) => '',
+      );
+
+      final history = repository.getHistory('plugin', item)!;
+      expect(
+        history.progresses[1]!.episodePageUrl,
+        'https://old.example.com/play/1',
+      );
+      expect(history.progresses[2]!.episodePageUrl, isEmpty);
+    });
+  });
 }
 
 Future<void> _noopHistorySync({

--- a/test/history_sync_test.dart
+++ b/test/history_sync_test.dart
@@ -364,7 +364,8 @@ void main() {
 
       final history = merged.histories.single;
       expect(history.entryKind, HistoryEntryKind.offline);
-      expect(history.episodePageUrl, '/episode/1');
+      expect(history.episodePageUrl, isEmpty);
+      expect(history.progresses[1]!.episodePageUrl, '/episode/1');
     });
 
     test('keeps online and offline progress separate for the same episode', () {
@@ -410,6 +411,174 @@ void main() {
       );
       expect(online.progresses[1]!.progress.inSeconds, 10);
       expect(offline.progresses[1]!.progress.inSeconds, 20);
+    });
+
+    test('matches progress by page url when episode index changes', () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 2,
+            progressMs: 10 * 1000,
+            episodePageUrl: '/online/2',
+          ),
+          _upsert(
+            deviceId: 'device-b',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 1,
+            progressMs: 20 * 1000,
+            episodePageUrl: '/online/2',
+          ),
+        ],
+      );
+
+      final progress = merged.histories.single.progresses.values.single;
+      expect(progress.episode, 1);
+      expect(progress.episodePageUrl, '/online/2');
+      expect(progress.progress.inSeconds, 20);
+    });
+
+    test('keeps different page urls separate when episode index collides', () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 1,
+            progressMs: 10 * 1000,
+            episodePageUrl: '/online/a',
+          ),
+          _upsert(
+            deviceId: 'device-b',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 1,
+            progressMs: 20 * 1000,
+            episodePageUrl: '/online/b',
+          ),
+        ],
+      );
+
+      final progresses = merged.histories.single.progresses.values;
+      expect(progresses, hasLength(2));
+      expect(
+        progresses
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/a',
+            )
+            .progress
+            .inSeconds,
+        10,
+      );
+      expect(
+        progresses
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/b',
+            )
+            .progress
+            .inSeconds,
+        20,
+      );
+    });
+
+    test('empty page url upsert ignores synthetic buckets for other episodes',
+        () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 1,
+            progressMs: 10 * 1000,
+            episodePageUrl: '/online/a',
+          ),
+          _upsert(
+            deviceId: 'device-b',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 1,
+            progressMs: 20 * 1000,
+            episodePageUrl: '/online/b',
+          ),
+          _upsert(
+            deviceId: 'device-c',
+            seq: 1,
+            updatedAt: 3000,
+            episode: 2,
+            progressMs: 30 * 1000,
+          ),
+        ],
+      );
+
+      final progresses = merged.histories.single.progresses.values;
+      expect(progresses, hasLength(3));
+      expect(
+        progresses
+            .singleWhere(
+              (progress) => progress.episodePageUrl == '/online/b',
+            )
+            .episode,
+        1,
+      );
+      final noUrlProgress = progresses.singleWhere(
+        (progress) => progress.episode == 2 && progress.episodePageUrl.isEmpty,
+      );
+      expect(noUrlProgress.progress.inSeconds, 30);
+    });
+
+    test('backfills synthetic legacy progress when page url appears later', () {
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.empty(),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 1000,
+            episode: 1,
+            progressMs: 10 * 1000,
+            episodePageUrl: '/online/a',
+          ),
+          _upsert(
+            deviceId: 'device-b',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 1,
+            progressMs: 20 * 1000,
+            episodePageUrl: '/online/b',
+          ),
+          _upsert(
+            deviceId: 'device-c',
+            seq: 1,
+            updatedAt: 3000,
+            episode: 2,
+            progressMs: 30 * 1000,
+          ),
+          _upsert(
+            deviceId: 'device-d',
+            seq: 1,
+            updatedAt: 4000,
+            episode: 2,
+            progressMs: 40 * 1000,
+            episodePageUrl: '/online/2',
+          ),
+        ],
+      );
+
+      final history = merged.histories.single;
+      expect(history.progresses, hasLength(3));
+      expect(history.progresses[2]!.episode, 1);
+      expect(history.progresses[2]!.episodePageUrl, '/online/b');
+      expect(history.progresses[3]!.episode, 2);
+      expect(history.progresses[3]!.episodePageUrl, '/online/2');
+      expect(history.progresses[3]!.progress.inSeconds, 40);
     });
 
     test('canonicalizes legacy snapshot keys to online scoped keys', () {
@@ -527,6 +696,42 @@ void main() {
       expect(mergedHistory.progresses[7]!.progress.inSeconds, 7);
     });
 
+    test('upsertProgress clears stale progress page url when payload has none',
+        () {
+      final history = History(
+        _item(1),
+        5,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        'https://example.com/video',
+        'EP5',
+        episodePageUrl: '/episode/5',
+      );
+      history.progresses[5] = Progress(
+        5,
+        0,
+        5 * 1000,
+        episodePageUrl: '/episode/5',
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.fromHistories([history]),
+        events: [
+          _upsert(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 5,
+            progressMs: 7 * 1000,
+          ),
+        ],
+      );
+
+      final progress = merged.histories.single.progresses[5]!;
+      expect(progress.progress.inSeconds, 7);
+      expect(progress.episodePageUrl, isEmpty);
+    });
+
     test('upsertWatchState updates latest episode metadata', () {
       final history = History(
         _item(1),
@@ -557,6 +762,41 @@ void main() {
       expect(mergedHistory.lastWatchEpisodeName, 'EP7');
     });
 
+    test('upsertWatchState clears stale page url when latest watch has none',
+        () {
+      final history = History(
+        _item(1),
+        5,
+        'plugin',
+        DateTime.fromMillisecondsSinceEpoch(1000),
+        'https://example.com/video',
+        'EP5',
+        episodePageUrl: '/episode/5',
+      );
+      history.progresses[5] = Progress(
+        5,
+        0,
+        5 * 1000,
+        episodePageUrl: '/episode/5',
+      );
+
+      final merged = HistorySyncMerger.merge(
+        snapshot: HistorySyncSnapshot.fromHistories([history]),
+        events: [
+          _watchState(
+            deviceId: 'device-a',
+            seq: 1,
+            updatedAt: 2000,
+            episode: 7,
+          ),
+        ],
+      );
+
+      final mergedHistory = merged.histories.single;
+      expect(mergedHistory.lastWatchEpisode, 7);
+      expect(mergedHistory.episodePageUrl, isEmpty);
+    });
+
     test('legacy upsertProgress payload can still update watch state', () {
       final legacyEvent = _legacyUpsert(
         deviceId: 'device-a',
@@ -582,6 +822,29 @@ void main() {
   });
 
   group('HistorySyncCodec', () {
+    test('round-trips progress page url and accepts legacy progress json', () {
+      final progress = Progress(
+        2,
+        1,
+        30 * 1000,
+        updatedAtMs: 4000,
+        episodePageUrl: '/episode/2',
+      );
+
+      final restored = HistorySyncCodec.progressFromJson(
+        HistorySyncCodec.progressToJson(progress),
+      );
+      final legacy = HistorySyncCodec.progressFromJson({
+        'episode': 1,
+        'road': 0,
+        'progressMs': 10 * 1000,
+      });
+
+      expect(restored.episodePageUrl, '/episode/2');
+      expect(restored.progress.inSeconds, 30);
+      expect(legacy.episodePageUrl, isEmpty);
+    });
+
     test('round-trips events through json lines', () {
       final events = [
         _upsert(
@@ -590,6 +853,7 @@ void main() {
           updatedAt: 1000,
           episode: 1,
           progressMs: 10,
+          episodePageUrl: '/episode/1',
         ),
         _watchState(
           deviceId: 'device-a',
@@ -615,6 +879,7 @@ void main() {
         HistorySyncOp.clearAll,
       ]);
       expect(restored.first.bangumiItem!.id, 1);
+      expect(restored.first.episodePageUrl, '/episode/1');
     });
   });
 
@@ -635,6 +900,7 @@ void main() {
         2,
         20 * 1000,
         updatedAtMs: 2500,
+        episodePageUrl: '/offline/progress-1',
       );
 
       final events =
@@ -649,7 +915,7 @@ void main() {
       );
       expect(progressEvent.entityKey, history.key);
       expect(progressEvent.entryKind, HistoryEntryKind.offline);
-      expect(progressEvent.episodePageUrl, '/offline/1');
+      expect(progressEvent.episodePageUrl, '/offline/progress-1');
       expect(progressEvent.updatedAt, 2500);
       expect(progressEvent.progressMs, 20 * 1000);
       expect(watchStateEvent.entryKind, HistoryEntryKind.offline);
@@ -705,6 +971,7 @@ HistorySyncEvent _upsert({
     0,
     progressMs,
     updatedAtMs: updatedAt,
+    episodePageUrl: episodePageUrl,
   );
   return HistorySyncEvent.upsertProgress(
     deviceId: deviceId,
@@ -714,6 +981,7 @@ HistorySyncEvent _upsert({
     road: 0,
     progressMs: progressMs,
     updatedAt: updatedAt,
+    episodePageUrl: episodePageUrl,
   );
 }
 


### PR DESCRIPTION
## 摘要

本 PR 为统一集数身份的 PR3：历史进度记录新增单条 `Progress.episodePageUrl`，让播放历史在同一集数编号但不同页面 URL 的场景下可以按 URL 精确恢复。

## 主要变更

- 为 `Progress` 持久化 `episodePageUrl`，并保持旧数据缺字段时默认为空字符串。
- 历史仓储查询、更新和清除进度时优先按 URL 匹配；URL 不存在或旧数据未写入时回退到原有集数匹配，并在安全路径懒回填 URL。
- 在线播放恢复时优先通过 `episodePageUrl` 在当前分线路列表中重新定位，源列表重排后仍能恢复到正确条目。
- 历史同步的 progress payload 复用 `episodePageUrl` 表示单条进度 URL，watch-state 仍表示最后观看 URL；旧 payload 缺字段继续兼容。
- 补充仓储、同步和播放定位测试，覆盖 URL 优先、旧数据回填、synthetic bucket 以及同步 JSON 兼容场景。

## 兼容性

- 不做全量 Hive 扫描迁移；旧历史数据通过查询、更新、同步路径懒回填。
- 空 URL 调用仍保留旧的集数回退行为，不覆盖已有不同 URL 的进度记录。

## 验证

- `flutter test test/history_repository_test.dart test/history_sync_test.dart test/episode_ref_test.dart test/episode_url_test.dart`
- `flutter analyze --no-fatal-infos`