### PR TITLE
支持 macOS 自定义下载保存路径（基于 #2300 扩展）

### DIFF
--- a/lib/pages/settings/download_settings.dart
+++ b/lib/pages/settings/download_settings.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
+import 'package:kazumi/services/platform/secure_bookmark_service.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/utils/file_system.dart';
 import 'package:card_settings_ui/card_settings_ui.dart';
@@ -73,6 +74,10 @@ class _DownloadSettingsPageState extends State<DownloadSettingsPage> {
       if (selectedPath == null || selectedPath.isEmpty) return;
 
       await ensureDirectoryWritable(selectedPath);
+      if (!await SecureBookmarkService.persist(selectedPath)) {
+        KazumiDialog.showToast(message: '无法获得该目录的持久访问权限，请更换目录');
+        return;
+      }
       await GStorage.putSetting(
         SettingsKeys.downloadDirectory,
         selectedPath,
@@ -93,6 +98,7 @@ class _DownloadSettingsPageState extends State<DownloadSettingsPage> {
   }
 
   Future<void> _resetDownloadDirectory() async {
+    await SecureBookmarkService.clear();
     await GStorage.putSetting(SettingsKeys.downloadDirectory, '');
     if (mounted) {
       setState(() => downloadDirectory = '');

--- a/lib/services/download/download_manager.dart
+++ b/lib/services/download/download_manager.dart
@@ -10,6 +10,7 @@ import 'package:kazumi/utils/m3u8_ad_filter.dart';
 import 'package:kazumi/utils/format.dart' as fmt;
 import 'package:kazumi/utils/file_system.dart';
 import 'package:kazumi/services/logging/logger.dart';
+import 'package:kazumi/services/platform/secure_bookmark_service.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:path/path.dart' as path;
 
@@ -218,7 +219,14 @@ class DownloadManager implements IDownloadManager {
     if (supportsCustomDownloadDirectory) {
       final customDir =
           GStorage.getSetting(SettingsKeys.downloadDirectory).trim();
-      if (customDir.isNotEmpty) return customDir;
+      if (customDir.isNotEmpty) {
+        // On macOS this re-establishes sandbox access after a restart;
+        // elsewhere it returns the path unchanged.
+        final usable = await SecureBookmarkService.restore(customDir);
+        if (usable != null) return usable;
+        KazumiLogger().w(
+            'DownloadManager: custom download directory unavailable, falling back to default');
+      }
     }
     return getDefaultDownloadDirectory();
   }

--- a/lib/services/platform/secure_bookmark_service.dart
+++ b/lib/services/platform/secure_bookmark_service.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:kazumi/services/logging/logger.dart';
+import 'package:kazumi/services/storage/storage.dart';
+import 'package:macos_secure_bookmarks/macos_secure_bookmarks.dart';
+
+/// Keeps the user-picked download directory writable across app restarts on
+/// sandboxed macOS via security-scoped bookmarks. No-op on other platforms.
+class SecureBookmarkService {
+  SecureBookmarkService._();
+
+  static final _bookmarks = SecureBookmarks();
+  static String _accessedPath = '';
+
+  /// Persist a bookmark for [path] just picked by the user. Returns false if
+  /// the bookmark cannot be created, in which case the path must not be used.
+  static Future<bool> persist(String path) async {
+    if (!Platform.isMacOS) return true;
+    try {
+      final bookmark = await _bookmarks.bookmark(Directory(path));
+      await GStorage.putSetting(
+          SettingsKeys.downloadDirectoryBookmark, bookmark);
+      // The picker grant already covers this session.
+      _accessedPath = path;
+      return true;
+    } catch (e) {
+      KazumiLogger()
+          .e('SecureBookmarkService: failed to bookmark $path', error: e);
+      return false;
+    }
+  }
+
+  /// Restore write access to the custom directory [path]. Returns the usable
+  /// path (which may differ from [path] if the directory was moved), or null
+  /// when access cannot be restored.
+  static Future<String?> restore(String path) async {
+    if (!Platform.isMacOS) return path;
+    if (_accessedPath == path) return path;
+    final String bookmark =
+        GStorage.getSetting(SettingsKeys.downloadDirectoryBookmark);
+    if (bookmark.isEmpty) return null;
+    try {
+      final entity = await _bookmarks.resolveBookmark(bookmark);
+      await _bookmarks.startAccessingSecurityScopedResource(entity);
+      _accessedPath = entity.path;
+      return entity.path;
+    } catch (e) {
+      KazumiLogger().e(
+          'SecureBookmarkService: failed to restore access to $path',
+          error: e);
+      return null;
+    }
+  }
+
+  static Future<void> clear() async {
+    if (!Platform.isMacOS) return;
+    await GStorage.putSetting(SettingsKeys.downloadDirectoryBookmark, '');
+    _accessedPath = '';
+  }
+}

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -446,6 +446,13 @@ class SettingsKeys {
     '',
     group: SettingGroup.download,
   );
+  // macOS only: security-scoped bookmark that keeps downloadDirectory
+  // writable across app restarts under the sandbox.
+  static const downloadDirectoryBookmark = SettingKey<String>(
+    'downloadDirectoryBookmark',
+    '',
+    group: SettingGroup.download,
+  );
   static const shortcutDialogShown = SettingKey<bool>(
     _SettingBoxKey.shortcutDialogShown,
     false,
@@ -589,6 +596,7 @@ class SettingsKeys {
     downloadParallelSegments,
     downloadDanmaku,
     downloadDirectory,
+    downloadDirectoryBookmark,
     shortcutDialogShown,
     bangumiSyncEnable,
     bangumiAccessToken,

--- a/lib/utils/file_system.dart
+++ b/lib/utils/file_system.dart
@@ -3,8 +3,11 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
-/// Custom download directories are currently Windows-only.
-bool get supportsCustomDownloadDirectory => Platform.isWindows;
+/// Custom download directories are supported on desktop platforms where the
+/// user can grant persistent access to an arbitrary directory. On macOS this
+/// additionally requires a security-scoped bookmark (SecureBookmarkService).
+bool get supportsCustomDownloadDirectory =>
+    Platform.isWindows || Platform.isMacOS;
 
 Future<String> getDefaultDownloadDirectory() async {
   final appSupport = await getApplicationSupportDirectory();

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
-    <true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,13 +4,13 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
-    <true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -928,6 +928,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  logging_appenders:
+    dependency: transitive
+    description:
+      name: logging_appenders
+      sha256: "7fefa09636824f312432721c0bf77967ab19003116650729bd202bdf98142d70"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0+1"
+  macos_secure_bookmarks:
+    dependency: "direct main"
+    description:
+      name: macos_secure_bookmarks
+      sha256: c3163875f8fd530a1654a7cf8aa426e6e208d28bf05724a1d4960e4b7d2ca1c6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,6 +133,7 @@ dependencies:
       url: https://github.com/Predidit/media-kit.git
       ref: 652cfc765a43792be8bec429ea72296d5d96fb7d
       path: ./libs/universal/media_kit_libs_video
+  macos_secure_bookmarks: ^0.2.1
 
 dependency_overrides:
   media_kit_libs_linux:


### PR DESCRIPTION
## 功能

在 #2300（Windows 自定义下载目录）的基础上，将自定义下载目录支持扩展到 macOS。

> 本 PR 原先同时实现了 Windows 与 macOS 支持，与后续合并的 #2300 功能重叠，现已基于 main 重写：完全复用 #2300 的架构（`supportsCustomDownloadDirectory` / `downloadDirectory` 设置项 / `_prepareEpisodeDir` / 删除逻辑），仅新增 macOS 所需的沙盒授权处理。

## 实现说明

- `supportsCustomDownloadDirectory` 扩展为 `Platform.isWindows || Platform.isMacOS`，设置页与下载管理器逻辑完全复用，无其他平台行为变化
- **macOS 沙盒处理**：沙盒下用户选择的目录授权无法跨重启保持，通过 security-scoped bookmarks 持久化（`macos_secure_bookmarks`），新增 `SecureBookmarkService`（非 macOS 平台全部直通）：
  - 选择目录时创建 bookmark 并持久化（失败则不保存该路径并提示用户）
  - 下载使用自定义路径前恢复授权（`startAccessingSecurityScopedResource`），目录被移动也能通过 bookmark 跟踪到新位置
  - 授权恢复失败（如外置盘未挂载、目录被删除）时自动回退默认下载目录并记录日志
  - 恢复默认位置时一并清除 bookmark
- entitlement 中 `user-selected` 由 read-only 升级为 read-write（沙盒保持开启，不影响存量用户数据路径）
- 新增设置项 `downloadDirectoryBookmark`（macOS 专用，存储序列化的 bookmark）

## 测试

- `flutter analyze` 无新增问题
- `flutter test` 120 个测试全部通过
- macOS debug 构建通过
