### PR TITLE
修复 WebDAV 多客户端同步冲突与错误成功响应

### DIFF
--- a/lib/modules/collect/collect_sync_merger.dart
+++ b/lib/modules/collect/collect_sync_merger.dart
@@ -55,6 +55,8 @@ class BangumiCollectiblesMergePlan {
 }
 
 class CollectSyncMerger {
+  static const int _maxHiveChangeId = 4294967295;
+
   static CollectiblesMergeResult mergeWebDav({
     required List<CollectedBangumi> localCollectibles,
     required List<CollectedBangumiChange> localChanges,
@@ -63,11 +65,46 @@ class CollectSyncMerger {
   }) {
     final mergedCollectibles =
         remoteCollectibles.map(_copyCollectible).toList();
-    final newLocalChanges = localChanges.where((localChange) {
-      return !remoteChanges
-          .any((remoteChange) => remoteChange.id == localChange.id);
-    }).toList()
-      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    final changesById = <int, CollectedBangumiChange>{
+      for (final change in remoteChanges) change.id: change,
+    };
+    var nextChangeId = [
+          ...remoteChanges,
+          ...localChanges,
+        ].fold<int>(
+          0,
+          (maximum, change) => change.id > maximum ? change.id : maximum,
+        ) +
+        1;
+    final newLocalChanges = <CollectedBangumiChange>[];
+    for (final localChange in localChanges) {
+      final existing = changesById[localChange.id];
+      if (existing == null) {
+        changesById[localChange.id] = localChange;
+        newLocalChanges.add(localChange);
+        continue;
+      }
+      if (_sameChange(existing, localChange)) {
+        continue;
+      }
+
+      while (changesById.containsKey(nextChangeId)) {
+        nextChangeId++;
+      }
+      if (nextChangeId > _maxHiveChangeId) {
+        throw StateError('WebDav collect change ID space exhausted');
+      }
+      final rekeyedChange = CollectedBangumiChange(
+        nextChangeId++,
+        localChange.bangumiID,
+        localChange.action,
+        localChange.type,
+        localChange.timestamp,
+      );
+      changesById[rekeyedChange.id] = rekeyedChange;
+      newLocalChanges.add(rekeyedChange);
+    }
+    newLocalChanges.sort((a, b) => a.timestamp.compareTo(b.timestamp));
 
     for (final change in newLocalChanges) {
       if (change.action == 3) {
@@ -104,10 +141,8 @@ class CollectSyncMerger {
       }
     }
 
-    final mergedChanges = <int, CollectedBangumiChange>{
-      for (final change in remoteChanges) change.id: change,
-      for (final change in newLocalChanges) change.id: change,
-    }.values.toList();
+    final mergedChanges = changesById.values.toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
 
     return CollectiblesMergeResult(
       collectibles: mergedCollectibles,
@@ -220,6 +255,17 @@ class CollectSyncMerger {
       collectible.time,
       collectible.type,
     );
+  }
+
+  static bool _sameChange(
+    CollectedBangumiChange first,
+    CollectedBangumiChange second,
+  ) {
+    return first.id == second.id &&
+        first.bangumiID == second.bangumiID &&
+        first.action == second.action &&
+        first.type == second.type &&
+        first.timestamp == second.timestamp;
   }
 
   CollectSyncMerger._();

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:crypto/crypto.dart';
 import 'package:webdav_client/webdav_client.dart' as webdav;
 import 'package:path_provider/path_provider.dart';
 import 'package:kazumi/modules/history/history_sync.dart';
@@ -453,22 +452,16 @@ class WebDav {
       rename: (sourcePath, targetPath) =>
           client.rename(sourcePath, targetPath, true),
       exists: _remoteEntryExists,
-      verify: _verifyRemoteFile,
+      moveApplied: _remoteMoveApplied,
     );
   }
 
-  Future<void> _verifyRemoteFile(
-    String sourceFilePath,
+  Future<bool> _remoteMoveApplied(
+    String temporaryPath,
     String destinationPath,
   ) async {
-    final localDigest =
-        await sha256.bind(File(sourceFilePath).openRead()).first;
-    final remoteDigest = sha256.convert(await client.read(destinationPath));
-    if (localDigest != remoteDigest) {
-      throw StateError(
-        'WebDav: remote verification failed for $destinationPath',
-      );
-    }
+    return !await _remoteEntryExists(temporaryPath) &&
+        await _remoteEntryExists(destinationPath);
   }
 
   Future<void> _removeDeviceHistoryChanges(String deviceId) async {

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:crypto/crypto.dart';
 import 'package:webdav_client/webdav_client.dart' as webdav;
 import 'package:path_provider/path_provider.dart';
 import 'package:kazumi/modules/history/history_sync.dart';
@@ -80,7 +81,6 @@ class WebDav {
     await _publishRemoteFile(
       sourceFilePath: tempFilePath,
       destinationPath: webDavPath,
-      temporaryPath: '$webDavPath.cache',
     );
     try {
       await File(tempFilePath).delete();
@@ -242,7 +242,6 @@ class WebDav {
         await historySync.writeSnapshotFile(mergedSnapshot, snapshotFile);
         await _publishHistorySnapshot(
           snapshotFile: snapshotFile,
-          deviceId: deviceId,
         );
         await historySync.completeCheckpoint(localBatch);
         await _removeDeviceHistoryChanges(deviceId);
@@ -423,12 +422,10 @@ class WebDav {
 
   Future<void> _publishHistorySnapshot({
     required File snapshotFile,
-    required String deviceId,
   }) {
     return _publishRemoteFile(
       sourceFilePath: snapshotFile.path,
       destinationPath: _historySnapshotPath,
-      temporaryPath: '$_historySnapshotPath.$deviceId.cache',
     );
   }
 
@@ -440,18 +437,15 @@ class WebDav {
     return _publishRemoteFile(
       sourceFilePath: sourceFile.path,
       destinationPath: destinationPath,
-      temporaryPath: '$destinationPath.cache',
     );
   }
 
   Future<void> _publishRemoteFile({
     required String sourceFilePath,
     required String destinationPath,
-    required String temporaryPath,
   }) async {
     await _remoteFileCommitter.replaceFile(
       sourceFilePath: sourceFilePath,
-      temporaryPath: temporaryPath,
       destinationPath: destinationPath,
       remove: (path) => client.remove(path),
       uploadFromFile: (sourceFilePath, remotePath) =>
@@ -459,7 +453,22 @@ class WebDav {
       rename: (sourcePath, targetPath) =>
           client.rename(sourcePath, targetPath, true),
       exists: _remoteEntryExists,
+      verify: _verifyRemoteFile,
     );
+  }
+
+  Future<void> _verifyRemoteFile(
+    String sourceFilePath,
+    String destinationPath,
+  ) async {
+    final localDigest =
+        await sha256.bind(File(sourceFilePath).openRead()).first;
+    final remoteDigest = sha256.convert(await client.read(destinationPath));
+    if (localDigest != remoteDigest) {
+      throw StateError(
+        'WebDav: remote verification failed for $destinationPath',
+      );
+    }
   }
 
   Future<void> _removeDeviceHistoryChanges(String deviceId) async {

--- a/lib/services/sync/webdav_remote_file_commit.dart
+++ b/lib/services/sync/webdav_remote_file_commit.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 typedef WebDavRemoveRemoteFile = Future<void> Function(String path);
 typedef WebDavUploadRemoteFile = Future<void> Function(
   String sourceFilePath,
@@ -8,32 +10,49 @@ typedef WebDavRenameRemoteFile = Future<void> Function(
   String destinationPath,
 );
 typedef WebDavRemoteEntryExists = Future<bool> Function(String path);
+typedef WebDavVerifyRemoteFile = Future<void> Function(
+  String sourceFilePath,
+  String destinationPath,
+);
 
 class WebDavRemoteFileCommitter {
   const WebDavRemoteFileCommitter();
 
+  static final Random _random = Random.secure();
+
   Future<void> replaceFile({
     required String sourceFilePath,
-    required String temporaryPath,
     required String destinationPath,
     required WebDavRemoveRemoteFile remove,
     required WebDavUploadRemoteFile uploadFromFile,
     required WebDavRenameRemoteFile rename,
     required WebDavRemoteEntryExists exists,
+    required WebDavVerifyRemoteFile verify,
   }) async {
-    await _removeIfExists(
-      temporaryPath,
-      remove: remove,
-      exists: exists,
-    );
+    final temporaryPath = '$destinationPath.${_createTemporaryToken()}.cache';
     try {
       await uploadFromFile(sourceFilePath, temporaryPath);
+      try {
+        await rename(temporaryPath, destinationPath);
+        await verify(sourceFilePath, destinationPath);
+        return;
+      } catch (_) {
+        // Some WebDAV implementations reject overwrite MOVE. Others return a
+        // 207 response containing a per-resource failure which webdav_client
+        // currently treats as success. Retry the compatible replace flow only
+        // when the uploaded temporary file is still present.
+        if (!await exists(temporaryPath)) {
+          rethrow;
+        }
+      }
+
       await _removeIfExists(
         destinationPath,
         remove: remove,
         exists: exists,
       );
       await rename(temporaryPath, destinationPath);
+      await verify(sourceFilePath, destinationPath);
     } catch (_) {
       await _removeIfExists(
         temporaryPath,
@@ -56,5 +75,11 @@ class WebDavRemoteFileCommitter {
         rethrow;
       }
     }
+  }
+
+  static String _createTemporaryToken() {
+    return List<int>.generate(16, (_) => _random.nextInt(256))
+        .map((value) => value.toRadixString(16).padLeft(2, '0'))
+        .join();
   }
 }

--- a/lib/services/sync/webdav_remote_file_commit.dart
+++ b/lib/services/sync/webdav_remote_file_commit.dart
@@ -10,8 +10,8 @@ typedef WebDavRenameRemoteFile = Future<void> Function(
   String destinationPath,
 );
 typedef WebDavRemoteEntryExists = Future<bool> Function(String path);
-typedef WebDavVerifyRemoteFile = Future<void> Function(
-  String sourceFilePath,
+typedef WebDavRemoteMoveApplied = Future<bool> Function(
+  String temporaryPath,
   String destinationPath,
 );
 
@@ -27,15 +27,16 @@ class WebDavRemoteFileCommitter {
     required WebDavUploadRemoteFile uploadFromFile,
     required WebDavRenameRemoteFile rename,
     required WebDavRemoteEntryExists exists,
-    required WebDavVerifyRemoteFile verify,
+    required WebDavRemoteMoveApplied moveApplied,
   }) async {
     final temporaryPath = '$destinationPath.${_createTemporaryToken()}.cache';
     try {
       await uploadFromFile(sourceFilePath, temporaryPath);
       try {
         await rename(temporaryPath, destinationPath);
-        await verify(sourceFilePath, destinationPath);
-        return;
+        if (await moveApplied(temporaryPath, destinationPath)) {
+          return;
+        }
       } catch (_) {
         // Some WebDAV implementations reject overwrite MOVE. Others return a
         // 207 response containing a per-resource failure which webdav_client
@@ -46,13 +47,22 @@ class WebDavRemoteFileCommitter {
         }
       }
 
+      if (!await exists(temporaryPath)) {
+        throw StateError(
+          'WebDav: MOVE did not produce the expected remote state',
+        );
+      }
       await _removeIfExists(
         destinationPath,
         remove: remove,
         exists: exists,
       );
       await rename(temporaryPath, destinationPath);
-      await verify(sourceFilePath, destinationPath);
+      if (!await moveApplied(temporaryPath, destinationPath)) {
+        throw StateError(
+          'WebDav: retried MOVE did not produce the expected remote state',
+        );
+      }
     } catch (_) {
       await _removeIfExists(
         temporaryPath,

--- a/test/collect_sync_test.dart
+++ b/test/collect_sync_test.dart
@@ -103,6 +103,33 @@ void main() {
       expect(mergeResult.changes.map((change) => change.id), [9, 10, 11, 12]);
     });
 
+    test('preserves changes from different devices when IDs collide', () {
+      final mergeResult = CollectSyncMerger.mergeWebDav(
+        localCollectibles: [
+          _collect(2, CollectType.watched, 20),
+        ],
+        localChanges: [
+          _change(10, 2, 1, CollectType.watched, 20),
+        ],
+        remoteCollectibles: [
+          _collect(1, CollectType.watching, 10),
+        ],
+        remoteChanges: [
+          _change(10, 1, 1, CollectType.watching, 10),
+        ],
+      );
+
+      expect(_typesById(mergeResult.collectibles), {
+        1: CollectType.watching.value,
+        2: CollectType.watched.value,
+      });
+      expect(mergeResult.changes, hasLength(2));
+      expect(
+        mergeResult.changes.map((change) => change.id).toSet(),
+        hasLength(2),
+      );
+    });
+
     test('plans Bangumi changes after local and WebDAV already diverged', () {
       final webDavResult = CollectSyncMerger.mergeWebDav(
         localCollectibles: [

--- a/test/webdav_remote_file_commit_test.dart
+++ b/test/webdav_remote_file_commit_test.dart
@@ -23,9 +23,9 @@ void main() {
           remoteFiles[destination] = remoteFiles.remove(source)!;
         },
         exists: (path) async => remoteFiles.containsKey(path),
-        verify: (localPath, remotePath) async {
-          expect(remoteFiles[remotePath], 'new-content');
-        },
+        moveApplied: (source, destination) async =>
+            !remoteFiles.containsKey(source) &&
+            remoteFiles.containsKey(destination),
       );
     }
 
@@ -71,11 +71,9 @@ void main() {
         remoteFiles[destination] = remoteFiles.remove(source)!;
       },
       exists: (path) async => remoteFiles.containsKey(path),
-      verify: (localPath, remotePath) async {
-        if (remoteFiles[remotePath] != 'new-content') {
-          throw StateError('remote content mismatch');
-        }
-      },
+      moveApplied: (source, destination) async =>
+          !remoteFiles.containsKey(source) &&
+          remoteFiles.containsKey(destination),
     );
 
     expect(renameCalls, 2);
@@ -104,11 +102,9 @@ void main() {
           // Simulates repeated false-success MOVE responses.
         },
         exists: (path) async => remoteFiles.containsKey(path),
-        verify: (localPath, remotePath) async {
-          if (remoteFiles[remotePath] != 'new-content') {
-            throw StateError('remote content mismatch');
-          }
-        },
+        moveApplied: (source, destination) async =>
+            !remoteFiles.containsKey(source) &&
+            remoteFiles.containsKey(destination),
       ),
       throwsA(isA<StateError>()),
     );

--- a/test/webdav_remote_file_commit_test.dart
+++ b/test/webdav_remote_file_commit_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/services/sync/webdav_remote_file_commit.dart';
+
+void main() {
+  test('uses a unique temporary path for every remote replacement', () async {
+    final remoteFiles = <String, String>{};
+    final uploadedPaths = <String>[];
+    const sourcePath = 'local-file';
+    const destinationPath = '/kazumiSync/collectibles.tmp';
+
+    Future<void> replace() {
+      return const WebDavRemoteFileCommitter().replaceFile(
+        sourceFilePath: sourcePath,
+        destinationPath: destinationPath,
+        remove: (path) async {
+          remoteFiles.remove(path);
+        },
+        uploadFromFile: (localPath, remotePath) async {
+          uploadedPaths.add(remotePath);
+          remoteFiles[remotePath] = 'new-content';
+        },
+        rename: (source, destination) async {
+          remoteFiles[destination] = remoteFiles.remove(source)!;
+        },
+        exists: (path) async => remoteFiles.containsKey(path),
+        verify: (localPath, remotePath) async {
+          expect(remoteFiles[remotePath], 'new-content');
+        },
+      );
+    }
+
+    await replace();
+    await replace();
+
+    expect(uploadedPaths, hasLength(2));
+    expect(uploadedPaths.toSet(), hasLength(2));
+    expect(
+      uploadedPaths,
+      everyElement(
+        allOf(
+          startsWith('$destinationPath.'),
+          endsWith('.cache'),
+        ),
+      ),
+    );
+  });
+
+  test('retries compatible replace when MOVE falsely reports success',
+      () async {
+    final remoteFiles = <String, String>{
+      '/kazumiSync/collectibles.tmp': 'old-content',
+    };
+    var renameCalls = 0;
+
+    await const WebDavRemoteFileCommitter().replaceFile(
+      sourceFilePath: 'local-file',
+      destinationPath: '/kazumiSync/collectibles.tmp',
+      remove: (path) async {
+        remoteFiles.remove(path);
+      },
+      uploadFromFile: (localPath, remotePath) async {
+        remoteFiles[remotePath] = 'new-content';
+      },
+      rename: (source, destination) async {
+        renameCalls++;
+        if (renameCalls == 1) {
+          // Simulates webdav_client accepting a 207 response whose body
+          // reports that the MOVE failed.
+          return;
+        }
+        remoteFiles[destination] = remoteFiles.remove(source)!;
+      },
+      exists: (path) async => remoteFiles.containsKey(path),
+      verify: (localPath, remotePath) async {
+        if (remoteFiles[remotePath] != 'new-content') {
+          throw StateError('remote content mismatch');
+        }
+      },
+    );
+
+    expect(renameCalls, 2);
+    expect(
+      remoteFiles['/kazumiSync/collectibles.tmp'],
+      'new-content',
+    );
+  });
+
+  test('reports failure when the retried MOVE still changes nothing', () async {
+    final remoteFiles = <String, String>{
+      '/kazumiSync/collectibles.tmp': 'old-content',
+    };
+
+    await expectLater(
+      const WebDavRemoteFileCommitter().replaceFile(
+        sourceFilePath: 'local-file',
+        destinationPath: '/kazumiSync/collectibles.tmp',
+        remove: (path) async {
+          remoteFiles.remove(path);
+        },
+        uploadFromFile: (localPath, remotePath) async {
+          remoteFiles[remotePath] = 'new-content';
+        },
+        rename: (source, destination) async {
+          // Simulates repeated false-success MOVE responses.
+        },
+        exists: (path) async => remoteFiles.containsKey(path),
+        verify: (localPath, remotePath) async {
+          if (remoteFiles[remotePath] != 'new-content') {
+            throw StateError('remote content mismatch');
+          }
+        },
+      ),
+      throwsA(isA<StateError>()),
+    );
+  });
+}


### PR DESCRIPTION
## 修改内容

- MOVE 完成后通过 WebDAV 元数据确认临时文件已消失且目标文件存在，避免错误成功响应导致同步数据未更新
- MOVE 覆盖失败或远端校验不通过时，自动回退到兼容的“删除目标文件后重新移动”流程
- 每次替换远端文件时生成唯一的临时路径，避免多个设备同时同步时共用 `.cache` 文件产生冲突
- 收藏变更 ID 相同但内容不同时，为本地变更重新分配 ID，保留两台设备各自的变更
- 添加 WebDAV 文件替换和收藏变更 ID 冲突的回归测试

## 问题原因

`webdav_client` 可能将 WebDAV MOVE 返回的 HTTP 207 响应视为成功，但响应正文中的单个资源实际上可能操作失败。因此，Kazumi 会认为同步已经完成，而远端目标文件仍是旧内容。

此外，原实现使用固定的 `.cache` 临时文件路径。多个客户端同时同步时，可能互相覆盖或删除对方的临时文件。

修复通过 PROPFIND 返回的目录元数据判断 MOVE 是否真正生效，不会为了验证发布结果重新下载完整文件。

收藏同步方面，原实现仅根据整数 ID 对变更记录去重。当两台设备独立生成了相同 ID、但内容不同的变更时，其中一条变更会在合并过程中被静默丢弃。

## 验证

- `flutter test test/collect_sync_test.dart test/webdav_remote_file_commit_test.dart`
- 对所有修改的 Dart 文件运行 `dart analyze`
- `git diff --check`

修复 #2341
