### PR TITLE
Fix Windows nested video source resolution

### DIFF
--- a/lib/utils/media.dart
+++ b/lib/utils/media.dart
@@ -3,25 +3,120 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
-String decodeVideoSource(String iframeUrl) {
-  final decodedUrl = Uri.decodeFull(iframeUrl);
-  final regExp = RegExp(
-    r'(http[s]?://.*?\.m3u8)|(http[s]?://.*?\.mp4)',
-    caseSensitive: false,
-  );
+final RegExp _embeddedVideoSourceRegExp = RegExp(
+  r"""((?:https?:)?//[^\s'"<>]+?\.(?:m3u8|mp4)(?:[^\s'"<>]*)?)""",
+  caseSensitive: false,
+);
 
-  final uri = Uri.parse(decodedUrl);
-  final params = uri.queryParameters;
+/// Extracts either a direct media URL or one nested inside a parser URL.
+String? extractVideoSourceUrl(String source) {
+  final nestedUrl = extractNestedVideoSourceUrl(source);
+  if (nestedUrl != null) {
+    return nestedUrl;
+  }
 
-  var matchedUrl = iframeUrl;
-  params.forEach((key, value) {
-    if (regExp.hasMatch(value)) {
-      matchedUrl = value;
-      return;
+  final rawUri = Uri.tryParse(source);
+  if (rawUri != null) {
+    if (_isDirectVideoSourceUri(rawUri)) {
+      return rawUri.toString();
     }
-  });
+  }
 
-  return Uri.encodeFull(matchedUrl);
+  final decodedSource = _decodeFullSafe(source);
+  final decodedUri = Uri.tryParse(decodedSource);
+  if (decodedUri != null) {
+    if (_isDirectVideoSourceUri(decodedUri)) {
+      return decodedUri.toString();
+    }
+  }
+
+  return null;
+}
+
+/// Extracts only media URLs embedded inside another source/parser URL.
+///
+/// Direct media URLs intentionally return null so generic source-load events do
+/// not preempt the dedicated media source handlers.
+String? extractNestedVideoSourceUrl(String source) {
+  final rawUri = Uri.tryParse(source);
+  if (rawUri != null) {
+    if (_isDirectVideoSourceUri(rawUri)) {
+      return null;
+    }
+    final nestedUrl = _extractFromQueryParameters(rawUri);
+    if (nestedUrl != null) {
+      return nestedUrl;
+    }
+  }
+
+  final decodedSource = _decodeFullSafe(source);
+  final decodedUri = Uri.tryParse(decodedSource);
+  if (decodedUri != null) {
+    if (_isDirectVideoSourceUri(decodedUri)) {
+      return null;
+    }
+    final nestedUrl = _extractFromQueryParameters(decodedUri);
+    if (nestedUrl != null) {
+      return nestedUrl;
+    }
+  }
+
+  final match = _embeddedVideoSourceRegExp.firstMatch(decodedSource);
+  final embeddedUrl = match?.group(1);
+  if (embeddedUrl == null || !_isDirectVideoSourceUrl(embeddedUrl)) {
+    return null;
+  }
+  final normalizedEmbeddedUrl = Uri.encodeFull(embeddedUrl);
+  if (normalizedEmbeddedUrl == _normalizeDirectVideoSourceUrl(source) ||
+      normalizedEmbeddedUrl == _normalizeDirectVideoSourceUrl(decodedSource)) {
+    return null;
+  }
+  return normalizedEmbeddedUrl;
+}
+
+String decodeVideoSource(String iframeUrl) {
+  return extractVideoSourceUrl(iframeUrl) ?? Uri.encodeFull(iframeUrl);
+}
+
+bool _isDirectVideoSourceUrl(String source) {
+  final uri = Uri.tryParse(source);
+  return uri != null && _isDirectVideoSourceUri(uri);
+}
+
+String? _normalizeDirectVideoSourceUrl(String source) {
+  final uri = Uri.tryParse(source);
+  if (uri == null || !_isDirectVideoSourceUri(uri)) {
+    return null;
+  }
+  return uri.toString();
+}
+
+String? _extractFromQueryParameters(Uri uri) {
+  for (final value in uri.queryParameters.values) {
+    final decodedValue = _decodeFullSafe(value);
+    if (_isDirectVideoSourceUrl(decodedValue)) {
+      return Uri.encodeFull(decodedValue);
+    }
+  }
+  return null;
+}
+
+String _decodeFullSafe(String value) {
+  try {
+    return Uri.decodeFull(value);
+  } on FormatException {
+    return value;
+  } on ArgumentError {
+    return value;
+  }
+}
+
+bool _isDirectVideoSourceUri(Uri uri) {
+  if (!uri.hasScheme && uri.host.isEmpty) {
+    return false;
+  }
+  final path = uri.path.toLowerCase();
+  return path.endsWith('.m3u8') || path.endsWith('.mp4');
 }
 
 int extractEpisodeNumber(String input) {

--- a/lib/webview/video/impl/video_webview_windows_impl.dart
+++ b/lib/webview/video/impl/video_webview_windows_impl.dart
@@ -4,6 +4,7 @@ import 'package:kazumi/webview/video/video_webview_controller.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/services/network/proxy_utils.dart';
 import 'package:kazumi/services/logging/logger.dart';
+import 'package:kazumi/utils/media.dart';
 
 class VideoWebviewWindowsImpl
     extends VideoWebviewController<WebviewController> {
@@ -51,33 +52,43 @@ class VideoWebviewWindowsImpl
     isIframeLoaded = false;
     isVideoSourceLoaded = false;
     videoLoadingEventController.add(true);
-    subscriptions.add(headlessWebview!.onM3USourceLoaded.listen((data) {
-      if (headlessWebview == null) return;
-      String url = data['url'] ?? '';
-      if (url.isEmpty) {
+    subscriptions.add(headlessWebview!.onSourceLoaded.listen((data) async {
+      final sourceUrl = data['url'] ?? '';
+      final videoSourceUrl = extractNestedVideoSourceUrl(sourceUrl);
+      if (videoSourceUrl == null) {
         return;
       }
-      unloadPage();
-      isIframeLoaded = true;
-      isVideoSourceLoaded = true;
-      videoLoadingEventController.add(false);
-      logEventController.add('Loading m3u8 source: $url');
-      videoParserEventController.add((url, offset));
+      await _completeVideoSource(
+        videoSourceUrl,
+        offset,
+        'Loading nested video source: $videoSourceUrl',
+      );
     }));
-    subscriptions.add(headlessWebview!.onVideoSourceLoaded.listen((data) {
-      if (headlessWebview == null) return;
-      String url = data['url'] ?? '';
-      if (url.isEmpty) {
-        return;
-      }
-      unloadPage();
-      isIframeLoaded = true;
-      isVideoSourceLoaded = true;
-      videoLoadingEventController.add(false);
-      logEventController.add('Loading video source: $url');
-      videoParserEventController.add((url, offset));
+    subscriptions.add(headlessWebview!.onM3USourceLoaded.listen((data) async {
+      final url = data['url'] ?? '';
+      await _completeVideoSource(url, offset, 'Loading m3u8 source: $url');
+    }));
+    subscriptions.add(headlessWebview!.onVideoSourceLoaded.listen((data) async {
+      final url = data['url'] ?? '';
+      await _completeVideoSource(url, offset, 'Loading video source: $url');
     }));
     await headlessWebview!.loadUrl(url);
+  }
+
+  Future<void> _completeVideoSource(
+    String url,
+    int offset,
+    String logMessage,
+  ) async {
+    if (headlessWebview == null || isVideoSourceLoaded || url.isEmpty) {
+      return;
+    }
+    isIframeLoaded = true;
+    isVideoSourceLoaded = true;
+    videoLoadingEventController.add(false);
+    logEventController.add(logMessage);
+    videoParserEventController.add((url, offset));
+    await unloadPage();
   }
 
   @override

--- a/test/video_source_url_test.dart
+++ b/test/video_source_url_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/utils/media.dart';
+
+void main() {
+  group('video source URL extraction', () {
+    test('extracts nested mp4 URL from parser request query', () {
+      const parserUrl =
+          'https://player.moedot.net/player/ec.php?code=xfdm1&from=cf&url=https://play.xfvod.pro:8088/G/foo%20bar.mp4';
+
+      expect(
+        extractVideoSourceUrl(parserUrl),
+        'https://play.xfvod.pro:8088/G/foo%20bar.mp4',
+      );
+    });
+
+    test('extracts xfdm-style encoded file names from parser request query',
+        () {
+      const parserUrl =
+          'https://player.moedot.net/player/ec.php?code=xfdm1&from=cf&url=https://play.xfvod.pro:8088/G/G-%E6%94%BB%E5%A3%B3/%5BSHANA%5D%5BStand_Alone_Complex%5D%5B13%5D%5B1080P%5D.mp4';
+
+      expect(
+        extractVideoSourceUrl(parserUrl),
+        'https://play.xfvod.pro:8088/G/G-%E6%94%BB%E5%A3%B3/%5BSHANA%5D%5BStand_Alone_Complex%5D%5B13%5D%5B1080P%5D.mp4',
+      );
+    });
+
+    test('extracts nested m3u8 URL from parser request query', () {
+      const parserUrl =
+          'https://example.com/player.php?url=https://cdn.example.com/live/index.m3u8';
+
+      expect(
+        extractVideoSourceUrl(parserUrl),
+        'https://cdn.example.com/live/index.m3u8',
+      );
+    });
+
+    test('extracts nested media URL with query tokens', () {
+      const parserUrl =
+          'https://example.com/player.php?url=https://cdn.example.com/video.mp4?token=abc';
+
+      expect(
+        extractVideoSourceUrl(parserUrl),
+        'https://cdn.example.com/video.mp4?token=abc',
+      );
+    });
+
+    test('extracts percent-encoded nested media URL', () {
+      const parserUrl =
+          'https://example.com/player.php?url=https%3A%2F%2Fcdn.example.com%2Fvideo.mp4%3Ftoken%3Dabc';
+
+      expect(
+        extractVideoSourceUrl(parserUrl),
+        'https://cdn.example.com/video.mp4?token=abc',
+      );
+    });
+
+    test('returns direct media URLs unchanged', () {
+      expect(
+        extractVideoSourceUrl('https://example.com/video.m3u8'),
+        'https://example.com/video.m3u8',
+      );
+      expect(
+        extractVideoSourceUrl('https://example.com/video.mp4'),
+        'https://example.com/video.mp4',
+      );
+      expect(
+        extractVideoSourceUrl('//cdn.example.com/video.mp4'),
+        '//cdn.example.com/video.mp4',
+      );
+    });
+
+    test('nested extraction ignores direct media URLs', () {
+      expect(
+        extractNestedVideoSourceUrl('https://example.com/video.m3u8'),
+        isNull,
+      );
+      expect(
+        extractNestedVideoSourceUrl('https://example.com/video.mp4?token=abc'),
+        isNull,
+      );
+    });
+
+    test('nested extraction ignores direct media URLs with media fallback query',
+        () {
+      const directUrl =
+          'https://cdn.example.com/video.mp4?fallback=https%3A%2F%2Fcdn.example.com%2Fbackup.mp4';
+
+      expect(extractNestedVideoSourceUrl(directUrl), isNull);
+      expect(extractVideoSourceUrl(directUrl), directUrl);
+    });
+
+    test('ignores ordinary page and asset URLs', () {
+      expect(
+        extractVideoSourceUrl('https://dm1.xfdm.pro/watch/907/1/13.html'),
+        isNull,
+      );
+      expect(
+        extractVideoSourceUrl('https://dm1.xfdm.pro/static/player.js'),
+        isNull,
+      );
+    });
+
+    test('decodeVideoSource preserves legacy no-match encoding behavior', () {
+      expect(
+        decodeVideoSource('https://example.com/watch/foo bar.html'),
+        'https://example.com/watch/foo%20bar.html',
+      );
+    });
+
+    test('decodeVideoSource still extracts nested media URLs', () {
+      const parserUrl =
+          'https://example.com/player.php?url=https://cdn.example.com/video.mp4?token=abc';
+
+      expect(
+        decodeVideoSource(parserUrl),
+        'https://cdn.example.com/video.mp4?token=abc',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extract mp4/m3u8 URLs nested inside player/parser request URLs.
- Keep direct media URLs on Windows handled by the existing dedicated `onM3USourceLoaded` / `onVideoSourceLoaded` paths.
- Route all Windows source-completion paths through one guarded helper so only one parser event is emitted per load.
- Preserve `decodeVideoSource()` fallback encoding behavior and add coverage for nested m3u8, query tokens, percent-encoded URLs, scheme-relative direct URLs, and direct URL handling.

## Root cause
Some player pages load an HTML parser URL whose query parameters already contain the final media URL. On Windows, the resolver only handled dedicated m3u8/video source events, so these pages could time out even though the WebView had already observed a reachable mp4/m3u8 URL inside the request URL.

## Validation
- `flutter test`
- `flutter analyze --no-fatal-infos --fatal-warnings`
- `flutter build windows --debug`
- Manual Windows playback and download validation for a nested mp4 source that previously timed out during resolution.