### PR TITLE
feat: show exact airing times（新番显示具体放送时间）

### DIFF
--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -4,6 +4,7 @@ import 'package:kazumi/bean/widget/collect_button.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
+import 'package:kazumi/request/apis/anilist_api.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -26,6 +27,54 @@ class BangumiInfoCardV extends StatefulWidget {
 
 class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
   int touchedIndex = -1;
+  DateTime? airingTime;
+  int? _lookupBangumiId;
+  String _lookupAirDate = '';
+  int _airingTimeRequestId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAiringTime();
+  }
+
+  @override
+  void didUpdateWidget(covariant BangumiInfoCardV oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _loadAiringTime();
+  }
+
+  Future<void> _loadAiringTime() async {
+    final item = widget.bangumiItem;
+    if (_lookupBangumiId == item.id && _lookupAirDate == item.airDate) {
+      return;
+    }
+
+    _lookupBangumiId = item.id;
+    _lookupAirDate = item.airDate;
+    final requestId = ++_airingTimeRequestId;
+    airingTime = null;
+
+    final time = await AniListApi.getAiringTime(item);
+    if (!mounted || requestId != _airingTimeRequestId) return;
+    setState(() => airingTime = time);
+  }
+
+  String get airingTimeText {
+    final time = airingTime!;
+    const weekdays = <String>[
+      '周一',
+      '周二',
+      '周三',
+      '周四',
+      '周五',
+      '周六',
+      '周日',
+    ];
+    return '${weekdays[time.weekday - 1]} '
+        '${time.hour.toString().padLeft(2, '0')}:'
+        '${time.minute.toString().padLeft(2, '0')}';
+  }
 
   Widget get voteBarChart {
     return Flexible(
@@ -183,6 +232,18 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                             ),
+                            if (airingTime != null && !widget.isLoading) ...[
+                              SizedBox(height: 8),
+                              Text('更新时间:'),
+                              Text(
+                                airingTimeText,
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: Theme.of(context).colorScheme.primary,
+                                ),
+                              ),
+                            ],
                             SizedBox(height: 8),
                             Text(
                               widget.showRating

--- a/lib/bean/card/bangumi_timeline_card.dart
+++ b/lib/bean/card/bangumi_timeline_card.dart
@@ -10,6 +10,7 @@ class BangumiTimelineCard extends StatelessWidget {
     super.key,
     required this.bangumiItem,
     required this.showRating,
+    this.airingTime,
     this.onTap,
     this.cardHeight = 120,
     this.cardWidth,
@@ -18,6 +19,7 @@ class BangumiTimelineCard extends StatelessWidget {
 
   final BangumiItem bangumiItem;
   final bool showRating;
+  final DateTime? airingTime;
   final VoidCallback? onTap;
   final bool enableHero;
   final double cardHeight;
@@ -201,8 +203,22 @@ class BangumiTimelineCard extends StatelessWidget {
             label: votesText,
             textStyle: metricStyle,
           ),
+        if (airingTime != null)
+          buildMetric(
+            context,
+            icon: Icons.schedule_outlined,
+            iconColor: colorScheme.tertiary,
+            label: _formatAiringTime(airingTime!),
+            textStyle: metricStyle,
+          ),
       ],
     );
+  }
+
+  String _formatAiringTime(DateTime time) {
+    final hour = time.hour.toString().padLeft(2, '0');
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
   }
 
   Widget buildMetric(

--- a/lib/pages/timeline/timeline_controller.dart
+++ b/lib/pages/timeline/timeline_controller.dart
@@ -71,6 +71,7 @@ abstract class _TimelineController with Store {
     isTimeOut = false;
     bangumiCalendar.clear();
     airingTimes.clear();
+    unawaited(AniListApi.preloadSeason(_selectedDate));
     final resBangumiCalendar = await BangumiApi.getCalendar();
     if (requestId != _scheduleRequestId) return;
     bangumiCalendar.clear();
@@ -84,6 +85,7 @@ abstract class _TimelineController with Store {
   @action
   Future<void> getSchedulesBySeason() async {
     final requestId = ++_scheduleRequestId;
+    unawaited(AniListApi.preloadSeason(selectedDate));
     if (_bangumiMirrorEnabled) {
       isLoading = true;
       isTimeOut = false;

--- a/lib/pages/timeline/timeline_controller.dart
+++ b/lib/pages/timeline/timeline_controller.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/anilist_api.dart';
 import 'package:kazumi/request/apis/bangumi_api.dart';
 import 'package:kazumi/utils/anime_season.dart';
 import 'package:kazumi/repositories/collect_repository.dart';
@@ -18,6 +21,8 @@ abstract class _TimelineController with Store {
   @observable
   ObservableList<List<BangumiItem>> bangumiCalendar =
       ObservableList<List<BangumiItem>>();
+
+  final ObservableMap<int, DateTime> airingTimes = ObservableMap();
 
   @observable
   String seasonString = '';
@@ -46,6 +51,8 @@ abstract class _TimelineController with Store {
   late DateTime _selectedDate;
   DateTime get selectedDate => _selectedDate;
 
+  int _scheduleRequestId = 0;
+
   bool get _bangumiMirrorEnabled =>
       GStorage.getSetting(SettingsKeys.enableBangumiProxy);
 
@@ -59,32 +66,40 @@ abstract class _TimelineController with Store {
   // clear+addAll never shows observers an intermediate empty list.
   @action
   Future<void> getSchedules() async {
+    final requestId = ++_scheduleRequestId;
     isLoading = true;
     isTimeOut = false;
     bangumiCalendar.clear();
+    airingTimes.clear();
     final resBangumiCalendar = await BangumiApi.getCalendar();
+    if (requestId != _scheduleRequestId) return;
     bangumiCalendar.clear();
     bangumiCalendar.addAll(resBangumiCalendar);
     changeSortType(sortType);
     isLoading = false;
     isTimeOut = bangumiCalendar.isEmpty;
+    unawaited(_loadAiringTimes(resBangumiCalendar, requestId));
   }
 
   @action
   Future<void> getSchedulesBySeason() async {
+    final requestId = ++_scheduleRequestId;
     if (_bangumiMirrorEnabled) {
       isLoading = true;
       isTimeOut = false;
       bangumiCalendar.clear();
+      airingTimes.clear();
       final resBangumiCalendar =
           await BangumiApi.getBangumiMirrorSeasonCalendar(
               AnimeSeason(selectedDate).toSeasonStartAndEnd());
+      if (requestId != _scheduleRequestId) return;
       bangumiCalendar.clear();
       bangumiCalendar.addAll(resBangumiCalendar);
       isLoading = false;
       isTimeOut = bangumiCalendar.every((innerList) => innerList.isEmpty);
       if (!isTimeOut) {
         changeSortType(sortType);
+        unawaited(_loadAiringTimes(resBangumiCalendar, requestId));
       }
       return;
     }
@@ -92,6 +107,7 @@ abstract class _TimelineController with Store {
     isLoading = true;
     isTimeOut = false;
     bangumiCalendar.clear();
+    airingTimes.clear();
     var time = 0;
     const maxTime = 4;
     const limit = 20;
@@ -100,6 +116,7 @@ abstract class _TimelineController with Store {
       final offset = time * limit;
       var newList = await BangumiApi.getCalendarBySearch(
           AnimeSeason(selectedDate).toSeasonStartAndEnd(), limit, offset);
+      if (requestId != _scheduleRequestId) return;
       for (int i = 0; i < resBangumiCalendar.length; ++i) {
         resBangumiCalendar[i].addAll(newList[i]);
       }
@@ -114,7 +131,22 @@ abstract class _TimelineController with Store {
     }
     if (!isTimeOut) {
       changeSortType(sortType);
+      unawaited(_loadAiringTimes(resBangumiCalendar, requestId));
     }
+  }
+
+  Future<void> _loadAiringTimes(
+      List<List<BangumiItem>> calendar, int requestId) async {
+    final airingTimesById = await AniListApi.getAiringTimes(
+      calendar.expand((items) => items),
+      selectedDate: selectedDate,
+    );
+    if (requestId != _scheduleRequestId) return;
+    runInAction(() {
+      airingTimes
+        ..clear()
+        ..addAll(airingTimesById);
+    });
   }
 
   void tryEnterSeason(DateTime date) {

--- a/lib/pages/timeline/timeline_page.dart
+++ b/lib/pages/timeline/timeline_page.dart
@@ -925,10 +925,14 @@ class _TimelinePageState extends State<TimelinePage>
                   (BuildContext context, int index) {
                     if (filteredList.isEmpty) return null;
                     final item = filteredList[index];
-                    return BangumiTimelineCard(
+                    return Observer(
+                      builder: (_) => BangumiTimelineCard(
                         bangumiItem: item,
                         cardHeight: cardHeight,
-                        showRating: showRating);
+                        showRating: showRating,
+                        airingTime: timelineController.airingTimes[item.id],
+                      ),
+                    );
                   },
                   childCount:
                       filteredList.isNotEmpty ? filteredList.length : 10,

--- a/lib/request/apis/anilist_api.dart
+++ b/lib/request/apis/anilist_api.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/clients/anilist_client.dart';
+import 'package:kazumi/services/logging/logger.dart';
+
+/// Resolves the next AniList episode time for Bangumi subjects.
+///
+/// AniList does not expose Bangumi IDs. Matches therefore require an exact
+/// normalized title, with an air-date check for aliases.
+class AniListApi {
+  static const _cacheTtl = Duration(hours: 1);
+  static const _query = r'''
+query ($page: Int!, $season: MediaSeason!, $seasonYear: Int!) {
+  Page(page: $page, perPage: 50) {
+    pageInfo { hasNextPage }
+    media(type: ANIME, season: $season, seasonYear: $seasonYear) {
+      status
+      startDate { year month day }
+      title { romaji native english }
+      synonyms
+      nextAiringEpisode { airingAt }
+    }
+  }
+}
+''';
+
+  static final AniListClient _client = AniListClient.instance;
+  static final Map<String, _SeasonCache> _cache = {};
+  static final Map<String, Future<List<_AniListMedia>>> _requests = {};
+
+  static Future<Map<int, DateTime>> getAiringTimes(
+    Iterable<BangumiItem> items, {
+    required DateTime selectedDate,
+  }) async {
+    final itemsBySeason = <String, List<BangumiItem>>{};
+    final datesBySeason = <String, DateTime>{};
+    for (final item in items) {
+      final airDate = DateTime.tryParse(item.airDate) ?? selectedDate;
+      final key = buildSeasonCacheKey(airDate);
+      (itemsBySeason[key] ??= []).add(item);
+      datesBySeason.putIfAbsent(key, () => airDate);
+    }
+
+    final matches = await Future.wait(itemsBySeason.entries.map((entry) async {
+      final media = await _getSeasonMedia(datesBySeason[entry.key]!);
+      return _matchAiringTimes(entry.value, media);
+    }));
+    return {for (final match in matches) ...match};
+  }
+
+  static Future<DateTime?> getAiringTime(BangumiItem item) async {
+    final airDate = DateTime.tryParse(item.airDate);
+    if (airDate == null) return null;
+    return (await getAiringTimes([item], selectedDate: airDate))[item.id];
+  }
+
+  static String buildSeasonCacheKey(DateTime date) {
+    return '${date.year}-${_seasonName(date)}';
+  }
+
+  static Map<int, DateTime> parseAiringTimes(
+    String payload,
+    Iterable<BangumiItem> items,
+  ) {
+    final decoded = jsonDecode(payload);
+    if (decoded is! List) {
+      throw const FormatException('AniList season payload must be a list');
+    }
+    return _matchAiringTimes(
+      items,
+      decoded.whereType<Map>().map(_AniListMedia.fromJson),
+    );
+  }
+
+  static Future<List<_AniListMedia>> _getSeasonMedia(DateTime date) {
+    final key = buildSeasonCacheKey(date);
+    final cached = _cache[key];
+    if (cached != null &&
+        DateTime.now().difference(cached.fetchedAt) < _cacheTtl) {
+      return Future.value(cached.media);
+    }
+
+    return _requests.putIfAbsent(key, () async {
+      try {
+        final media = await _fetchSeasonMedia(date);
+        _cache[key] = _SeasonCache(media, DateTime.now());
+        return media;
+      } catch (error) {
+        KazumiLogger()
+            .e('Network: resolve AniList airing schedule failed', error: error);
+        return const [];
+      } finally {
+        _requests.remove(key);
+      }
+    });
+  }
+
+  static Future<List<_AniListMedia>> _fetchSeasonMedia(DateTime date) async {
+    final media = <_AniListMedia>[];
+    var page = 1;
+    var hasNextPage = true;
+    while (hasNextPage) {
+      final response = await _client.query(
+        _query,
+        variables: {
+          'page': page,
+          'season': _seasonName(date),
+          'seasonYear': date.year,
+        },
+      );
+      final data = response is Map ? response['data'] : null;
+      final pageData = data is Map ? data['Page'] : null;
+      if (pageData is! Map) {
+        throw const FormatException('AniList response does not contain Page');
+      }
+      final pageMedia = pageData['media'];
+      if (pageMedia is List) {
+        media.addAll(pageMedia.whereType<Map>().map(_AniListMedia.fromJson));
+      }
+      final pageInfo = pageData['pageInfo'];
+      hasNextPage = pageInfo is Map && pageInfo['hasNextPage'] == true;
+      page++;
+    }
+    return media;
+  }
+
+  static Map<int, DateTime> _matchAiringTimes(
+    Iterable<BangumiItem> items,
+    Iterable<_AniListMedia> media,
+  ) {
+    final result = <int, DateTime>{};
+    for (final item in items) {
+      final match = _findMatch(item, media);
+      if (match?.airingTime case final airingTime?) {
+        result[item.id] = airingTime;
+      }
+    }
+    return result;
+  }
+
+  static _AniListMedia? _findMatch(
+    BangumiItem item,
+    Iterable<_AniListMedia> media,
+  ) {
+    final labels = {
+      item.name,
+      item.nameCn,
+      ...item.alias,
+    }.map(_normalizeTitle).where((label) => label.isNotEmpty).toSet();
+    if (labels.isEmpty) return null;
+
+    final exactName = _normalizeTitle(item.name);
+    final airDate = DateTime.tryParse(item.airDate);
+    final matches = media.where((candidate) {
+      if (candidate.hasEnded || candidate.airingTime == null) return false;
+      if (!labels.any(candidate.labels.contains)) return false;
+      if (candidate.labels.contains(exactName)) return true;
+      return airDate != null &&
+          candidate.startDate != null &&
+          _isSameDate(airDate, candidate.startDate!);
+    }).toList();
+    return matches.length == 1 ? matches.single : null;
+  }
+
+  static bool _isSameDate(DateTime left, DateTime right) {
+    return left.year == right.year &&
+        left.month == right.month &&
+        left.day == right.day;
+  }
+
+  static String _seasonName(DateTime date) {
+    switch ((date.month - 1) ~/ 3) {
+      case 0:
+        return 'WINTER';
+      case 1:
+        return 'SPRING';
+      case 2:
+        return 'SUMMER';
+      default:
+        return 'FALL';
+    }
+  }
+
+  static String _normalizeTitle(String value) {
+    return value.toLowerCase().replaceAll(
+        RegExp(r'''[\s\-_!！?？:：;；,，.。/／·・～~()（）\[\]【】「」『』'\"]'''), '');
+  }
+}
+
+class _SeasonCache {
+  const _SeasonCache(this.media, this.fetchedAt);
+
+  final List<_AniListMedia> media;
+  final DateTime fetchedAt;
+}
+
+class _AniListMedia {
+  const _AniListMedia({
+    required this.status,
+    required this.startDate,
+    required this.labels,
+    required this.airingTime,
+  });
+
+  factory _AniListMedia.fromJson(Map value) {
+    final title = value['title'] is Map ? value['title'] as Map : const {};
+    final start = value['startDate'] is Map ? value['startDate'] as Map : null;
+    final nextEpisode = value['nextAiringEpisode'] is Map
+        ? value['nextAiringEpisode'] as Map
+        : null;
+    final seconds = nextEpisode?['airingAt'];
+    final airingAt = seconds is int ? seconds : int.tryParse('$seconds');
+    final titles = [
+      title['romaji'],
+      title['native'],
+      title['english'],
+      ...(value['synonyms'] as List? ?? const []),
+    ];
+    return _AniListMedia(
+      status: value['status']?.toString() ?? '',
+      startDate: _dateFromParts(start?['year'], start?['month'], start?['day']),
+      labels: titles
+          .map((value) => AniListApi._normalizeTitle('$value'))
+          .where((value) => value.isNotEmpty)
+          .toSet(),
+      airingTime: airingAt == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(airingAt * 1000, isUtc: true)
+              .toLocal(),
+    );
+  }
+
+  final String status;
+  final DateTime? startDate;
+  final Set<String> labels;
+  final DateTime? airingTime;
+
+  bool get hasEnded => status == 'FINISHED' || status == 'CANCELLED';
+
+  static DateTime? _dateFromParts(dynamic year, dynamic month, dynamic day) {
+    if (year is! int || month is! int || day is! int) return null;
+    return DateTime(year, month, day);
+  }
+}

--- a/lib/request/apis/anilist_api.dart
+++ b/lib/request/apis/anilist_api.dart
@@ -29,6 +29,11 @@ query ($page: Int!, $season: MediaSeason!, $seasonYear: Int!) {
   static final Map<String, _SeasonCache> _cache = {};
   static final Map<String, Future<List<_AniListMedia>>> _requests = {};
 
+  /// Starts loading a season so a timeline request can run in parallel.
+  static Future<void> preloadSeason(DateTime date) async {
+    await _getSeasonMedia(date);
+  }
+
   static Future<Map<int, DateTime>> getAiringTimes(
     Iterable<BangumiItem> items, {
     required DateTime selectedDate,

--- a/lib/request/clients/anilist_client.dart
+++ b/lib/request/clients/anilist_client.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+import 'package:kazumi/request/config/api_endpoints.dart';
+import 'package:kazumi/request/core/dio_factory.dart';
+import 'package:kazumi/request/core/network_error_mapper.dart';
+
+class AniListClient {
+  AniListClient._();
+
+  static final AniListClient instance = AniListClient._();
+
+  Future<dynamic> query(
+    String query, {
+    Map<String, dynamic> variables = const {},
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await DioFactory.apiDio.post(
+        ApiEndpoints.aniListAPIDomain,
+        data: {
+          'query': query,
+          'variables': variables,
+        },
+        options: Options(
+          headers: const {'content-type': 'application/json'},
+        ),
+        cancelToken: cancelToken,
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw await NetworkErrorMapper.mapException(e);
+    }
+  }
+}

--- a/lib/request/config/api_endpoints.dart
+++ b/lib/request/config/api_endpoints.dart
@@ -74,6 +74,9 @@ class ApiEndpoints {
   /// Bangumi Next API Domain
   static const String bangumiAPINextDomain = 'https://next.bgm.tv';
 
+  /// AniList GraphQL API
+  static const String aniListAPIDomain = 'https://graphql.anilist.co';
+
   /// 每日放送
   static const String bangumiCalendar = '/p1/calendar';
 

--- a/test/anilist_api_test.dart
+++ b/test/anilist_api_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/anilist_api.dart';
+
+void main() {
+  BangumiItem item({
+    required int id,
+    required String name,
+    required String airDate,
+    List<String> alias = const [],
+  }) {
+    return BangumiItem(
+      id: id,
+      type: 2,
+      name: name,
+      nameCn: '',
+      summary: '',
+      airDate: airDate,
+      airWeekday: 1,
+      rank: 0,
+      images: const {},
+      tags: const [],
+      alias: alias,
+      ratingScore: 0,
+      votes: 0,
+      votesCount: const [],
+      info: '',
+    );
+  }
+
+  String payload(List<Map<String, dynamic>> media) => jsonEncode(media);
+
+  Map<String, dynamic> media({
+    required String status,
+    required String nativeTitle,
+    required DateTime startDate,
+    int? airingAt,
+    List<String> synonyms = const [],
+  }) {
+    return {
+      'status': status,
+      'startDate': {
+        'year': startDate.year,
+        'month': startDate.month,
+        'day': startDate.day,
+      },
+      'title': {
+        'romaji': nativeTitle,
+        'native': nativeTitle,
+        'english': '',
+      },
+      'synonyms': synonyms,
+      'nextAiringEpisode': airingAt == null ? null : {'airingAt': airingAt},
+    };
+  }
+
+  test(
+      'matches the native title and converts AniList UTC seconds to local time',
+      () {
+    final utcTime = DateTime.utc(2026, 7, 5, 14);
+    final result = AniListApi.parseAiringTimes(
+      payload([
+        media(
+          status: 'RELEASING',
+          nativeTitle: '测试番剧',
+          startDate: DateTime(2026, 7, 5),
+          airingAt: utcTime.millisecondsSinceEpoch ~/ 1000,
+        ),
+      ]),
+      [item(id: 1, name: '测试番剧', airDate: '2026-07-05')],
+    );
+
+    expect(result[1], utcTime.toLocal());
+  });
+
+  test('matches an alias only when the original air date confirms it', () {
+    final result = AniListApi.parseAiringTimes(
+      payload([
+        media(
+          status: 'RELEASING',
+          nativeTitle: 'AniList Native',
+          startDate: DateTime(2026, 7, 5),
+          airingAt: 1783260000,
+        ),
+      ]),
+      [
+        item(
+          id: 1,
+          name: 'Bangumi Name',
+          airDate: '2026-07-05',
+          alias: const ['AniList Native'],
+        ),
+      ],
+    );
+
+    expect(result, contains(1));
+  });
+
+  test('does not display finished anime or ambiguous title-only matches', () {
+    final result = AniListApi.parseAiringTimes(
+      payload([
+        media(
+          status: 'FINISHED',
+          nativeTitle: '已完结',
+          startDate: DateTime(2026, 7, 5),
+          airingAt: 1783260000,
+        ),
+        media(
+          status: 'RELEASING',
+          nativeTitle: '仅别名匹配',
+          startDate: DateTime(2026, 7, 5),
+          airingAt: 1783260000,
+        ),
+      ]),
+      [
+        item(id: 1, name: '已完结', airDate: '2026-07-05'),
+        item(
+          id: 2,
+          name: '不同标题',
+          airDate: '',
+          alias: const ['仅别名匹配'],
+        ),
+      ],
+    );
+
+    expect(result, isEmpty);
+  });
+
+  test('uses AniList season names for quarterly cache keys', () {
+    expect(AniListApi.buildSeasonCacheKey(DateTime(2026, 1)), '2026-WINTER');
+    expect(AniListApi.buildSeasonCacheKey(DateTime(2026, 4)), '2026-SPRING');
+    expect(AniListApi.buildSeasonCacheKey(DateTime(2026, 7)), '2026-SUMMER');
+    expect(AniListApi.buildSeasonCacheKey(DateTime(2026, 10)), '2026-FALL');
+  });
+}


### PR DESCRIPTION
#1659

<img width="1495" height="791" alt="image" src="https://github.com/user-attachments/assets/6f813660-50b7-4273-9bac-74e9bb66be8e" />

<img width="1324" height="501" alt="image" src="https://github.com/user-attachments/assets/b372431d-b8df-4954-b331-5e0b7f7a1771" />


## 描述

为时间表补充新番的具体放送时间，并在详情页显示更新时间。

## 实现细节

1. 基于aniList api完成请求。
2. 已完结的番不再显示放送时间。
3. 由于bangumi id与aniList id不同，故使用日文标题匹配等方法。但由于bangumi和aniList的日文标题有小概率不一致，所以可能有少数番剧匹配不上。

