### PR TITLE
feat: 番剧详情页新增集数列表弹窗和集成按钮 

### DIFF
--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -14,11 +14,15 @@ class BangumiInfoCardV extends StatefulWidget {
     required this.bangumiItem,
     required this.isLoading,
     required this.showRating,
+    this.onEpisodesTap,
   });
 
   final BangumiItem bangumiItem;
   final bool isLoading;
   final bool showRating;
+
+  /// 点击「集数详情」按钮的回调。为 null 时不显示该按钮。
+  final VoidCallback? onEpisodesTap;
 
   @override
   State<BangumiInfoCardV> createState() => _BangumiInfoCardVState();
@@ -246,12 +250,23 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                             ),
                           ],
                         ),
-                        SizedBox(
-                          width: 120,
-                          height: 40,
-                          child: CollectButton.extend(
-                            bangumiItem: widget.bangumiItem,
-                          ),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              width: 120,
+                              height: 40,
+                              child: CollectButton.extend(
+                                bangumiItem: widget.bangumiItem,
+                              ),
+                            ),
+                            if (widget.onEpisodesTap != null) ...[
+                              const SizedBox(width: 8),
+                              _EpisodeListButton(
+                                onPressed: widget.onEpisodesTap!,
+                              ),
+                            ],
+                          ],
                         ),
                       ],
                     ),
@@ -266,6 +281,37 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 番剧详情卡片右上角的「集数详情」按钮
+class _EpisodeListButton extends StatelessWidget {
+  const _EpisodeListButton({
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 40,
+      height: 40,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: const Icon(Icons.video_collection_rounded),
+        style: IconButton.styleFrom(
+          backgroundColor: theme.colorScheme.primaryContainer,
+          foregroundColor: theme.colorScheme.onPrimaryContainer,
+          padding: EdgeInsets.zero,
+          minimumSize: const Size(40, 40),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(16)),
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/info/episode_list_sheet.dart
+++ b/lib/pages/info/episode_list_sheet.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:kazumi/bean/widget/error_widget.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/episode_item.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+/// 番剧详情页的「集数详情」浮动展示。
+///
+/// 仅展示 Bangumi `/v0/episodes` 返回的分集元信息，点击不跳转播放页，
+/// 与视频源/播放链路完全解耦。
+class EpisodeListSheet extends StatelessWidget {
+  const EpisodeListSheet({
+    super.key,
+    required this.bangumiItem,
+    required this.episodeList,
+    required this.isLoading,
+    required this.queryTimeout,
+    required this.isEmpty,
+    required this.onRetry,
+  });
+
+  final BangumiItem bangumiItem;
+  final List<EpisodeInfo> episodeList;
+  final bool isLoading;
+  final bool queryTimeout;
+  final bool isEmpty;
+  final Future<void> Function() onRetry;
+
+  /// 把 [EpisodeInfo.type] 映射为分段标题。
+  /// 0=本篇 / 1=特别篇 / 2=片头曲 / 3=片尾曲。
+  String _sectionTitle(int type) {
+    switch (type) {
+      case 0:
+        return '本篇';
+      case 1:
+        return '特别篇';
+      case 2:
+        return '片头曲';
+      case 3:
+        return '片尾曲';
+      default:
+        return '其它';
+    }
+  }
+
+  /// 渲染单集编号前缀，例如 `EP1`、`SP2`、`OP`、`ED`。
+  /// type=2/3 的 OP/ED 通常没有 sort，直接显示类型缩写。
+  String _episodePrefix(EpisodeInfo episode) {
+    final typeStr = episode.readType().toUpperCase();
+    final sort = episode.episode;
+    if (sort == 0 && (episode.type == 2 || episode.type == 3)) {
+      return typeStr;
+    }
+    // sort 是 num，可能是 1.0 或 1.5。整数显示为整数。
+    final sortStr =
+        sort == sort.toInt() ? sort.toInt().toString() : sort.toString();
+    return '$typeStr$sortStr';
+  }
+
+  /// 优先用中文名，回退到日文名。
+  String _episodeName(EpisodeInfo episode) {
+    final cn = episode.nameCn.trim();
+    if (cn.isNotEmpty) return cn;
+    return episode.name.trim();
+  }
+
+  /// 按 type 分组并保留 Bangumi 返回顺序。
+  List<({String title, List<EpisodeInfo> episodes})> _groupedSections() {
+    final byType = <int, List<EpisodeInfo>>{};
+    final order = <int>[];
+    for (final ep in episodeList) {
+      final type = ep.type;
+      if (!byType.containsKey(type)) {
+        byType[type] = <EpisodeInfo>[];
+        order.add(type);
+      }
+      byType[type]!.add(ep);
+    }
+    return [
+      for (final type in order)
+        (title: _sectionTitle(type), episodes: byType[type]!),
+    ];
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title, int count) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12, bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '($count)',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEpisodeTile(BuildContext context, EpisodeInfo episode) {
+    final prefix = _episodePrefix(episode);
+    final name = _episodeName(episode);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 56),
+            child: SelectableText(
+              '$prefix:',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: SelectableText(
+              name,
+              style: name.isEmpty
+                  ? TextStyle(
+                      color: Theme.of(context).colorScheme.outline,
+                      fontStyle: FontStyle.italic,
+                    )
+                  : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    if (isLoading && episodeList.isEmpty) {
+      return Skeletonizer.zone(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (int i = 0; i < 6; i++)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Bone.text(fontSize: 14, width: 40),
+                    const SizedBox(width: 8),
+                    Expanded(child: Bone.text(fontSize: 14, width: 200)),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    if (queryTimeout && episodeList.isEmpty) {
+      return GeneralErrorWidget(
+        errMsg: '集数获取失败',
+        actions: [
+          GeneralErrorButton(
+            onPressed: () => onRetry(),
+            text: '重试',
+          ),
+        ],
+      );
+    }
+
+    if (isEmpty && episodeList.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Text('什么都没有找到 (´;ω;`)'),
+        ),
+      );
+    }
+
+    final sections = _groupedSections();
+    return ListView.builder(
+      shrinkWrap: true,
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+      itemCount: sections.length,
+      itemBuilder: (context, sectionIndex) {
+        final section = sections[sectionIndex];
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildSectionHeader(context, section.title, section.episodes.length),
+            for (final episode in section.episodes)
+              _buildEpisodeTile(context, episode),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 16, 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '集数详情',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '数据来源：Bangumi · 仅作参考，请以实际播放源集数为准',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: '关闭',
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Flexible(child: _buildContent(context)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -1,6 +1,7 @@
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/modules/bangumi/bangumi_interest.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/episode_item.dart';
 import 'package:kazumi/pages/collect/collect_controller.dart';
 import 'package:kazumi/modules/search/plugin_search_module.dart';
 import 'package:kazumi/pages/info/rating_review_dialog.dart';
@@ -39,6 +40,19 @@ abstract class _InfoController with Store {
   @observable
   var staffList = ObservableList<StaffFullItem>();
 
+  // 分集列表：进入番剧详情页自动预加载，仅用于展示。
+  @observable
+  var episodeList = ObservableList<EpisodeInfo>();
+
+  @observable
+  bool episodesIsLoading = false;
+
+  @observable
+  bool episodesQueryTimeout = false;
+
+  @observable
+  bool episodesIsEmpty = false;
+
   bool _isFillingInterestUserProfile = false;
 
   int _commentsOffset = 0;
@@ -46,6 +60,13 @@ abstract class _InfoController with Store {
   void clearComments() {
     commentsList.clear();
     _commentsOffset = 0;
+  }
+
+  void clearEpisodes() {
+    episodeList.clear();
+    episodesIsLoading = false;
+    episodesQueryTimeout = false;
+    episodesIsEmpty = false;
   }
 
   Future<bool> fillInterestUserProfileIfNeeded() async {
@@ -202,6 +223,32 @@ abstract class _InfoController with Store {
     });
     KazumiLogger()
         .i('InfoController: loaded staff list length ${staffList.length}');
+  }
+
+  Future<void> queryBangumiEpisodesByID(int id) async {
+    if (episodesIsLoading) {
+      return;
+    }
+    episodesIsLoading = true;
+    episodesQueryTimeout = false;
+    episodesIsEmpty = false;
+    try {
+      final list = await BangumiApi.getBangumiEpisodesByID(id);
+      episodeList = ObservableList<EpisodeInfo>.of(list);
+      // BangumiApi.getBangumiEpisodesByID 内部吞掉异常后返回空列表，
+      // 因此空列表既可能是失败也可能是真空。统一走「重试」入口，
+      // 让用户决定是再拉一次还是放弃。
+      if (episodeList.isEmpty) {
+        episodesQueryTimeout = true;
+      }
+      KazumiLogger().i(
+          'InfoController: loaded episode list length ${episodeList.length}');
+    } catch (e) {
+      KazumiLogger().e('InfoController: failed to load episodes', error: e);
+      episodesQueryTimeout = true;
+    } finally {
+      episodesIsLoading = false;
+    }
   }
 
   Future<bool> rateBangumi(RatingReviewResult data,

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -15,6 +15,7 @@ import 'package:kazumi/plugins/plugins_controller.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/pages/info/info_tabview.dart';
+import 'package:kazumi/pages/info/episode_list_sheet.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -206,6 +207,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.clearComments();
     infoController.staffList.clear();
     infoController.pluginSearchResponseList.clear();
+    infoController.clearEpisodes();
     // Search results can miss rating distribution or summaries, so fill those
     // fields without replacing image URLs that are already rendered.
     if (_needsBangumiInfoRefresh(infoController.bangumiItem)) {
@@ -216,6 +218,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
         enforceMinimumLoadingDuration: true,
       );
     }
+    // 分集列表仅做展示，与播放页解耦，进入详情页即自动预加载。
+    loadEpisodes();
     sourceTabController =
         TabController(length: pluginsController.pluginList.length, vsync: this);
     infoTabController = TabController(length: _infoTabs.length, vsync: this);
@@ -224,6 +228,34 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoTabController.addListener(onInfoTabChanged);
     infoTabController.addListener(_syncFabTabIndex);
     infoTabController.animation?.addListener(_syncFabTabIndex);
+  }
+
+  Future<void> loadEpisodes() async {
+    await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> retryLoadEpisodes() async {
+    await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void showEpisodeListSheet() {
+    showAdaptiveBottomSheet<void>(
+      context: context,
+      builder: (context) => EpisodeListSheet(
+        bangumiItem: infoController.bangumiItem,
+        episodeList: infoController.episodeList,
+        isLoading: infoController.episodesIsLoading,
+        queryTimeout: infoController.episodesQueryTimeout,
+        isEmpty: infoController.episodesIsEmpty,
+        onRetry: retryLoadEpisodes,
+      ),
+    );
   }
 
   void onInfoTabChanged() {
@@ -290,6 +322,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.clearComments();
     infoController.staffList.clear();
     infoController.pluginSearchResponseList.clear();
+    infoController.clearEpisodes();
     sourceTabController.dispose();
     infoTabController.dispose();
     super.dispose();
@@ -440,6 +473,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
                                       bangumiItem: infoController.bangumiItem,
                                       isLoading: showBangumiInfoSkeleton,
                                       showRating: showRating,
+                                      onEpisodesTap: showEpisodeListSheet,
                                     ),
                                   ),
                                 ),


### PR DESCRIPTION
## 关联issue 
# 修改
- 支持分组显示（本篇/特别篇/OP/ED）及骨架屏加载 
- 集成到番剧详情页，补齐原有交互遗漏