### PR TITLE
2302-底部UI在发送弹幕后无法自动收起

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -62,10 +62,10 @@ class PlayerItem extends StatefulWidget {
   final Future<void> Function(int episode, {int currentRoad, int offset})
       changeEpisode;
   final void Function(BuildContext) onBackPressed;
-  final void Function(String) sendDanmaku;
+  final bool Function(String) sendDanmaku;
   final FocusNode keyboardFocus;
   final bool disableAnimations;
-  final void Function(String) showDanmakuDestinationPickerAndSend;
+  final Future<bool> Function(String) showDanmakuDestinationPickerAndSend;
   final VoidCallback pauseForTimedShutdown;
 
   @override

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -71,11 +72,11 @@ class PlayerItemPanel extends StatefulWidget {
   final void Function() handleDanmaku;
   final void Function(String direction) handlePreNextEpisode;
   final void Function() skipOP;
-  final void Function(String) sendDanmaku;
+  final bool Function(String) sendDanmaku;
   final void Function() showVideoInfo;
   final void Function() showSyncPlayRoomCreateDialog;
   final void Function() showSyncPlayEndPointSwitchDialog;
-  final void Function(String) showDanmakuDestinationPickerAndSend;
+  final Future<bool> Function(String) showDanmakuDestinationPickerAndSend;
   final VoidCallback pauseForTimedShutdown;
   final bool disableAnimations;
 
@@ -125,6 +126,19 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
     _danmakuTextFieldHold = null;
   }
 
+  Future<void> _submitDanmakuText(String message) async {
+    textFieldFocus.unfocus();
+    _releaseDanmakuTextFieldPanel();
+
+    final sent = await widget.showDanmakuDestinationPickerAndSend(message);
+    if (!mounted) {
+      return;
+    }
+    if (sent) {
+      textController.clear();
+    }
+  }
+
   Widget get danmakuTextField {
     return Observer(builder: (context) {
       return Container(
@@ -161,10 +175,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
               children: [
                 TextButton(
                   onPressed: () {
-                    textFieldFocus.unfocus();
-                    widget.showDanmakuDestinationPickerAndSend(
-                        textController.text);
-                    textController.clear();
+                    unawaited(_submitDanmakuText(textController.text));
                   },
                   style: TextButton.styleFrom(
                     foregroundColor: playerController.danmaku.danmakuOn
@@ -187,10 +198,7 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
             _holdDanmakuTextFieldPanel();
           },
           onSubmitted: (msg) {
-            textFieldFocus.unfocus();
-            widget.showDanmakuDestinationPickerAndSend(msg);
-            _releaseDanmakuTextFieldPanel();
-            textController.clear();
+            unawaited(_submitDanmakuText(msg));
           },
           onTapOutside: (_) {
             _releaseDanmakuTextFieldPanel();

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -449,24 +449,24 @@ class _VideoPageState extends State<VideoPage>
     }
   }
 
-  void sendDanmaku(String msg) async {
+  bool sendDanmaku(String msg) {
     final playerController = _playerController;
     if (playerController == null) {
-      return;
+      return false;
     }
     keyboardFocus.requestFocus();
     if (playerController.danmaku.danDanmakus.isEmpty) {
       KazumiDialog.showToast(
         message: '当前剧集不支持弹幕发送的说',
       );
-      return;
+      return false;
     }
     if (msg.isEmpty) {
       KazumiDialog.showToast(message: '弹幕内容为空');
-      return;
+      return false;
     } else if (msg.length > 100) {
       KazumiDialog.showToast(message: '弹幕内容过长');
-      return;
+      return false;
     }
 
     final destination = playerController.danmaku.danmakuDestination;
@@ -474,7 +474,7 @@ class _VideoPageState extends State<VideoPage>
     if (destination == DanmakuDestination.chatRoom) {
       if (playerController.syncplay.syncplayRoom.isEmpty) {
         KazumiDialog.showToast(message: '你还没有加入一起看，无法发送聊天室弹幕');
-        return;
+        return false;
       }
 
       final sender =
@@ -491,13 +491,15 @@ class _VideoPageState extends State<VideoPage>
         ),
       );
 
-      playerController.sendSyncPlayChatMessage(msg);
+      unawaited(playerController.sendSyncPlayChatMessage(msg));
     } else {
       // The remote danmaku provider does not expose a send API here; render the
       // local echo so the user still sees their message immediately.
       playerController.danmaku.canvasController
           .addDanmaku(DanmakuContentItem(msg, selfSend: true));
     }
+
+    return true;
   }
 
   Future<void> showMobileDanmakuInput() async {
@@ -551,17 +553,17 @@ class _VideoPageState extends State<VideoPage>
     if (!mounted || message == null) {
       return;
     }
-    showDanmakuDestinationPickerAndSend(message);
+    await showDanmakuDestinationPickerAndSend(message);
   }
 
-  void showDanmakuDestinationPickerAndSend(String msg) async {
+  Future<bool> showDanmakuDestinationPickerAndSend(String msg) async {
     final playerController = _playerController;
     if (playerController == null) {
-      return;
+      return false;
     }
     if (msg.trim().isEmpty) {
       KazumiDialog.showToast(message: '弹幕内容为空');
-      return;
+      return false;
     }
 
     final DanmakuDestination? result =
@@ -612,14 +614,13 @@ class _VideoPageState extends State<VideoPage>
       },
     );
 
-    if (result != null) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {});
-      playerController.danmaku.danmakuDestination = result;
-      sendDanmaku(msg);
+    if (result == null || !mounted) {
+      return false;
     }
+
+    setState(() {});
+    playerController.danmaku.danmakuDestination = result;
+    return sendDanmaku(msg);
   }
 
   @override


### PR DESCRIPTION
issue: https://github.com/Predidit/Kazumi/issues/2302

## 原因
点击弹幕输入框会申请 `PlayerPanelHold`，原发送路径没有可靠释放 hold，可能导致播放器控制 UI 无法通过等待或点击空白区域隐藏。取消发送时原逻辑也会提前清空输入内容。

## 验证
- `dart format --output=none --set-exit-if-changed lib\pages\player\player_item_panel.dart lib\pages\player\player_item.dart lib\pages\video\video_page.dart`
- `dart analyze lib\pages\player\player_item_panel.dart lib\pages\player\player_item.dart lib\pages\video\video_page.dart`
- `git diff --check`