### PR TITLE
fix: 修复搜索隐藏已看结果不足

### DIFF
--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:mobx/mobx.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/collect/collect_type.dart';
@@ -20,14 +21,31 @@ typedef SearchPageRequestLoader = Future<BangumiSearchPage?> Function(
   int offset,
 );
 
-class SearchPageController = _SearchPageController with _$SearchPageController;
+class SearchPageController extends _SearchPageController
+    with _$SearchPageController {
+  SearchPageController(
+    super.collectRepository,
+    super.searchHistoryRepository,
+  );
+
+  @visibleForTesting
+  SearchPageController.withPageLoader(
+    super.collectRepository,
+    super.searchHistoryRepository,
+    SearchPageRequestLoader pageLoader,
+  ) : super(pageLoader: pageLoader);
+}
 
 abstract class _SearchPageController with Store {
   static const int _searchPageSize = 20;
 
-  _SearchPageController(this._collectRepository, this._searchHistoryRepository,
-      {SearchPageRequestLoader? pageLoader})
-      : _pageLoader = pageLoader ?? _defaultPageLoader;
+  _SearchPageController(
+    ICollectRepository collectRepository,
+    ISearchHistoryRepository searchHistoryRepository, {
+    SearchPageRequestLoader? pageLoader,
+  })  : _collectRepository = collectRepository,
+        _searchHistoryRepository = searchHistoryRepository,
+        _pageLoader = pageLoader ?? _defaultPageLoader;
 
   final ICollectRepository _collectRepository;
   final ISearchHistoryRepository _searchHistoryRepository;
@@ -243,15 +261,25 @@ abstract class _SearchPageController with Store {
   Future<void> retryHiddenView() async {
     final buffer = _resultBuffer;
     if (buffer == null) return;
+    final retryingSelectedHiddenView =
+        selectedViewMode == SearchViewMode.hideWatched;
     pendingViewMode = SearchViewMode.hideWatched;
     hiddenViewError = null;
     isHiddenViewPreparing = true;
+    if (retryingSelectedHiddenView) {
+      isLoading = true;
+      isTimeOut = false;
+    }
     final generation = _queryGeneration;
     final future = buffer.retry(minimumItems: _searchPageSize);
     _backgroundPreparation = future;
     await future;
     if (generation != _queryGeneration) return;
     _finishHiddenPreparation(generation);
+    if (retryingSelectedHiddenView) {
+      isLoading = false;
+      isTimeOut = hiddenViewError != null;
+    }
   }
 
   Future<void> waitForBackgroundPreparation() async {
@@ -324,7 +352,11 @@ abstract class _SearchPageController with Store {
       await buffer.ensureReadyFor(mode, minimumItems: target);
     }
     if (generation != _queryGeneration) return;
-    _publishMode(mode, minimumItems: target);
+    final activeMode = selectedViewMode;
+    final activeMinimumItems = activeMode == mode
+        ? target
+        : _publishedCounts[activeMode] ?? _searchPageSize;
+    _publishMode(activeMode, minimumItems: activeMinimumItems);
     isLoading = false;
     hasMoreSearchResults = !buffer.isExhausted;
     if (!isHiddenViewReady && !isHiddenViewPreparing) {

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -10,24 +10,55 @@ import 'package:kazumi/repositories/search_history_repository.dart';
 import 'package:kazumi/request/apis/bangumi_api.dart';
 import 'package:kazumi/request/apis/trace_api.dart';
 import 'package:kazumi/utils/search_parser.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
 
 part 'search_controller.g.dart';
+
+typedef SearchPageRequestLoader = Future<BangumiSearchPage?> Function(
+  String keyword,
+  SearchFilterState filterState,
+  int offset,
+);
 
 class SearchPageController = _SearchPageController with _$SearchPageController;
 
 abstract class _SearchPageController with Store {
   static const int _searchPageSize = 20;
-  static const int _maxPagesPerSearch = 3;
 
-  _SearchPageController(
-    this._collectRepository,
-    this._searchHistoryRepository,
-  );
+  _SearchPageController(this._collectRepository, this._searchHistoryRepository,
+      {SearchPageRequestLoader? pageLoader})
+      : _pageLoader = pageLoader ?? _defaultPageLoader;
 
   final ICollectRepository _collectRepository;
   final ISearchHistoryRepository _searchHistoryRepository;
+  final SearchPageRequestLoader _pageLoader;
 
-  int _searchOffset = 0;
+  static Future<BangumiSearchPage?> _defaultPageLoader(
+    String keyword,
+    SearchFilterState filterState,
+    int offset,
+  ) {
+    return BangumiApi.bangumiSearch(
+      filterState.keyword,
+      tags: filterState.tags,
+      limit: _searchPageSize,
+      offset: offset,
+      sort: filterState.sort,
+      dateRange: filterState.effectiveDateRange,
+      rankRange: filterState.rankRange,
+      scoreRange: filterState.scoreRange,
+      weekdays: filterState.weekdays,
+    );
+  }
+
+  SearchResultBuffer? _resultBuffer;
+  Future<void>? _backgroundPreparation;
+  int _queryGeneration = 0;
+  String _activeInput = '';
+  final Map<SearchViewMode, int> _publishedCounts = {
+    SearchViewMode.all: 0,
+    SearchViewMode.hideWatched: 0,
+  };
 
   bool hasMoreSearchResults = true;
 
@@ -45,6 +76,21 @@ abstract class _SearchPageController with Store {
 
   @observable
   ObservableList<BangumiItem> bangumiList = ObservableList.of([]);
+
+  @observable
+  SearchViewMode selectedViewMode = SearchViewMode.all;
+
+  @observable
+  SearchViewMode? pendingViewMode;
+
+  @observable
+  bool isHiddenViewPreparing = false;
+
+  @observable
+  bool isHiddenViewReady = false;
+
+  @observable
+  Object? hiddenViewError;
 
   @observable
   ObservableList<SearchHistory> searchHistories = ObservableList.of([]);
@@ -67,75 +113,237 @@ abstract class _SearchPageController with Store {
 
   @action
   Future<void> searchBangumi(String input, {String type = 'add'}) async {
-    if (type != 'add') {
-      bangumiList.clear();
-      _searchOffset = 0;
-      hasMoreSearchResults = true;
-      bool privateMode = _collectRepository.getPrivateMode();
-      if (!privateMode) {
-        // 检查是否已满，删除最旧的记录
-        if (_searchHistoryRepository.isHistoryFull(10)) {
-          await _searchHistoryRepository.deleteOldest();
-        }
-        // 删除重复的历史记录
-        await _searchHistoryRepository.deleteDuplicates(input);
-        // 保存新的搜索历史
-        await _searchHistoryRepository.saveHistory(input);
-        // 重新加载历史记录
-        loadSearchHistories();
-      }
+    final filterState = SearchParser(input).toFilterState();
+    final normalizedInput = SearchParser.fromFilterState(filterState);
+    final isNewQuery = type != 'add' ||
+        _resultBuffer == null ||
+        _activeInput != normalizedInput;
+
+    if (!isNewQuery) {
+      await _loadMoreSearchResults();
+      return;
     }
+
+    final requestedMode = selectedViewMode;
+    final generation = ++_queryGeneration;
+    _activeInput = normalizedInput;
+    _resultBuffer = null;
+    _backgroundPreparation = null;
+    _publishedCounts
+      ..[SearchViewMode.all] = 0
+      ..[SearchViewMode.hideWatched] = 0;
+    pendingViewMode = null;
+    isHiddenViewPreparing = false;
+    isHiddenViewReady = false;
+    hiddenViewError = null;
+    hasMoreSearchResults = true;
+    bangumiList.clear();
     isLoading = true;
     isTimeOut = false;
-    SearchParser parser = SearchParser(input);
-    final filterState = parser.toFilterState();
-    String? idString = filterState.id.isEmpty ? null : filterState.id;
+
+    if (!_collectRepository.getPrivateMode()) {
+      if (_searchHistoryRepository.isHistoryFull(10)) {
+        await _searchHistoryRepository.deleteOldest();
+      }
+      await _searchHistoryRepository.deleteDuplicates(input);
+      await _searchHistoryRepository.saveHistory(input);
+      loadSearchHistories();
+    }
+    if (generation != _queryGeneration) return;
+
+    final idString = filterState.id.isEmpty ? null : filterState.id;
     if (idString != null) {
       final id = int.tryParse(idString);
       if (id != null) {
-        final BangumiItem? item = await BangumiApi.getBangumiInfoByID(id);
-        if (item != null) {
-          bangumiList.add(item);
+        final item = await BangumiApi.getBangumiInfoByID(id);
+        if (generation != _queryGeneration) return;
+        final buffer = SearchResultBuffer(
+          pageLoader: (offset) async => offset == 0 && item != null
+              ? BangumiSearchPage(items: [item], rawCount: 1)
+              : const BangumiSearchPage(items: [], rawCount: 0),
+          watchedIds: loadWatchedBangumiIds,
+          abandonedIds: loadAbandonedBangumiIds,
+          hideAbandoned: notShowAbandonedBangumis,
+        );
+        _resultBuffer = buffer;
+        await buffer.ensureReadyFor(SearchViewMode.all);
+        if (generation != _queryGeneration) return;
+        if (requestedMode == SearchViewMode.hideWatched) {
+          pendingViewMode = SearchViewMode.hideWatched;
+          await _startHiddenPreparation(generation);
+          if (generation != _queryGeneration) return;
+          isLoading = false;
+          hasMoreSearchResults = !buffer.isExhausted;
+          isTimeOut = hiddenViewError != null;
+        } else {
+          _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
+          isLoading = false;
+          hasMoreSearchResults = !buffer.isExhausted;
+          isTimeOut = bangumiList.isEmpty;
+          _startHiddenPreparation(generation);
         }
-        hasMoreSearchResults = false;
-        isLoading = false;
-        isTimeOut = bangumiList.isEmpty;
         return;
       }
     }
-    var addedVisibleItems = false;
-    var fetchedAnyPage = false;
-    var pagesFetched = 0;
-    do {
-      final page = await BangumiApi.bangumiSearch(filterState.keyword,
-          tags: filterState.tags,
-          limit: _searchPageSize,
-          offset: _searchOffset,
-          sort: filterState.sort,
-          dateRange: filterState.effectiveDateRange,
-          rankRange: filterState.rankRange,
-          scoreRange: filterState.scoreRange,
-          weekdays: filterState.weekdays);
-      if (page == null) {
-        break;
+
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) => _pageLoader(input, filterState, offset),
+      watchedIds: loadWatchedBangumiIds,
+      abandonedIds: loadAbandonedBangumiIds,
+      hideAbandoned: notShowAbandonedBangumis,
+    );
+    _resultBuffer = buffer;
+    await buffer.ensureReadyFor(SearchViewMode.all);
+    if (generation != _queryGeneration) return;
+    if (requestedMode == SearchViewMode.hideWatched) {
+      pendingViewMode = SearchViewMode.hideWatched;
+      await _startHiddenPreparation(generation);
+      if (generation != _queryGeneration) return;
+      isLoading = false;
+      hasMoreSearchResults = !buffer.isExhausted;
+      isTimeOut = hiddenViewError != null;
+    } else {
+      _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
+      isLoading = false;
+      hasMoreSearchResults = !buffer.isExhausted;
+      isTimeOut =
+          bangumiList.isEmpty && (buffer.error != null || buffer.isExhausted);
+      _startHiddenPreparation(generation);
+    }
+  }
+
+  @action
+  Future<void> requestViewMode(SearchViewMode mode) async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    if (mode == selectedViewMode && pendingViewMode == null) return;
+
+    pendingViewMode = mode;
+    if (mode == SearchViewMode.all) {
+      _publishMode(
+        SearchViewMode.all,
+        minimumItems: _publishedCounts[SearchViewMode.all] ?? _searchPageSize,
+      );
+      pendingViewMode = null;
+      return;
+    }
+
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
+    if (isHiddenViewReady && hiddenViewError == null) {
+      _publishMode(SearchViewMode.hideWatched, minimumItems: _searchPageSize);
+      pendingViewMode = null;
+      return;
+    }
+    if (hiddenViewError == null) {
+      _startHiddenPreparation(_queryGeneration);
+    }
+  }
+
+  @action
+  Future<void> retryHiddenView() async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    pendingViewMode = SearchViewMode.hideWatched;
+    hiddenViewError = null;
+    isHiddenViewPreparing = true;
+    final generation = _queryGeneration;
+    final future = buffer.retry(minimumItems: _searchPageSize);
+    _backgroundPreparation = future;
+    await future;
+    if (generation != _queryGeneration) return;
+    _finishHiddenPreparation(generation);
+  }
+
+  Future<void> waitForBackgroundPreparation() async {
+    final preparation = _backgroundPreparation;
+    if (preparation == null) return;
+    await preparation;
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> _startHiddenPreparation(int generation) {
+    final buffer = _resultBuffer;
+    if (buffer == null || generation != _queryGeneration) {
+      return Future<void>.value();
+    }
+    final existing = _backgroundPreparation;
+    if (existing != null) {
+      return existing.whenComplete(() {
+        if (generation == _queryGeneration &&
+            (!buffer.isReady(SearchViewMode.all) ||
+                !buffer.isReady(SearchViewMode.hideWatched))) {
+          return _startHiddenPreparation(generation);
+        }
+      });
+    }
+    if (buffer.isReady(SearchViewMode.all) &&
+        buffer.isReady(SearchViewMode.hideWatched) &&
+        buffer.error == null) {
+      _finishHiddenPreparation(generation);
+      return Future<void>.value();
+    }
+
+    isHiddenViewPreparing = true;
+    hiddenViewError = null;
+    final future = buffer.ensureReady(minimumItems: _searchPageSize);
+    _backgroundPreparation = future;
+    future.whenComplete(() {
+      if (generation == _queryGeneration) {
+        _finishHiddenPreparation(generation);
       }
-      fetchedAnyPage = true;
-      pagesFetched++;
-      _searchOffset += page.rawCount;
-      hasMoreSearchResults = page.rawCount == _searchPageSize;
-      final existingIds = bangumiList.map((item) => item.id).toSet();
-      final newItems =
-          page.items.where((item) => existingIds.add(item.id)).toList();
-      if (newItems.isNotEmpty) {
-        bangumiList.addAll(newItems);
-        addedVisibleItems = true;
-      }
-    } while (!addedVisibleItems &&
-        hasMoreSearchResults &&
-        pagesFetched < _maxPagesPerSearch);
+    });
+    return future;
+  }
+
+  void _finishHiddenPreparation(int generation) {
+    final buffer = _resultBuffer;
+    if (buffer == null || generation != _queryGeneration) return;
+    isHiddenViewPreparing = false;
+    hiddenViewError = buffer.error;
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
+    _backgroundPreparation = null;
+    if (hiddenViewError == null &&
+        pendingViewMode == SearchViewMode.hideWatched &&
+        isHiddenViewReady) {
+      _publishMode(SearchViewMode.hideWatched, minimumItems: _searchPageSize);
+      pendingViewMode = null;
+    }
+  }
+
+  Future<void> _loadMoreSearchResults() async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final generation = _queryGeneration;
+    final mode = selectedViewMode;
+    final published = _publishedCounts[mode] ?? 0;
+    final target = published + _searchPageSize;
+    isLoading = true;
+    final items =
+        mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
+    if (items.length < target && !buffer.isExhausted) {
+      await buffer.ensureReadyFor(mode, minimumItems: target);
+    }
+    if (generation != _queryGeneration) return;
+    _publishMode(mode, minimumItems: target);
     isLoading = false;
-    isTimeOut =
-        bangumiList.isEmpty && (!fetchedAnyPage || !hasMoreSearchResults);
+    hasMoreSearchResults = !buffer.isExhausted;
+    if (!isHiddenViewReady && !isHiddenViewPreparing) {
+      _startHiddenPreparation(generation);
+    }
+  }
+
+  void _publishMode(SearchViewMode mode, {required int minimumItems}) {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final items =
+        mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
+    final visibleCount =
+        items.length < minimumItems ? items.length : minimumItems;
+    _publishedCounts[mode] = visibleCount;
+    bangumiList = ObservableList.of(items.take(visibleCount));
+    selectedViewMode = mode;
+    hasMoreSearchResults = !buffer.isExhausted;
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
   }
 
   @action
@@ -200,11 +408,39 @@ abstract class _SearchPageController with Store {
   @action
   Future<void> setNotShowWatchedBangumis(bool value) async {
     notShowWatchedBangumis = value;
+    if (value) {
+      await requestViewMode(SearchViewMode.hideWatched);
+    } else {
+      await requestViewMode(SearchViewMode.all);
+    }
   }
 
   @action
   Future<void> setNotShowAbandonedBangumis(bool value) async {
     notShowAbandonedBangumis = value;
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+
+    final mode = selectedViewMode;
+    final generation = _queryGeneration;
+    buffer.setHideAbandoned(value);
+    _publishMode(
+      mode,
+      minimumItems: _publishedCounts[mode] ?? _searchPageSize,
+    );
+    if (buffer.isReady(SearchViewMode.all) &&
+        buffer.isReady(SearchViewMode.hideWatched)) {
+      return;
+    }
+
+    await _startHiddenPreparation(generation);
+    if (generation != _queryGeneration || mode != selectedViewMode) return;
+    final minimumItems = _publishedCounts[mode] ?? _searchPageSize;
+    _publishMode(
+      mode,
+      minimumItems:
+          minimumItems < _searchPageSize ? _searchPageSize : minimumItems,
+    );
   }
 
   Set<int> loadWatchedBangumiIds() {

--- a/lib/pages/search/search_controller.g.dart
+++ b/lib/pages/search/search_controller.g.dart
@@ -91,6 +91,87 @@ mixin _$SearchPageController on _SearchPageController, Store {
     });
   }
 
+  late final _$selectedViewModeAtom =
+      Atom(name: '_SearchPageController.selectedViewMode', context: context);
+
+  @override
+  SearchViewMode get selectedViewMode {
+    _$selectedViewModeAtom.reportRead();
+    return super.selectedViewMode;
+  }
+
+  @override
+  set selectedViewMode(SearchViewMode value) {
+    _$selectedViewModeAtom.reportWrite(value, super.selectedViewMode, () {
+      super.selectedViewMode = value;
+    });
+  }
+
+  late final _$pendingViewModeAtom =
+      Atom(name: '_SearchPageController.pendingViewMode', context: context);
+
+  @override
+  SearchViewMode? get pendingViewMode {
+    _$pendingViewModeAtom.reportRead();
+    return super.pendingViewMode;
+  }
+
+  @override
+  set pendingViewMode(SearchViewMode? value) {
+    _$pendingViewModeAtom.reportWrite(value, super.pendingViewMode, () {
+      super.pendingViewMode = value;
+    });
+  }
+
+  late final _$isHiddenViewPreparingAtom = Atom(
+      name: '_SearchPageController.isHiddenViewPreparing', context: context);
+
+  @override
+  bool get isHiddenViewPreparing {
+    _$isHiddenViewPreparingAtom.reportRead();
+    return super.isHiddenViewPreparing;
+  }
+
+  @override
+  set isHiddenViewPreparing(bool value) {
+    _$isHiddenViewPreparingAtom.reportWrite(value, super.isHiddenViewPreparing,
+        () {
+      super.isHiddenViewPreparing = value;
+    });
+  }
+
+  late final _$isHiddenViewReadyAtom =
+      Atom(name: '_SearchPageController.isHiddenViewReady', context: context);
+
+  @override
+  bool get isHiddenViewReady {
+    _$isHiddenViewReadyAtom.reportRead();
+    return super.isHiddenViewReady;
+  }
+
+  @override
+  set isHiddenViewReady(bool value) {
+    _$isHiddenViewReadyAtom.reportWrite(value, super.isHiddenViewReady, () {
+      super.isHiddenViewReady = value;
+    });
+  }
+
+  late final _$hiddenViewErrorAtom =
+      Atom(name: '_SearchPageController.hiddenViewError', context: context);
+
+  @override
+  Object? get hiddenViewError {
+    _$hiddenViewErrorAtom.reportRead();
+    return super.hiddenViewError;
+  }
+
+  @override
+  set hiddenViewError(Object? value) {
+    _$hiddenViewErrorAtom.reportWrite(value, super.hiddenViewError, () {
+      super.hiddenViewError = value;
+    });
+  }
+
   late final _$searchHistoriesAtom =
       Atom(name: '_SearchPageController.searchHistories', context: context);
 
@@ -162,6 +243,22 @@ mixin _$SearchPageController on _SearchPageController, Store {
   Future<void> searchBangumi(String input, {String type = 'add'}) {
     return _$searchBangumiAsyncAction
         .run(() => super.searchBangumi(input, type: type));
+  }
+
+  late final _$requestViewModeAsyncAction =
+      AsyncAction('_SearchPageController.requestViewMode', context: context);
+
+  @override
+  Future<void> requestViewMode(SearchViewMode mode) {
+    return _$requestViewModeAsyncAction.run(() => super.requestViewMode(mode));
+  }
+
+  late final _$retryHiddenViewAsyncAction =
+      AsyncAction('_SearchPageController.retryHiddenView', context: context);
+
+  @override
+  Future<void> retryHiddenView() {
+    return _$retryHiddenViewAsyncAction.run(() => super.retryHiddenView());
   }
 
   late final _$deleteSearchHistoryAsyncAction = AsyncAction(
@@ -254,6 +351,11 @@ isTimeOut: ${isTimeOut},
 notShowWatchedBangumis: ${notShowWatchedBangumis},
 notShowAbandonedBangumis: ${notShowAbandonedBangumis},
 bangumiList: ${bangumiList},
+selectedViewMode: ${selectedViewMode},
+pendingViewMode: ${pendingViewMode},
+isHiddenViewPreparing: ${isHiddenViewPreparing},
+isHiddenViewReady: ${isHiddenViewReady},
+hiddenViewError: ${hiddenViewError},
 searchHistories: ${searchHistories},
 isImageSearching: ${isImageSearching},
 imageSearchError: ${imageSearchError},

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -215,6 +215,8 @@ class _SearchPageState extends State<SearchPage> {
         }
         final preparing = searchPageController.isHiddenViewPreparing;
         final failed = searchPageController.hiddenViewError != null;
+        final canRetrySelectedHiddenView = failed &&
+            searchPageController.selectedViewMode == SearchViewMode.hideWatched;
         return Padding(
           padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
           child: Row(
@@ -239,7 +241,7 @@ class _SearchPageState extends State<SearchPage> {
                       value: SearchViewMode.hideWatched,
                       label: const Text('隐藏已看'),
                       icon: failed
-                          ? const Icon(Icons.refresh_rounded)
+                          ? const Icon(Icons.error_outline)
                           : preparing
                               ? const SizedBox(
                                   width: 16,
@@ -253,6 +255,16 @@ class _SearchPageState extends State<SearchPage> {
                   ],
                 ),
               ),
+              if (canRetrySelectedHiddenView) ...[
+                const SizedBox(width: 4),
+                Tooltip(
+                  message: '重试准备隐藏已看',
+                  child: IconButton(
+                    icon: const Icon(Icons.refresh_rounded),
+                    onPressed: searchPageController.retryHiddenView,
+                  ),
+                ),
+              ],
             ],
           ),
         );

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -6,8 +6,9 @@ import 'package:kazumi/bean/dialog/material_bottom_sheet.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/bean/card/bangumi_card.dart';
 import 'package:kazumi/bean/widget/error_widget.dart';
-import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/pages/search/search_result_grid.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/utils/date_time.dart';
@@ -112,7 +113,6 @@ class _SearchPageState extends State<SearchPage> {
       builder: (context) {
         return _SearchWorkbenchSheet(
           initialState: filterState,
-          initialNotShowWatched: searchPageController.notShowWatchedBangumis,
           initialNotShowAbandoned:
               searchPageController.notShowAbandonedBangumis,
         );
@@ -120,7 +120,6 @@ class _SearchPageState extends State<SearchPage> {
     );
 
     if (result == null) return;
-    await searchPageController.setNotShowWatchedBangumis(result.notShowWatched);
     await searchPageController
         .setNotShowAbandonedBangumis(result.notShowAbandoned);
     await _applyFilterState(result.filterState, search: result.shouldSearch);
@@ -195,14 +194,6 @@ class _SearchPageState extends State<SearchPage> {
         ),
       ));
     }
-    if (searchPageController.notShowWatchedBangumis) {
-      chips.add(InputChip(
-        label: const Text('隐藏已看'),
-        onDeleted: () async {
-          await searchPageController.setNotShowWatchedBangumis(false);
-        },
-      ));
-    }
     if (searchPageController.notShowAbandonedBangumis) {
       chips.add(InputChip(
         label: const Text('隐藏已弃'),
@@ -213,6 +204,60 @@ class _SearchPageState extends State<SearchPage> {
     }
 
     return chips;
+  }
+
+  Widget buildViewModeControl() {
+    return Observer(
+      builder: (_) {
+        if (searchPageController.bangumiList.isEmpty &&
+            searchPageController.selectedViewMode == SearchViewMode.all) {
+          return const SizedBox.shrink();
+        }
+        final preparing = searchPageController.isHiddenViewPreparing;
+        final failed = searchPageController.hiddenViewError != null;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: SegmentedButton<SearchViewMode>(
+                  selected: {searchPageController.selectedViewMode},
+                  onSelectionChanged: (selection) {
+                    final mode = selection.first;
+                    if (mode == SearchViewMode.hideWatched && failed) {
+                      searchPageController.retryHiddenView();
+                    } else {
+                      searchPageController.requestViewMode(mode);
+                    }
+                  },
+                  segments: [
+                    const ButtonSegment(
+                      value: SearchViewMode.all,
+                      label: Text('全部'),
+                    ),
+                    ButtonSegment(
+                      value: SearchViewMode.hideWatched,
+                      label: const Text('隐藏已看'),
+                      icon: failed
+                          ? const Icon(Icons.refresh_rounded)
+                          : preparing
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : null,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _submitSearch(String value) async {
@@ -331,6 +376,7 @@ class _SearchPageState extends State<SearchPage> {
               );
             },
           ),
+          buildViewModeControl(),
           Expanded(
             child: Observer(builder: (context) {
               if (searchPageController.isTimeOut) {
@@ -367,45 +413,22 @@ class _SearchPageState extends State<SearchPage> {
                   LayoutBreakpoint.medium['width']!) {
                 crossCount = 6;
               }
-              List<BangumiItem> filteredList =
-                  searchPageController.bangumiList.toList();
-
-              if (searchPageController.notShowWatchedBangumis) {
-                final watchedBangumiIds =
-                    searchPageController.loadWatchedBangumiIds();
-                filteredList = filteredList
-                    .where((item) => !watchedBangumiIds.contains(item.id))
-                    .toList();
+              final items = searchPageController.bangumiList.toList();
+              if (items.isEmpty) {
+                return const Center(child: Text('当前视图没有可显示的番剧'));
               }
-
-              if (searchPageController.notShowAbandonedBangumis) {
-                final abandonedBangumiIds =
-                    searchPageController.loadAbandonedBangumiIds();
-                filteredList = filteredList
-                    .where((item) => !abandonedBangumiIds.contains(item.id))
-                    .toList();
-              }
-
-              return GridView.builder(
-                controller: scrollController,
-                padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  mainAxisSpacing: StyleString.cardSpace - 2,
-                  crossAxisSpacing: StyleString.cardSpace,
-                  crossAxisCount: crossCount,
-                  mainAxisExtent:
-                      MediaQuery.of(context).size.width / crossCount / 0.65 +
-                          MediaQuery.textScalerOf(context).scale(32.0),
+              return SearchResultGrid(
+                items: items,
+                crossCount: crossCount,
+                cardExtent:
+                    MediaQuery.sizeOf(context).width / crossCount / 0.65 +
+                        MediaQuery.textScalerOf(context).scale(32.0),
+                itemBuilder: (context, item) => BangumiCardV(
+                  enableHero: false,
+                  bangumiItem: item,
                 ),
-                itemCount: filteredList.isNotEmpty ? filteredList.length : 10,
-                itemBuilder: (context, index) {
-                  return filteredList.isNotEmpty
-                      ? BangumiCardV(
-                          enableHero: false,
-                          bangumiItem: filteredList[index],
-                        )
-                      : Container();
-                },
+                scrollController: scrollController,
+                spacing: StyleString.cardSpace,
               );
             }),
           ),
@@ -418,13 +441,11 @@ class _SearchPageState extends State<SearchPage> {
 class _SearchWorkbenchResult {
   const _SearchWorkbenchResult({
     required this.filterState,
-    required this.notShowWatched,
     required this.notShowAbandoned,
     required this.shouldSearch,
   });
 
   final SearchFilterState filterState;
-  final bool notShowWatched;
   final bool notShowAbandoned;
   final bool shouldSearch;
 }
@@ -432,12 +453,10 @@ class _SearchWorkbenchResult {
 class _SearchWorkbenchSheet extends StatefulWidget {
   const _SearchWorkbenchSheet({
     required this.initialState,
-    required this.initialNotShowWatched,
     required this.initialNotShowAbandoned,
   });
 
   final SearchFilterState initialState;
-  final bool initialNotShowWatched;
   final bool initialNotShowAbandoned;
 
   @override
@@ -446,7 +465,6 @@ class _SearchWorkbenchSheet extends StatefulWidget {
 
 class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
   late SearchFilterState draft = widget.initialState;
-  late bool notShowWatched = widget.initialNotShowWatched;
   late bool notShowAbandoned = widget.initialNotShowAbandoned;
   final TextEditingController tagController = TextEditingController();
 
@@ -840,17 +858,10 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                 const SizedBox(height: 12),
                 MaterialBottomSheetSection(
                   title: '过滤',
-                  description: '控制是否隐藏已经看过或放弃的番剧。',
+                  description: '控制是否隐藏已经放弃的番剧。',
                   icon: Icons.filter_alt_outlined,
                   child: Column(
                     children: [
-                      _SearchSwitchTile(
-                        title: '隐藏已看',
-                        value: notShowWatched,
-                        onChanged: (value) {
-                          setState(() => notShowWatched = value);
-                        },
-                      ),
                       _SearchSwitchTile(
                         title: '隐藏已弃',
                         value: notShowAbandoned,
@@ -872,7 +883,6 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                   onPressed: () {
                     setState(() {
                       draft = resetAdvancedFilters();
-                      notShowWatched = false;
                       notShowAbandoned = false;
                     });
                   },
@@ -886,7 +896,6 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                       context,
                       _SearchWorkbenchResult(
                         filterState: draft,
-                        notShowWatched: notShowWatched,
                         notShowAbandoned: notShowAbandoned,
                         shouldSearch: true,
                       ),

--- a/lib/pages/search/search_result_buffer.dart
+++ b/lib/pages/search/search_result_buffer.dart
@@ -1,0 +1,160 @@
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+
+enum SearchViewMode {
+  all,
+  hideWatched,
+}
+
+typedef SearchPageLoader = Future<BangumiSearchPage?> Function(int offset);
+
+class SearchResultBuffer {
+  SearchResultBuffer({
+    required SearchPageLoader pageLoader,
+    required Set<int> Function() watchedIds,
+    required Set<int> Function() abandonedIds,
+    this.hideAbandoned = false,
+    this.pageSize = 20,
+  })  : _pageLoader = pageLoader,
+        _watchedIds = watchedIds,
+        _abandonedIds = abandonedIds;
+
+  final SearchPageLoader _pageLoader;
+  final Set<int> Function() _watchedIds;
+  final Set<int> Function() _abandonedIds;
+
+  final int pageSize;
+  bool hideAbandoned;
+
+  final List<BangumiItem> _rawItems = [];
+  final Set<int> _rawIds = <int>{};
+  int _offset = 0;
+  bool _isExhausted = false;
+  bool _isPreparing = false;
+  Object? _error;
+  Future<void>? _preparationFuture;
+
+  List<BangumiItem> get allItems => List.unmodifiable(_projectAll());
+
+  List<BangumiItem> get hideWatchedItems =>
+      List.unmodifiable(_projectHideWatched());
+
+  bool get isExhausted => _isExhausted;
+
+  bool get isPreparing => _isPreparing;
+
+  Object? get error => _error;
+
+  int get offset => _offset;
+
+  bool isReady(SearchViewMode mode, {int minimumItems = 20}) {
+    if (_isExhausted) return true;
+    final items = mode == SearchViewMode.all ? allItems : hideWatchedItems;
+    return items.length >= minimumItems;
+  }
+
+  Future<void> ensureReady({int minimumItems = 20}) async {
+    await ensureReadyFor(SearchViewMode.all, minimumItems: minimumItems);
+    if (_error != null) return;
+    await ensureReadyFor(SearchViewMode.hideWatched,
+        minimumItems: minimumItems);
+  }
+
+  Future<void> ensureReadyFor(
+    SearchViewMode mode, {
+    int minimumItems = 20,
+  }) {
+    final existing = _preparationFuture;
+    if (existing != null) return existing;
+
+    final future = _prepare(mode, minimumItems);
+    _preparationFuture = future;
+    return future.whenComplete(() {
+      if (identical(_preparationFuture, future)) {
+        _preparationFuture = null;
+      }
+    });
+  }
+
+  Future<void> ensureNextBatch(
+    SearchViewMode mode, {
+    int batchSize = 20,
+  }) async {
+    final currentCount =
+        mode == SearchViewMode.all ? allItems.length : hideWatchedItems.length;
+    await ensureReadyFor(mode, minimumItems: currentCount + batchSize);
+  }
+
+  Future<void> retry({int minimumItems = 20}) async {
+    if (_error == null) return;
+    await ensureReady(minimumItems: minimumItems);
+  }
+
+  void setHideAbandoned(bool value) {
+    hideAbandoned = value;
+  }
+
+  List<BangumiItem> _projectAll() {
+    final abandoned = _abandonedIds();
+    return _rawItems
+        .where((item) => !hideAbandoned || !abandoned.contains(item.id))
+        .toList(growable: false);
+  }
+
+  List<BangumiItem> _projectHideWatched() {
+    final watched = _watchedIds();
+    return _projectAll()
+        .where((item) => !watched.contains(item.id))
+        .toList(growable: false);
+  }
+
+  bool _hasEnough(List<BangumiItem> items, int minimumItems) {
+    return items.length >= minimumItems;
+  }
+
+  Future<void> _prepare(SearchViewMode mode, int minimumItems) async {
+    _isPreparing = true;
+    _error = null;
+    try {
+      while (!_isExhausted) {
+        final items =
+            mode == SearchViewMode.all ? _projectAll() : _projectHideWatched();
+        if (_hasEnough(items, minimumItems)) break;
+        final page = await _loadNextPage();
+        if (page == null) break;
+      }
+    } finally {
+      _isPreparing = false;
+    }
+  }
+
+  Future<BangumiSearchPage?> _loadNextPage() async {
+    final requestedOffset = _offset;
+    try {
+      final page = await _pageLoader(requestedOffset);
+      if (page == null) {
+        _error = StateError('Search page request failed');
+        return null;
+      }
+
+      _offset += page.rawCount;
+      if (page.rawCount < pageSize || page.rawCount == 0) {
+        _isExhausted = true;
+      }
+
+      final previousCount = _rawIds.length;
+      for (final item in page.items) {
+        if (_rawIds.add(item.id)) {
+          _rawItems.add(item);
+        }
+      }
+      if (_rawIds.length == previousCount) {
+        _isExhausted = true;
+      }
+      return page;
+    } catch (error) {
+      _error = error;
+      return null;
+    }
+  }
+}

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -41,9 +41,8 @@ class _SearchResultGridState extends State<SearchResultGrid>
   List<BangumiItem> _fromItems = const [];
   List<BangumiItem> _toItems = const [];
   late final AnimationController _animationController;
-  int? _anchorId;
-  double? _anchorY;
   bool _animating = false;
+  bool _reversingToStart = false;
 
   double get _rowExtent => widget.cardExtent + widget.spacing;
 
@@ -56,7 +55,9 @@ class _SearchResultGridState extends State<SearchResultGrid>
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 420),
-    )..addStatusListener(_handleAnimationStatus);
+    )
+      ..addListener(_rebuildForAnimation)
+      ..addStatusListener(_handleAnimationStatus);
   }
 
   @override
@@ -68,15 +69,33 @@ class _SearchResultGridState extends State<SearchResultGrid>
 
   @override
   void dispose() {
+    _animationController.removeListener(_rebuildForAnimation);
     _animationController.dispose();
     super.dispose();
   }
 
+  void _rebuildForAnimation() {
+    if (mounted && _animating) {
+      setState(() {});
+    }
+  }
+
   void _startTransition(List<BangumiItem> nextItems) {
-    _captureAnchor(nextItems);
+    if (_animating && _sameIds(nextItems, _fromItems)) {
+      _reversingToStart = true;
+      _animationController.reverse();
+      return;
+    }
+    if (_animating && _sameIds(nextItems, _toItems)) {
+      _reversingToStart = false;
+      _animationController.forward();
+      return;
+    }
+
     _animationController.stop();
     _fromItems = List<BangumiItem>.of(_visibleItems);
     _toItems = nextItems;
+    _reversingToStart = false;
 
     final reduceMotion =
         MediaQuery.maybeOf(context)?.disableAnimations ?? false;
@@ -86,7 +105,6 @@ class _SearchResultGridState extends State<SearchResultGrid>
         _fromItems = nextItems;
         _animating = false;
       });
-      WidgetsBinding.instance.addPostFrameCallback((_) => _restoreAnchor());
       return;
     }
 
@@ -94,73 +112,20 @@ class _SearchResultGridState extends State<SearchResultGrid>
     _animationController.forward(from: 0);
   }
 
-  void _captureAnchor(List<BangumiItem> nextItems) {
-    if (!widget.scrollController.hasClients || _visibleItems.isEmpty) {
-      _anchorId = null;
-      _anchorY = null;
-      return;
-    }
-    final offset = widget.scrollController.offset;
-    var row = math.max(0, (offset / _rowExtent).floor());
-    if (offset - row * _rowExtent >= widget.cardExtent) {
-      row++;
-    }
-    final firstVisibleIndex = math.min(
-      row * widget.crossCount,
-      _visibleItems.length - 1,
-    );
-    final nextIds = nextItems.map((item) => item.id).toSet();
-    var anchorIndex = -1;
-
-    for (var index = firstVisibleIndex; index < _visibleItems.length; index++) {
-      if (nextIds.contains(_visibleItems[index].id)) {
-        anchorIndex = index;
-        break;
-      }
-    }
-    for (var index = firstVisibleIndex - 1;
-        anchorIndex < 0 && index >= 0;
-        index--) {
-      if (nextIds.contains(_visibleItems[index].id)) {
-        anchorIndex = index;
-      }
-    }
-    if (anchorIndex < 0) {
-      _anchorId = null;
-      _anchorY = null;
-      return;
-    }
-
-    _anchorId = _visibleItems[anchorIndex].id;
-    _anchorY = (anchorIndex ~/ widget.crossCount) * _rowExtent - offset;
-  }
-
   void _handleAnimationStatus(AnimationStatus status) {
-    if (status != AnimationStatus.completed || !mounted) return;
+    if (!mounted ||
+        (status != AnimationStatus.completed &&
+            (status != AnimationStatus.dismissed || !_reversingToStart))) {
+      return;
+    }
+    final settledItems =
+        status == AnimationStatus.completed ? _toItems : _fromItems;
     setState(() {
-      _visibleItems = List<BangumiItem>.of(_toItems);
+      _visibleItems = List<BangumiItem>.of(settledItems);
       _fromItems = _visibleItems;
       _animating = false;
+      _reversingToStart = false;
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) => _restoreAnchor());
-  }
-
-  void _restoreAnchor() {
-    final anchorId = _anchorId;
-    final anchorY = _anchorY;
-    if (anchorId == null ||
-        anchorY == null ||
-        !widget.scrollController.hasClients) {
-      return;
-    }
-    final index = _visibleItems.indexWhere((item) => item.id == anchorId);
-    if (index < 0) return;
-    final row = index ~/ widget.crossCount;
-    final desiredOffset = row * _rowExtent - anchorY;
-    final position = widget.scrollController.position;
-    final clamped =
-        desiredOffset.clamp(0.0, position.maxScrollExtent).toDouble();
-    widget.scrollController.jumpTo(clamped);
   }
 
   bool _sameIds(List<BangumiItem> first, List<BangumiItem> second) {

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -1,0 +1,279 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+
+typedef SearchResultItemBuilder = Widget Function(
+  BuildContext context,
+  BangumiItem item,
+);
+
+/// A fixed-format search grid that animates cards between two ordered views.
+class SearchResultGrid extends StatefulWidget {
+  const SearchResultGrid({
+    super.key,
+    required this.items,
+    required this.crossCount,
+    required this.cardExtent,
+    required this.itemBuilder,
+    required this.scrollController,
+    this.spacing = 8,
+    this.padding = const EdgeInsets.fromLTRB(8, 0, 8, 0),
+    this.animate = true,
+  });
+
+  final List<BangumiItem> items;
+  final int crossCount;
+  final double cardExtent;
+  final SearchResultItemBuilder itemBuilder;
+  final ScrollController scrollController;
+  final double spacing;
+  final EdgeInsets padding;
+  final bool animate;
+
+  @override
+  State<SearchResultGrid> createState() => _SearchResultGridState();
+}
+
+class _SearchResultGridState extends State<SearchResultGrid>
+    with SingleTickerProviderStateMixin {
+  late List<BangumiItem> _visibleItems;
+  List<BangumiItem> _fromItems = const [];
+  List<BangumiItem> _toItems = const [];
+  late final AnimationController _animationController;
+  int? _anchorId;
+  double? _anchorY;
+  bool _animating = false;
+
+  double get _rowExtent => widget.cardExtent + widget.spacing;
+
+  @override
+  void initState() {
+    super.initState();
+    _visibleItems = List<BangumiItem>.of(widget.items);
+    _fromItems = _visibleItems;
+    _toItems = _visibleItems;
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 420),
+    )..addStatusListener(_handleAnimationStatus);
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchResultGrid oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_sameIds(widget.items, _toItems)) return;
+    _startTransition(List<BangumiItem>.of(widget.items));
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _startTransition(List<BangumiItem> nextItems) {
+    _captureAnchor(nextItems);
+    _animationController.stop();
+    _fromItems = List<BangumiItem>.of(_visibleItems);
+    _toItems = nextItems;
+
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    if (!widget.animate || reduceMotion) {
+      setState(() {
+        _visibleItems = nextItems;
+        _fromItems = nextItems;
+        _animating = false;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) => _restoreAnchor());
+      return;
+    }
+
+    setState(() => _animating = true);
+    _animationController.forward(from: 0);
+  }
+
+  void _captureAnchor(List<BangumiItem> nextItems) {
+    if (!widget.scrollController.hasClients || _visibleItems.isEmpty) {
+      _anchorId = null;
+      _anchorY = null;
+      return;
+    }
+    final offset = widget.scrollController.offset;
+    var row = math.max(0, (offset / _rowExtent).floor());
+    if (offset - row * _rowExtent >= widget.cardExtent) {
+      row++;
+    }
+    final firstVisibleIndex = math.min(
+      row * widget.crossCount,
+      _visibleItems.length - 1,
+    );
+    final nextIds = nextItems.map((item) => item.id).toSet();
+    var anchorIndex = -1;
+
+    for (var index = firstVisibleIndex; index < _visibleItems.length; index++) {
+      if (nextIds.contains(_visibleItems[index].id)) {
+        anchorIndex = index;
+        break;
+      }
+    }
+    for (var index = firstVisibleIndex - 1;
+        anchorIndex < 0 && index >= 0;
+        index--) {
+      if (nextIds.contains(_visibleItems[index].id)) {
+        anchorIndex = index;
+      }
+    }
+    if (anchorIndex < 0) {
+      _anchorId = null;
+      _anchorY = null;
+      return;
+    }
+
+    _anchorId = _visibleItems[anchorIndex].id;
+    _anchorY = (anchorIndex ~/ widget.crossCount) * _rowExtent - offset;
+  }
+
+  void _handleAnimationStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed || !mounted) return;
+    setState(() {
+      _visibleItems = List<BangumiItem>.of(_toItems);
+      _fromItems = _visibleItems;
+      _animating = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) => _restoreAnchor());
+  }
+
+  void _restoreAnchor() {
+    final anchorId = _anchorId;
+    final anchorY = _anchorY;
+    if (anchorId == null ||
+        anchorY == null ||
+        !widget.scrollController.hasClients) {
+      return;
+    }
+    final index = _visibleItems.indexWhere((item) => item.id == anchorId);
+    if (index < 0) return;
+    final row = index ~/ widget.crossCount;
+    final desiredOffset = row * _rowExtent - anchorY;
+    final position = widget.scrollController.position;
+    final clamped =
+        desiredOffset.clamp(0.0, position.maxScrollExtent).toDouble();
+    widget.scrollController.jumpTo(clamped);
+  }
+
+  bool _sameIds(List<BangumiItem> first, List<BangumiItem> second) {
+    if (first.length != second.length) return false;
+    for (var index = 0; index < first.length; index++) {
+      if (first[index].id != second[index].id) return false;
+    }
+    return true;
+  }
+
+  int _indexOf(List<BangumiItem> items, int id) {
+    return items.indexWhere((item) => item.id == id);
+  }
+
+  Offset _positionFor(int index, double tileWidth) {
+    final row = index ~/ widget.crossCount;
+    final column = index % widget.crossCount;
+    return Offset(
+      column * (tileWidth + widget.spacing),
+      row * _rowExtent,
+    );
+  }
+
+  Widget _buildAnimatedCard(
+    BuildContext context,
+    BangumiItem item,
+    double tileWidth,
+  ) {
+    final progress = Curves.easeInOut.transform(_animationController.value);
+    final fromIndex = _indexOf(_fromItems, item.id);
+    final toIndex = _indexOf(_toItems, item.id);
+    final startIndex = fromIndex >= 0 ? fromIndex : toIndex;
+    final endIndex = toIndex >= 0 ? toIndex : fromIndex;
+    final start = _positionFor(startIndex, tileWidth);
+    final end = _positionFor(endIndex, tileWidth);
+    final position = Offset.lerp(start, end, progress) ?? end;
+
+    final removed = toIndex < 0;
+    final added = fromIndex < 0;
+    final phase = _animationController.value;
+    final opacity = removed
+        ? 1 - Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+        : added
+            ? Curves.easeOut.transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+            : 1.0;
+    final scale = removed
+        ? 1 - 0.08 * Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+        : added
+            ? 0.92 +
+                0.08 *
+                    Curves.easeOut
+                        .transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+            : 1.0;
+
+    return Positioned(
+      key: ValueKey(item.id),
+      left: position.dx,
+      top: position.dy,
+      width: tileWidth,
+      height: widget.cardExtent,
+      child: Opacity(
+        opacity: opacity,
+        child: Transform.scale(
+          scale: scale,
+          child: widget.itemBuilder(context, item),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = math.max(
+          0.0,
+          constraints.maxWidth - widget.padding.horizontal,
+        );
+        final tileWidth = widget.crossCount <= 0
+            ? width
+            : (width - widget.spacing * (widget.crossCount - 1)) /
+                widget.crossCount;
+        final ids = <int>{
+          ..._fromItems.map((item) => item.id),
+          ..._toItems.map((item) => item.id),
+        };
+        final itemById = <int, BangumiItem>{
+          for (final item in [..._fromItems, ..._toItems]) item.id: item,
+        };
+        final maxRows = math.max(
+          (_fromItems.length / widget.crossCount).ceil(),
+          (_toItems.length / widget.crossCount).ceil(),
+        );
+
+        return SingleChildScrollView(
+          controller: widget.scrollController,
+          physics: _animating
+              ? const NeverScrollableScrollPhysics()
+              : const AlwaysScrollableScrollPhysics(),
+          padding: widget.padding,
+          child: SizedBox(
+            width: width,
+            height: math.max(0.0, maxRows * _rowExtent - widget.spacing),
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                for (final id in ids)
+                  _buildAnimatedCard(context, itemById[id]!, tileWidth),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,7 +116,7 @@ packages:
     source: hosted
     version: "2.0.3"
   auto_injector:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: auto_injector
       sha256: "81815294ad9a512e294d97819bdbeccc7f93f18daeceac321e0c046a6f25eeb1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -168,6 +168,7 @@ dependency_overrides:
       path: ./libs/ohos/media_kit_libs_ohos
 
 dev_dependencies:
+  auto_injector: ^2.2.0
   path_provider_platform_interface: ^2.1.2
   plugin_platform_interface: ^2.1.8
   flutter_test:

--- a/test/search_controller_view_test.dart
+++ b/test/search_controller_view_test.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/modules/search/search_history_module.dart';
+import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+import 'package:kazumi/repositories/search_history_repository.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+BangumiSearchPage _page(Iterable<int> ids, {int? rawCount}) {
+  final items = ids.map(_item).toList();
+  return BangumiSearchPage(items: items, rawCount: rawCount ?? items.length);
+}
+
+class _CollectRepository implements ICollectRepository {
+  Set<int> watched = <int>{};
+  Set<int> abandoned = <int>{};
+
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) {
+    return switch (type) {
+      CollectType.watched => watched,
+      CollectType.abandoned => abandoned,
+      _ => <int>{},
+    };
+  }
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => <int>{};
+
+  @override
+  bool getPrivateMode() => true;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}
+
+class _SearchHistoryRepository implements ISearchHistoryRepository {
+  @override
+  Future<void> clearAllHistories() async {}
+
+  @override
+  Future<void> deleteHistory(SearchHistory history) async {}
+
+  @override
+  Future<void> deleteDuplicates(String keyword) async {}
+
+  @override
+  Future<void> deleteOldest() async {}
+
+  @override
+  List<SearchHistory> getAllHistories() => <SearchHistory>[];
+
+  @override
+  bool isHistoryFull(int maxCount) => false;
+
+  @override
+  Future<bool> saveHistory(String keyword) async => true;
+}
+
+SearchPageController _controller(
+  SearchPageRequestLoader loader,
+  _CollectRepository collect,
+) {
+  return SearchPageController(
+    collect,
+    _SearchHistoryRepository(),
+    pageLoader: loader,
+  );
+}
+
+void main() {
+  test('initial search exposes all items before hidden view finishes',
+      () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final calls = <int>[];
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future;
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.bangumiList.map((item) => item.id),
+        Iterable<int>.generate(20, (i) => i + 1));
+    expect(controller.isHiddenViewPreparing, isTrue);
+    expect(calls, [0, 20]);
+
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+  });
+
+  test('requesting hidden view while preparing preserves all mode', () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller(
+      (keyword, filter, offset) => offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future,
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.pendingViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id),
+        Iterable<int>.generate(20, (i) => i + 1));
+
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.length, 20);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('failed hidden prefetch exposes retry state without clearing all items',
+      () async {
+    var attempts = 0;
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      attempts++;
+      if (attempts == 1) {
+        return Future<BangumiSearchPage?>.error(StateError('offline'));
+      }
+      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.hiddenViewError, isA<StateError>());
+    expect(controller.isHiddenViewPreparing, isFalse);
+    expect(controller.bangumiList.length, 20);
+
+    await controller.retryHiddenView();
+
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('late pages from an old query cannot replace the new query', () async {
+    final oldPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository();
+    final controller = _controller((keyword, filter, offset) {
+      if (keyword == 'old') return oldPage.future;
+      return Future.value(_page([99]));
+    }, collect);
+
+    final oldSearch = controller.searchBangumi('old', type: 'init');
+    await Future<void>.delayed(Duration.zero);
+    await controller.searchBangumi('new', type: 'init');
+    oldPage.complete(_page([1]));
+    await oldSearch;
+
+    expect(controller.bangumiList.map((item) => item.id), [99]);
+  });
+
+  test('cached raw pages are reused when revealing the next all batch',
+      () async {
+    final calls = <int>[];
+    final secondPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => secondPage.future,
+        _ => Future.value(null),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+    await controller.searchBangumi('alpha', type: 'add');
+
+    expect(controller.bangumiList.length, 40);
+    expect(calls, [0, 20]);
+  });
+
+  test('changing hide abandoned rebuilds both projections from raw order',
+      () async {
+    final collect = _CollectRepository()..abandoned = {1};
+    final controller = _controller(
+      (keyword, filter, offset) =>
+          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.setNotShowAbandonedBangumis(true);
+
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
+  });
+
+  test('hiding abandoned items refills the prepared views', () async {
+    final collect = _CollectRepository()
+      ..abandoned = {for (var i = 1; i < 20; i++) i};
+    final calls = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        _ => Future.value(null),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.setNotShowAbandonedBangumis(true);
+
+    expect(calls, [0, 20]);
+    expect(controller.bangumiList.length, 20);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('an empty hidden view can switch back to all results', () async {
+    final collect = _CollectRepository()..watched = {1, 2, 3};
+    final controller = _controller(
+      (keyword, filter, offset) =>
+          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList, isEmpty);
+
+    await controller.requestViewMode(SearchViewMode.all);
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.bangumiList.map((item) => item.id), [1, 2, 3]);
+  });
+
+  test('new search from hidden mode never publishes watched items first',
+      () async {
+    final hiddenPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      return hiddenPage.future;
+    }, collect);
+    controller.selectedViewMode = SearchViewMode.hideWatched;
+
+    final search = controller.searchBangumi('new', type: 'init');
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.bangumiList, isEmpty);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+
+    hiddenPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await search;
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.first.id, 20);
+  });
+}

--- a/test/search_controller_view_test.dart
+++ b/test/search_controller_view_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:auto_injector/auto_injector.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/collect/collect_type.dart';
@@ -100,14 +101,25 @@ SearchPageController _controller(
   SearchPageRequestLoader loader,
   _CollectRepository collect,
 ) {
-  return SearchPageController(
+  return SearchPageController.withPageLoader(
     collect,
     _SearchHistoryRepository(),
-    pageLoader: loader,
+    loader,
   );
 }
 
 void main() {
+  test('can be created through the route injector', () {
+    final injector = AutoInjector();
+    injector
+      ..add<ICollectRepository>(_CollectRepository.new)
+      ..add<ISearchHistoryRepository>(_SearchHistoryRepository.new)
+      ..add<SearchPageController>(SearchPageController.new)
+      ..commit();
+
+    expect(injector.get<SearchPageController>(), isA<SearchPageController>());
+  });
+
   test('initial search exposes all items before hidden view finishes',
       () async {
     final secondPage = Completer<BangumiSearchPage?>();
@@ -188,6 +200,55 @@ void main() {
     expect(controller.hiddenViewError, isNull);
     expect(controller.selectedViewMode, SearchViewMode.hideWatched);
     expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('a failed search started from hidden mode can retry in place', () async {
+    var attempts = 0;
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      attempts++;
+      return attempts == 1
+          ? Future<BangumiSearchPage?>.error(StateError('offline'))
+          : Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    }, collect)
+      ..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.hiddenViewError, isA<StateError>());
+    expect(controller.bangumiList, isEmpty);
+
+    await controller.retryHiddenView();
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.isTimeOut, isFalse);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('finishing a load more request preserves a newer view selection',
+      () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final controller = _controller(
+      (keyword, filter, offset) => offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future,
+      _CollectRepository(),
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    final loadMore = controller.searchBangumi('alpha', type: 'add');
+    await Future<void>.delayed(Duration.zero);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await loadMore;
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
   });
 
   test('late pages from an old query cannot replace the new query', () async {

--- a/test/search_page_test.dart
+++ b/test/search_page_test.dart
@@ -1,0 +1,222 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/modules/search/search_history_module.dart';
+import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_page.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+import 'package:kazumi/repositories/search_history_repository.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+import 'package:kazumi/services/storage/storage.dart';
+
+class _CollectRepository implements ICollectRepository {
+  Set<int> watched = <int>{};
+
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) {
+    return type == CollectType.watched ? watched : <int>{};
+  }
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => <int>{};
+
+  @override
+  bool getPrivateMode() => true;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}
+
+class _SearchHistoryRepository implements ISearchHistoryRepository {
+  @override
+  Future<void> clearAllHistories() async {}
+
+  @override
+  Future<void> deleteHistory(SearchHistory history) async {}
+
+  @override
+  Future<void> deleteDuplicates(String keyword) async {}
+
+  @override
+  Future<void> deleteOldest() async {}
+
+  @override
+  List<SearchHistory> getAllHistories() => <SearchHistory>[];
+
+  @override
+  bool isHistoryFull(int maxCount) => false;
+
+  @override
+  Future<bool> saveHistory(String keyword) async => true;
+}
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('kazumi_search_page_test_');
+    Hive.init(tempDir.path);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => tempDir.path,
+    );
+    await GStorage.init();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('opens with an empty result state without a framework exception',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('搜索'), findsOneWidget);
+  });
+
+  testWidgets('opens when the hidden view is selected before it has results',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    )..selectedViewMode = SearchViewMode.hideWatched;
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('隐藏已看'), findsOneWidget);
+  });
+
+  testWidgets('retries failed hidden view preparation from the control',
+      (tester) async {
+    var attempts = 0;
+    final controller = SearchPageController.withPageLoader(
+      _CollectRepository()..watched = {for (var i = 1; i < 20; i++) i},
+      _SearchHistoryRepository(),
+      (keyword, filter, offset) {
+        if (offset == 0) {
+          return Future.value(
+            BangumiSearchPage(
+              items: List<BangumiItem>.generate(20, (i) => _item(i + 1)),
+              rawCount: 40,
+            ),
+          );
+        }
+        attempts++;
+        return attempts == 1
+            ? Future<BangumiSearchPage?>.error(StateError('offline'))
+            : Future.value(
+                BangumiSearchPage(
+                  items: List<BangumiItem>.generate(20, (i) => _item(i + 21)),
+                  rawCount: 40,
+                ),
+              );
+      },
+    )..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(find.byTooltip('重试准备隐藏已看'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('重试准备隐藏已看'));
+    await tester.pumpAndSettle();
+
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(find.text('name-20'), findsOneWidget);
+  });
+
+  testWidgets('opens a populated result grid without a framework exception',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    )..bangumiList.addAll([_item(1), _item(2), _item(3)]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('name-1'), findsOneWidget);
+  });
+
+  testWidgets('opens the search input view without a framework exception',
+      (tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.tap(find.byType(SearchBar));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/search_result_buffer_test.dart
+++ b/test/search_result_buffer_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+BangumiSearchPage _page(Iterable<int> ids, {int? rawCount}) {
+  final items = ids.map(_item).toList();
+  return BangumiSearchPage(items: items, rawCount: rawCount ?? items.length);
+}
+
+void main() {
+  test(
+      'fills hidden view from later raw pages when first page is mostly watched',
+      () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page(Iterable<int>.generate(20, (index) => index + 1)),
+        20 => _page(Iterable<int>.generate(20, (index) => index + 21)),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => Set<int>.from(Iterable<int>.generate(19, (i) => i + 1)),
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.allItems.take(20).map((item) => item.id),
+        Iterable<int>.generate(20, (index) => index + 1));
+    expect(buffer.hideWatchedItems.take(20).map((item) => item.id),
+        [20, ...Iterable<int>.generate(19, (index) => index + 21)]);
+    expect(offsets, [0, 20]);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+  });
+
+  test('advances offset by raw count instead of filtered item count', () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page([1, 2], rawCount: 5),
+        5 => _page([3, 4], rawCount: 2),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+      pageSize: 5,
+    );
+
+    await buffer.ensureReady();
+
+    expect(offsets, [0, 5]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2, 3, 4]);
+  });
+
+  test('deduplicates IDs and stops when a page adds no new item', () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page([1, 2], rawCount: 20),
+        20 => _page([1, 2], rawCount: 20),
+        40 => _page([3], rawCount: 1),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(offsets, [0, 20]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2]);
+    expect(buffer.isExhausted, isTrue);
+  });
+
+  test(
+      'marks filtered view ready with fewer items when raw results are exhausted',
+      () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async => offset == 0 ? _page([1, 2]) : null,
+      watchedIds: () => <int>{1},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.hideWatchedItems.map((item) => item.id), [2]);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+  });
+
+  test('retries a failed page without discarding existing results', () async {
+    var attempts = 0;
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async {
+        attempts++;
+        if (attempts == 1) throw StateError('temporary failure');
+        return _page([1]);
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+    expect(buffer.error, isA<StateError>());
+    expect(buffer.allItems, isEmpty);
+
+    await buffer.retry();
+
+    expect(buffer.error, isNull);
+    expect(buffer.allItems.map((item) => item.id), [1]);
+  });
+
+  test('applies hide abandoned to both views before hide watched', () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async => offset == 0 ? _page([1, 2, 3]) : null,
+      watchedIds: () => <int>{2},
+      abandonedIds: () => <int>{1},
+      hideAbandoned: true,
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.allItems.map((item) => item.id), [2, 3]);
+    expect(buffer.hideWatchedItems.map((item) => item.id), [3]);
+  });
+}

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/pages/search/search_result_grid.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+Widget _card(BuildContext context, BangumiItem item) {
+  return ColoredBox(
+    key: ValueKey(item.id),
+    color: Colors.blueGrey,
+    child: Center(child: Text('item-${item.id}')),
+  );
+}
+
+void main() {
+  testWidgets('renders items in the supplied order', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchResultGrid(
+            items: [_item(1), _item(2), _item(3)],
+            crossCount: 2,
+            cardExtent: 100,
+            itemBuilder: _card,
+            scrollController: ScrollController(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('item-1'), findsOneWidget);
+    expect(find.text('item-2'), findsOneWidget);
+    expect(find.text('item-3'), findsOneWidget);
+  });
+
+  testWidgets('animates removed cards before settling on the hidden list',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump(const Duration(milliseconds: 80));
+    expect(find.text('item-2'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('item-2'), findsNothing);
+    expect(find.text('item-3'), findsOneWidget);
+  });
+
+  testWidgets('preserves the visible anchor after restoring the all list',
+      (tester) async {
+    late StateSetter update;
+    var items = List<BangumiItem>.generate(12, (index) => _item(index + 1));
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    scrollController.jumpTo(208);
+    await tester.pump();
+    update(() => items = [
+          _item(1),
+          _item(2),
+          _item(5),
+          _item(6),
+          _item(7),
+          _item(8),
+          _item(9),
+          _item(10),
+          _item(11),
+          _item(12),
+        ]);
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, closeTo(100, 2));
+
+    update(() =>
+        items = List<BangumiItem>.generate(12, (index) => _item(index + 1)));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, closeTo(208, 2));
+    expect(find.text('item-5'), findsOneWidget);
+  });
+}

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -79,15 +79,68 @@ void main() {
       ),
     );
 
+    final initialPosition = tester.getTopLeft(find.text('item-3'));
     update(() => items = [_item(1), _item(3)]);
-    await tester.pump(const Duration(milliseconds: 80));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+
     expect(find.text('item-2'), findsOneWidget);
+    final middlePosition = tester.getTopLeft(find.text('item-3'));
     await tester.pumpAndSettle();
+
+    final finalPosition = tester.getTopLeft(find.text('item-3'));
+    expect(middlePosition.dy, lessThan(initialPosition.dy));
+    expect(middlePosition.dy, greaterThan(finalPosition.dy));
     expect(find.text('item-2'), findsNothing);
     expect(find.text('item-3'), findsOneWidget);
   });
 
-  testWidgets('preserves the visible anchor after restoring the all list',
+  testWidgets('reverses an in-progress view transition without snapping',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    final initialPosition = tester.getTopLeft(find.text('item-3'));
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+    final hiddenPosition = tester.getTopLeft(find.text('item-3'));
+
+    update(() => items = [_item(1), _item(2), _item(3), _item(4)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 105));
+    final returningPosition = tester.getTopLeft(find.text('item-3'));
+
+    expect(returningPosition.dy, greaterThan(hiddenPosition.dy));
+    expect(returningPosition.dy, lessThan(initialPosition.dy));
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('item-3')).dy,
+        closeTo(initialPosition.dy, 0.1));
+  });
+
+  testWidgets('keeps the current scroll position when switching views',
       (tester) async {
     late StateSetter update;
     var items = List<BangumiItem>.generate(12, (index) => _item(index + 1));
@@ -128,7 +181,7 @@ void main() {
           _item(12),
         ]);
     await tester.pumpAndSettle();
-    expect(scrollController.offset, closeTo(100, 2));
+    expect(scrollController.offset, closeTo(208, 2));
 
     update(() =>
         items = List<BangumiItem>.generate(12, (index) => _item(index + 1)));


### PR DESCRIPTION
Fixes #2304

## 问题
旧实现先加载有限的原始搜索结果，再在页面端过滤已看条目。搜索结果前段大多已看时，例如 issue 中的《名侦探柯南》剧场版，开启“隐藏已看”后会只剩一两项可见结果，尽管后续页仍有未看的 TV 版或特别篇。

## 修改内容
- 缓存已获取的原始搜索页，分别生成“全部”和“隐藏已看”结果视图。
- 后台继续请求后续页，直到“隐藏已看”视图有 20 项结果或服务端结果耗尽；不会只过滤首批结果。
- 保留高级筛选面板中的“隐藏已看”，同时在结果顶部提供“全部 / 隐藏已看”常驻切换。
- 切换中保留卡片连续移动，已看卡片淡出、恢复时淡入；移除结束后的强制滚动定位。
- 补充隐藏视图准备失败的重试、异步分页竞争和快速反向切换的处理。
- 修复搜索页经 Flutter Modular 创建控制器时的红屏崩溃。

## 验证
- 覆盖“前 19 项已看、第二页补足隐藏视图”的回归测试。
- `flutter test --no-pub`（152 项通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无错误或警告；17 条仓库原有 info）
- `flutter build apk --debug --no-pub`（通过）
- Android 真机验证核心搜索和双视图切换；失败恢复、加载竞争和快速反向切换由自动化回归测试覆盖。