### PR TITLE
fix: 修复检索结果分页重复

### DIFF
--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -28,6 +28,8 @@ abstract class _SearchPageController with Store {
 
   int _searchOffset = 0;
 
+  bool hasMoreSearchResults = true;
+
   @observable
   bool isLoading = false;
 
@@ -67,6 +69,7 @@ abstract class _SearchPageController with Store {
     if (type != 'add') {
       bangumiList.clear();
       _searchOffset = 0;
+      hasMoreSearchResults = true;
       bool privateMode = _collectRepository.getPrivateMode();
       if (!privateMode) {
         // 检查是否已满，删除最旧的记录
@@ -93,24 +96,35 @@ abstract class _SearchPageController with Store {
         if (item != null) {
           bangumiList.add(item);
         }
+        hasMoreSearchResults = false;
         isLoading = false;
         isTimeOut = bangumiList.isEmpty;
         return;
       }
     }
-    final result = await BangumiApi.bangumiSearch(filterState.keyword,
-        tags: filterState.tags,
-        offset: _searchOffset,
-        sort: filterState.sort,
-        dateRange: filterState.effectiveDateRange,
-        rankRange: filterState.rankRange,
-        scoreRange: filterState.scoreRange,
-        weekdays: filterState.weekdays);
-    if (result.isNotEmpty) {
-      _searchOffset += _searchPageSize;
-    }
-    final existingIds = bangumiList.map((item) => item.id).toSet();
-    bangumiList.addAll(result.where((item) => existingIds.add(item.id)));
+    var addedVisibleItems = false;
+    do {
+      final page = await BangumiApi.bangumiSearch(filterState.keyword,
+          tags: filterState.tags,
+          offset: _searchOffset,
+          sort: filterState.sort,
+          dateRange: filterState.effectiveDateRange,
+          rankRange: filterState.rankRange,
+          scoreRange: filterState.scoreRange,
+          weekdays: filterState.weekdays);
+      if (page == null) {
+        break;
+      }
+      _searchOffset += page.rawCount;
+      hasMoreSearchResults = page.rawCount == _searchPageSize;
+      final existingIds = bangumiList.map((item) => item.id).toSet();
+      final newItems =
+          page.items.where((item) => existingIds.add(item.id)).toList();
+      if (newItems.isNotEmpty) {
+        bangumiList.addAll(newItems);
+        addedVisibleItems = true;
+      }
+    } while (!addedVisibleItems && hasMoreSearchResults);
     isLoading = false;
     isTimeOut = bangumiList.isEmpty;
   }

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -132,7 +132,7 @@ abstract class _SearchPageController with Store {
         hasMoreSearchResults &&
         pagesFetched < _maxPagesPerSearch);
     isLoading = false;
-    isTimeOut = bangumiList.isEmpty;
+    isTimeOut = bangumiList.isEmpty && !hasMoreSearchResults;
   }
 
   @action

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -17,6 +17,7 @@ class SearchPageController = _SearchPageController with _$SearchPageController;
 
 abstract class _SearchPageController with Store {
   static const int _searchPageSize = 20;
+  static const int _maxPagesPerSearch = 3;
 
   _SearchPageController(
     this._collectRepository,
@@ -103,9 +104,11 @@ abstract class _SearchPageController with Store {
       }
     }
     var addedVisibleItems = false;
+    var pagesFetched = 0;
     do {
       final page = await BangumiApi.bangumiSearch(filterState.keyword,
           tags: filterState.tags,
+          limit: _searchPageSize,
           offset: _searchOffset,
           sort: filterState.sort,
           dateRange: filterState.effectiveDateRange,
@@ -115,6 +118,7 @@ abstract class _SearchPageController with Store {
       if (page == null) {
         break;
       }
+      pagesFetched++;
       _searchOffset += page.rawCount;
       hasMoreSearchResults = page.rawCount == _searchPageSize;
       final existingIds = bangumiList.map((item) => item.id).toSet();
@@ -124,7 +128,9 @@ abstract class _SearchPageController with Store {
         bangumiList.addAll(newItems);
         addedVisibleItems = true;
       }
-    } while (!addedVisibleItems && hasMoreSearchResults);
+    } while (!addedVisibleItems &&
+        hasMoreSearchResults &&
+        pagesFetched < _maxPagesPerSearch);
     isLoading = false;
     isTimeOut = bangumiList.isEmpty;
   }

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -104,6 +104,7 @@ abstract class _SearchPageController with Store {
       }
     }
     var addedVisibleItems = false;
+    var fetchedAnyPage = false;
     var pagesFetched = 0;
     do {
       final page = await BangumiApi.bangumiSearch(filterState.keyword,
@@ -118,6 +119,7 @@ abstract class _SearchPageController with Store {
       if (page == null) {
         break;
       }
+      fetchedAnyPage = true;
       pagesFetched++;
       _searchOffset += page.rawCount;
       hasMoreSearchResults = page.rawCount == _searchPageSize;
@@ -132,7 +134,8 @@ abstract class _SearchPageController with Store {
         hasMoreSearchResults &&
         pagesFetched < _maxPagesPerSearch);
     isLoading = false;
-    isTimeOut = bangumiList.isEmpty && !hasMoreSearchResults;
+    isTimeOut =
+        bangumiList.isEmpty && (!fetchedAnyPage || !hasMoreSearchResults);
   }
 
   @action

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -16,6 +16,8 @@ part 'search_controller.g.dart';
 class SearchPageController = _SearchPageController with _$SearchPageController;
 
 abstract class _SearchPageController with Store {
+  static const int _searchPageSize = 20;
+
   _SearchPageController(
     this._collectRepository,
     this._searchHistoryRepository,
@@ -23,6 +25,8 @@ abstract class _SearchPageController with Store {
 
   final ICollectRepository _collectRepository;
   final ISearchHistoryRepository _searchHistoryRepository;
+
+  int _searchOffset = 0;
 
   @observable
   bool isLoading = false;
@@ -62,6 +66,7 @@ abstract class _SearchPageController with Store {
   Future<void> searchBangumi(String input, {String type = 'add'}) async {
     if (type != 'add') {
       bangumiList.clear();
+      _searchOffset = 0;
       bool privateMode = _collectRepository.getPrivateMode();
       if (!privateMode) {
         // 检查是否已满，删除最旧的记录
@@ -95,13 +100,17 @@ abstract class _SearchPageController with Store {
     }
     final result = await BangumiApi.bangumiSearch(filterState.keyword,
         tags: filterState.tags,
-        offset: bangumiList.length,
+        offset: _searchOffset,
         sort: filterState.sort,
         dateRange: filterState.effectiveDateRange,
         rankRange: filterState.rankRange,
         scoreRange: filterState.scoreRange,
         weekdays: filterState.weekdays);
-    bangumiList.addAll(result);
+    if (result.isNotEmpty) {
+      _searchOffset += _searchPageSize;
+    }
+    final existingIds = bangumiList.map((item) => item.id).toSet();
+    bangumiList.addAll(result.where((item) => existingIds.add(item.id)));
     isLoading = false;
     isTimeOut = bangumiList.isEmpty;
   }

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -98,7 +98,7 @@ class _SearchPageState extends State<SearchPage> {
         !searchPageController.isLoading &&
         (searchController.text.trim().isNotEmpty ||
             filterState.hasAdvancedFilters) &&
-        searchPageController.bangumiList.length >= 20) {
+        searchPageController.hasMoreSearchResults) {
       KazumiLogger().i('SearchController: search results is loading more');
       searchPageController.searchBangumi(searchController.text, type: 'add');
     }

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -15,6 +15,16 @@ import 'package:kazumi/modules/bangumi/bangumi_collection_type.dart';
 import 'package:kazumi/modules/comments/comment_item.dart';
 import 'package:kazumi/utils/search_parser.dart';
 
+class BangumiSearchPage {
+  const BangumiSearchPage({
+    required this.items,
+    required this.rawCount,
+  });
+
+  final List<BangumiItem> items;
+  final int rawCount;
+}
+
 class BangumiApi {
   static final BangumiClient _client = BangumiClient.instance;
 
@@ -292,7 +302,7 @@ class BangumiApi {
     };
   }
 
-  static Future<List<BangumiItem>> bangumiSearch(String keyword,
+  static Future<BangumiSearchPage?> bangumiSearch(String keyword,
       {List<String> tags = const [],
       int offset = 0,
       String sort = 'heat',
@@ -333,10 +343,14 @@ class BangumiApi {
           }
         }
       }
+      return BangumiSearchPage(
+        items: bangumiList,
+        rawCount: jsonList.length,
+      );
     } catch (e) {
       KazumiLogger().e('Network: unknown search problem', error: e);
+      return null;
     }
-    return bangumiList;
   }
 
   static Future<BangumiItem?> getBangumiInfoByID(int id) async {

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -304,6 +304,7 @@ class BangumiApi {
 
   static Future<BangumiSearchPage?> bangumiSearch(String keyword,
       {List<String> tags = const [],
+      int limit = 20,
       int offset = 0,
       String sort = 'heat',
       SearchDateRange? dateRange,
@@ -326,7 +327,7 @@ class BangumiApi {
       final jsonData = await _client.post(
         ApiEndpoints.formatUrl(
             ApiEndpoints.bangumiAPIDomain + ApiEndpoints.bangumiRankSearch,
-            [20, offset]),
+            [limit, offset]),
         data: params,
       );
       final jsonList = jsonData['data'];


### PR DESCRIPTION
## 修改内容

- 将检索分页 offset 与本地结果列表长度解耦
- 按接口固定页大小 20 推进服务端 offset
- 发起新检索时重置 offset
- 按 Bangumi ID 去重，避免接口相邻页面重叠时出现重复卡片

## 问题原因

检索接口每页请求 20 条数据，但解析过程中会过滤没有中文名的条目。原实现使用过滤后的 `bangumiList.length` 作为下一页 offset，因此当一页有效结果少于 20 条时，下一页会从错误位置开始并与上一页重叠。

这是 #2368 中热门页面分页问题在检索页面的同类情况，本 PR 单独修复检索页面。

## 验证

- `flutter analyze lib/pages/search/search_controller.dart`（仅保留文件原有的 MobX `library_private_types_in_public_api` info）
- `flutter test`（120 项全部通过）
