### PR TITLE
fix: 补足搜索“隐藏已看”结果并优化切换体验

### DIFF
--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -40,8 +40,6 @@ class SearchPageController extends _SearchPageController
 
 abstract class _SearchPageController with Store implements Disposable {
   static const int _searchPageSize = 20;
-  static const Duration _defaultPageRequestInterval =
-      Duration(milliseconds: 250);
   static const Duration _collectionRefreshDebounce = Duration(milliseconds: 50);
 
   _SearchPageController(
@@ -50,9 +48,7 @@ abstract class _SearchPageController with Store implements Disposable {
     SearchPageRequestLoader? pageLoader,
   })  : _collectRepository = collectRepository,
         _searchHistoryRepository = searchHistoryRepository,
-        _pageLoader = pageLoader ?? _defaultPageLoader,
-        _searchPageRequestInterval =
-            pageLoader == null ? _defaultPageRequestInterval : Duration.zero {
+        _pageLoader = pageLoader ?? _defaultPageLoader {
     _collectiblesSubscription =
         _collectRepository.onCollectiblesChanged.listen((_) {
       _scheduleResultProjectionRefresh();
@@ -62,7 +58,6 @@ abstract class _SearchPageController with Store implements Disposable {
   final ICollectRepository _collectRepository;
   final ISearchHistoryRepository _searchHistoryRepository;
   final SearchPageRequestLoader _pageLoader;
-  final Duration _searchPageRequestInterval;
   late final StreamSubscription<void> _collectiblesSubscription;
   Timer? _collectiblesRefreshTimer;
 
@@ -85,13 +80,12 @@ abstract class _SearchPageController with Store implements Disposable {
   }
 
   SearchResultBuffer? _resultBuffer;
-  Future<void>? _backgroundPreparation;
   int _queryGeneration = 0;
   String _activeInput = '';
   bool _disposed = false;
-  final Map<SearchViewMode, int> _publishedCounts = {};
 
-  bool hasMoreSearchResults = true;
+  @observable
+  bool hasMoreSearchResults = false;
 
   @observable
   bool isLoading = false;
@@ -107,18 +101,6 @@ abstract class _SearchPageController with Store implements Disposable {
 
   @observable
   SearchViewMode selectedViewMode = SearchViewMode.all;
-
-  @observable
-  SearchViewMode? pendingViewMode;
-
-  @observable
-  bool isHiddenViewPreparing = false;
-
-  @observable
-  bool isHiddenViewReady = false;
-
-  @observable
-  Object? hiddenViewError;
 
   @observable
   ObservableList<SearchHistory> searchHistories = ObservableList.of([]);
@@ -157,12 +139,6 @@ abstract class _SearchPageController with Store implements Disposable {
     final generation = ++_queryGeneration;
     _activeInput = normalizedInput;
     _resultBuffer = null;
-    _backgroundPreparation = null;
-    _publishedCounts.clear();
-    pendingViewMode = null;
-    isHiddenViewPreparing = false;
-    isHiddenViewReady = false;
-    hiddenViewError = null;
     hasMoreSearchResults = true;
     bangumiList.clear();
     isLoading = true;
@@ -192,26 +168,17 @@ abstract class _SearchPageController with Store implements Disposable {
           watchedIds: loadWatchedBangumiIds,
           abandonedIds: loadAbandonedBangumiIds,
           hideAbandoned: notShowAbandonedBangumis,
-          pageRequestInterval: _searchPageRequestInterval,
           shouldContinue: () =>
               generation == _queryGeneration &&
               identical(_resultBuffer, buffer),
         );
         _resultBuffer = buffer;
-        await buffer.ensureReadyFor(SearchViewMode.all);
+        await buffer.loadNextPage();
         if (generation != _queryGeneration) return;
-        if (requestedMode == SearchViewMode.hideWatched) {
-          pendingViewMode = SearchViewMode.hideWatched;
-          await _startHiddenPreparation(generation);
-          if (generation != _queryGeneration) return;
-          isLoading = false;
-          isTimeOut = hiddenViewError != null;
-        } else {
-          _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
-          isLoading = false;
-          isTimeOut = bangumiList.isEmpty;
-          _startHiddenPreparation(generation);
-        }
+        _publishMode(requestedMode);
+        isLoading = false;
+        isTimeOut =
+            bangumiList.isEmpty && (buffer.error != null || buffer.isExhausted);
         return;
       }
     }
@@ -223,198 +190,52 @@ abstract class _SearchPageController with Store implements Disposable {
       watchedIds: loadWatchedBangumiIds,
       abandonedIds: loadAbandonedBangumiIds,
       hideAbandoned: notShowAbandonedBangumis,
-      pageRequestInterval: _searchPageRequestInterval,
       shouldContinue: () =>
           generation == _queryGeneration && identical(_resultBuffer, buffer),
     );
     _resultBuffer = buffer;
-    await buffer.ensureReadyFor(SearchViewMode.all);
+    await buffer.loadNextPage();
     if (generation != _queryGeneration) return;
-    if (requestedMode == SearchViewMode.hideWatched) {
-      pendingViewMode = SearchViewMode.hideWatched;
-      await _startHiddenPreparation(generation);
-      if (generation != _queryGeneration) return;
-      isLoading = false;
-      isTimeOut = hiddenViewError != null;
-    } else {
-      _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
-      isLoading = false;
-      isTimeOut =
-          bangumiList.isEmpty && (buffer.error != null || buffer.isExhausted);
-      _startHiddenPreparation(generation);
-    }
+    _publishMode(requestedMode);
+    isLoading = false;
+    isTimeOut =
+        bangumiList.isEmpty && (buffer.error != null || buffer.isExhausted);
   }
 
   @action
   Future<void> requestViewMode(SearchViewMode mode) async {
     final buffer = _resultBuffer;
     if (buffer == null) return;
-    if (mode == selectedViewMode && pendingViewMode == null) return;
-
-    pendingViewMode = mode;
-    if (mode == SearchViewMode.all) {
-      _publishMode(
-        SearchViewMode.all,
-        minimumItems: _minimumPublishedItems(SearchViewMode.all),
-      );
-      pendingViewMode = null;
-      return;
-    }
-
-    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
-    if (isHiddenViewReady && hiddenViewError == null) {
-      _publishMode(
-        SearchViewMode.hideWatched,
-        minimumItems: _minimumPublishedItems(SearchViewMode.hideWatched),
-      );
-      pendingViewMode = null;
-      return;
-    }
-    if (hiddenViewError == null) {
-      _startHiddenPreparation(_queryGeneration);
-    }
+    if (mode == selectedViewMode) return;
+    _publishMode(mode);
   }
 
   @action
-  Future<void> retryHiddenView() async {
-    final buffer = _resultBuffer;
-    if (buffer == null) return;
-    final retryingSelectedHiddenView =
-        selectedViewMode == SearchViewMode.hideWatched;
-    pendingViewMode = SearchViewMode.hideWatched;
-    hiddenViewError = null;
-    isHiddenViewPreparing = true;
-    if (retryingSelectedHiddenView) {
-      isLoading = true;
-      isTimeOut = false;
-    }
-    final generation = _queryGeneration;
-    final future = buffer.retry(minimumItems: _searchPageSize);
-    _backgroundPreparation = future;
-    try {
-      await future;
-    } finally {
-      if (identical(_backgroundPreparation, future)) {
-        _backgroundPreparation = null;
-      }
-    }
-    if (generation != _queryGeneration) return;
-    _finishHiddenPreparation(generation);
-    if (retryingSelectedHiddenView) {
-      isLoading = false;
-      isTimeOut = hiddenViewError != null;
-    }
-  }
-
-  Future<void> waitForBackgroundPreparation() async {
-    final preparation = _backgroundPreparation;
-    if (preparation == null) return;
-    await preparation;
-    await Future<void>.delayed(Duration.zero);
-  }
-
-  Future<void> _startHiddenPreparation(int generation) {
-    final buffer = _resultBuffer;
-    if (buffer == null || generation != _queryGeneration) {
-      return Future<void>.value();
-    }
-    final existing = _backgroundPreparation;
-    if (existing != null) return existing;
-    if (buffer.isReady(SearchViewMode.all) &&
-        buffer.isReady(SearchViewMode.hideWatched) &&
-        buffer.error == null) {
-      _finishHiddenPreparation(generation);
-      return Future<void>.value();
-    }
-
-    isHiddenViewPreparing = true;
-    hiddenViewError = null;
-    late final Future<void> preparation;
-    preparation =
-        buffer.ensureReady(minimumItems: _searchPageSize).whenComplete(() {
-      if (generation == _queryGeneration) {
-        _finishHiddenPreparation(generation);
-      }
-      if (identical(_backgroundPreparation, preparation)) {
-        _backgroundPreparation = null;
-      }
-    });
-    _backgroundPreparation = preparation;
-    return preparation;
-  }
-
-  void _finishHiddenPreparation(int generation) {
-    final buffer = _resultBuffer;
-    if (buffer == null || generation != _queryGeneration) return;
-    isHiddenViewPreparing = false;
-    hiddenViewError = buffer.error;
-    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
-    if (hiddenViewError == null &&
-        pendingViewMode == SearchViewMode.hideWatched &&
-        isHiddenViewReady) {
-      _publishMode(
-        SearchViewMode.hideWatched,
-        minimumItems: _minimumPublishedItems(SearchViewMode.hideWatched),
-      );
-      pendingViewMode = null;
-    } else if (hiddenViewError == null &&
-        selectedViewMode == SearchViewMode.all &&
-        bangumiList.isEmpty &&
-        buffer.allItems.isNotEmpty) {
-      _publishMode(
-        SearchViewMode.all,
-        minimumItems: _minimumPublishedItems(SearchViewMode.all),
-      );
-      isTimeOut = false;
-    }
-    _updateHasMoreSearchResults();
+  Future<void> loadMoreSearchResults() async {
+    if (_disposed || isLoading) return;
+    await _loadMoreSearchResults();
   }
 
   Future<void> _loadMoreSearchResults() async {
     final buffer = _resultBuffer;
     if (buffer == null) return;
     final generation = _queryGeneration;
-    final mode = selectedViewMode;
-    final published = _minimumPublishedItems(mode);
-    final target = published + _searchPageSize;
     isLoading = true;
-    final items =
-        mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
-    if (items.length < target && !buffer.isExhausted) {
-      await buffer.ensureReadyFor(mode, minimumItems: target);
-    }
+    await buffer.loadNextPage();
     if (generation != _queryGeneration) return;
-    final activeMode = selectedViewMode;
-    final activeMinimumItems =
-        activeMode == mode ? target : _minimumPublishedItems(activeMode);
-    _publishMode(activeMode, minimumItems: activeMinimumItems);
+    _publishMode(selectedViewMode);
     isLoading = false;
-    if (!isHiddenViewReady && !isHiddenViewPreparing) {
-      _startHiddenPreparation(generation);
-    }
   }
 
-  void _publishMode(SearchViewMode mode, {required int minimumItems}) {
+  void _publishMode(SearchViewMode mode) {
     final buffer = _resultBuffer;
     if (buffer == null) return;
     final items =
         mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
-    final visibleCount =
-        items.length < minimumItems ? items.length : minimumItems;
-    _publishedCounts[mode] = minimumItems;
-    bangumiList = ObservableList.of(items.take(visibleCount));
+    bangumiList = ObservableList.of(items);
     selectedViewMode = mode;
     isTimeOut = false;
     _updateHasMoreSearchResults();
-    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
-  }
-
-  int _minimumPublishedItems(SearchViewMode mode) {
-    final published = _publishedCounts[mode];
-    if (published == null || published < _searchPageSize) {
-      return _searchPageSize;
-    }
-    return published;
   }
 
   void _updateHasMoreSearchResults() {
@@ -423,11 +244,7 @@ abstract class _SearchPageController with Store implements Disposable {
       hasMoreSearchResults = false;
       return;
     }
-    final items = selectedViewMode == SearchViewMode.all
-        ? buffer.allItems
-        : buffer.hideWatchedItems;
-    final published = _publishedCounts[selectedViewMode] ?? 0;
-    hasMoreSearchResults = published < items.length || !buffer.isExhausted;
+    hasMoreSearchResults = !buffer.isExhausted;
   }
 
   @action
@@ -490,35 +307,13 @@ abstract class _SearchPageController with Store implements Disposable {
   }
 
   @action
-  Future<void> setNotShowAbandonedBangumis(
-    bool value, {
-    bool prepare = true,
-  }) async {
+  Future<void> setNotShowAbandonedBangumis(bool value) async {
     notShowAbandonedBangumis = value;
     final buffer = _resultBuffer;
     if (buffer == null) return;
 
-    final mode = selectedViewMode;
-    final generation = _queryGeneration;
     buffer.setHideAbandoned(value);
-    _publishMode(
-      mode,
-      minimumItems: _minimumPublishedItems(mode),
-    );
-    if (buffer.isReady(SearchViewMode.all) &&
-        buffer.isReady(SearchViewMode.hideWatched)) {
-      return;
-    }
-    if (!prepare) return;
-
-    await _startHiddenPreparation(generation);
-    if (generation != _queryGeneration || mode != selectedViewMode) return;
-    final minimumItems = _minimumPublishedItems(mode);
-    _publishMode(
-      mode,
-      minimumItems:
-          minimumItems < _searchPageSize ? _searchPageSize : minimumItems,
-    );
+    _publishMode(selectedViewMode);
   }
 
   @action
@@ -526,14 +321,7 @@ abstract class _SearchPageController with Store implements Disposable {
     if (_disposed) return;
     final buffer = _resultBuffer;
     if (buffer == null) return;
-    final generation = _queryGeneration;
-    _publishMode(
-      selectedViewMode,
-      minimumItems: _minimumPublishedItems(selectedViewMode),
-    );
-    if (!isHiddenViewReady && !isHiddenViewPreparing) {
-      _startHiddenPreparation(generation);
-    }
+    _publishMode(selectedViewMode);
   }
 
   void _scheduleResultProjectionRefresh() {
@@ -551,7 +339,6 @@ abstract class _SearchPageController with Store implements Disposable {
     _disposed = true;
     _queryGeneration++;
     _resultBuffer = null;
-    _backgroundPreparation = null;
     _collectiblesRefreshTimer?.cancel();
     _collectiblesRefreshTimer = null;
     bangumiList.clear();

--- a/lib/pages/search/search_controller.dart
+++ b/lib/pages/search/search_controller.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/collect/collect_type.dart';
@@ -10,24 +13,83 @@ import 'package:kazumi/repositories/search_history_repository.dart';
 import 'package:kazumi/request/apis/bangumi_api.dart';
 import 'package:kazumi/request/apis/trace_api.dart';
 import 'package:kazumi/utils/search_parser.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
 
 part 'search_controller.g.dart';
 
-class SearchPageController = _SearchPageController with _$SearchPageController;
+typedef SearchPageRequestLoader = Future<BangumiSearchPage?> Function(
+  String keyword,
+  SearchFilterState filterState,
+  int offset,
+);
 
-abstract class _SearchPageController with Store {
+class SearchPageController extends _SearchPageController
+    with _$SearchPageController {
+  SearchPageController(
+    super.collectRepository,
+    super.searchHistoryRepository,
+  );
+
+  @visibleForTesting
+  SearchPageController.withPageLoader(
+    super.collectRepository,
+    super.searchHistoryRepository,
+    SearchPageRequestLoader pageLoader,
+  ) : super(pageLoader: pageLoader);
+}
+
+abstract class _SearchPageController with Store implements Disposable {
   static const int _searchPageSize = 20;
-  static const int _maxPagesPerSearch = 3;
+  static const Duration _defaultPageRequestInterval =
+      Duration(milliseconds: 250);
+  static const Duration _collectionRefreshDebounce = Duration(milliseconds: 50);
 
   _SearchPageController(
-    this._collectRepository,
-    this._searchHistoryRepository,
-  );
+    ICollectRepository collectRepository,
+    ISearchHistoryRepository searchHistoryRepository, {
+    SearchPageRequestLoader? pageLoader,
+  })  : _collectRepository = collectRepository,
+        _searchHistoryRepository = searchHistoryRepository,
+        _pageLoader = pageLoader ?? _defaultPageLoader,
+        _searchPageRequestInterval =
+            pageLoader == null ? _defaultPageRequestInterval : Duration.zero {
+    _collectiblesSubscription =
+        _collectRepository.onCollectiblesChanged.listen((_) {
+      _scheduleResultProjectionRefresh();
+    });
+  }
 
   final ICollectRepository _collectRepository;
   final ISearchHistoryRepository _searchHistoryRepository;
+  final SearchPageRequestLoader _pageLoader;
+  final Duration _searchPageRequestInterval;
+  late final StreamSubscription<void> _collectiblesSubscription;
+  Timer? _collectiblesRefreshTimer;
 
-  int _searchOffset = 0;
+  static Future<BangumiSearchPage?> _defaultPageLoader(
+    String keyword,
+    SearchFilterState filterState,
+    int offset,
+  ) {
+    return BangumiApi.bangumiSearch(
+      keyword,
+      tags: filterState.tags,
+      limit: _searchPageSize,
+      offset: offset,
+      sort: filterState.sort,
+      dateRange: filterState.effectiveDateRange,
+      rankRange: filterState.rankRange,
+      scoreRange: filterState.scoreRange,
+      weekdays: filterState.weekdays,
+    );
+  }
+
+  SearchResultBuffer? _resultBuffer;
+  Future<void>? _backgroundPreparation;
+  int _queryGeneration = 0;
+  String _activeInput = '';
+  bool _disposed = false;
+  final Map<SearchViewMode, int> _publishedCounts = {};
 
   bool hasMoreSearchResults = true;
 
@@ -38,13 +100,25 @@ abstract class _SearchPageController with Store {
   bool isTimeOut = false;
 
   @observable
-  bool notShowWatchedBangumis = false;
-
-  @observable
   bool notShowAbandonedBangumis = false;
 
   @observable
   ObservableList<BangumiItem> bangumiList = ObservableList.of([]);
+
+  @observable
+  SearchViewMode selectedViewMode = SearchViewMode.all;
+
+  @observable
+  SearchViewMode? pendingViewMode;
+
+  @observable
+  bool isHiddenViewPreparing = false;
+
+  @observable
+  bool isHiddenViewReady = false;
+
+  @observable
+  Object? hiddenViewError;
 
   @observable
   ObservableList<SearchHistory> searchHistories = ObservableList.of([]);
@@ -67,75 +141,293 @@ abstract class _SearchPageController with Store {
 
   @action
   Future<void> searchBangumi(String input, {String type = 'add'}) async {
-    if (type != 'add') {
-      bangumiList.clear();
-      _searchOffset = 0;
-      hasMoreSearchResults = true;
-      bool privateMode = _collectRepository.getPrivateMode();
-      if (!privateMode) {
-        // 检查是否已满，删除最旧的记录
-        if (_searchHistoryRepository.isHistoryFull(10)) {
-          await _searchHistoryRepository.deleteOldest();
-        }
-        // 删除重复的历史记录
-        await _searchHistoryRepository.deleteDuplicates(input);
-        // 保存新的搜索历史
-        await _searchHistoryRepository.saveHistory(input);
-        // 重新加载历史记录
-        loadSearchHistories();
-      }
+    if (_disposed) return;
+    final filterState = SearchParser(input).toFilterState();
+    final normalizedInput = SearchParser.fromFilterState(filterState);
+    final isNewQuery = type != 'add' ||
+        _resultBuffer == null ||
+        _activeInput != normalizedInput;
+
+    if (!isNewQuery) {
+      await _loadMoreSearchResults();
+      return;
     }
+
+    final requestedMode = selectedViewMode;
+    final generation = ++_queryGeneration;
+    _activeInput = normalizedInput;
+    _resultBuffer = null;
+    _backgroundPreparation = null;
+    _publishedCounts.clear();
+    pendingViewMode = null;
+    isHiddenViewPreparing = false;
+    isHiddenViewReady = false;
+    hiddenViewError = null;
+    hasMoreSearchResults = true;
+    bangumiList.clear();
     isLoading = true;
     isTimeOut = false;
-    SearchParser parser = SearchParser(input);
-    final filterState = parser.toFilterState();
-    String? idString = filterState.id.isEmpty ? null : filterState.id;
+
+    if (!_collectRepository.getPrivateMode()) {
+      if (_searchHistoryRepository.isHistoryFull(10)) {
+        await _searchHistoryRepository.deleteOldest();
+      }
+      await _searchHistoryRepository.deleteDuplicates(input);
+      await _searchHistoryRepository.saveHistory(input);
+      loadSearchHistories();
+    }
+    if (generation != _queryGeneration) return;
+
+    final idString = filterState.id.isEmpty ? null : filterState.id;
     if (idString != null) {
       final id = int.tryParse(idString);
       if (id != null) {
-        final BangumiItem? item = await BangumiApi.getBangumiInfoByID(id);
-        if (item != null) {
-          bangumiList.add(item);
+        final item = await BangumiApi.getBangumiInfoByID(id);
+        if (generation != _queryGeneration) return;
+        late final SearchResultBuffer buffer;
+        buffer = SearchResultBuffer(
+          pageLoader: (offset) async => offset == 0 && item != null
+              ? BangumiSearchPage(items: [item], rawCount: 1)
+              : const BangumiSearchPage(items: [], rawCount: 0),
+          watchedIds: loadWatchedBangumiIds,
+          abandonedIds: loadAbandonedBangumiIds,
+          hideAbandoned: notShowAbandonedBangumis,
+          pageRequestInterval: _searchPageRequestInterval,
+          shouldContinue: () =>
+              generation == _queryGeneration &&
+              identical(_resultBuffer, buffer),
+        );
+        _resultBuffer = buffer;
+        await buffer.ensureReadyFor(SearchViewMode.all);
+        if (generation != _queryGeneration) return;
+        if (requestedMode == SearchViewMode.hideWatched) {
+          pendingViewMode = SearchViewMode.hideWatched;
+          await _startHiddenPreparation(generation);
+          if (generation != _queryGeneration) return;
+          isLoading = false;
+          isTimeOut = hiddenViewError != null;
+        } else {
+          _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
+          isLoading = false;
+          isTimeOut = bangumiList.isEmpty;
+          _startHiddenPreparation(generation);
         }
-        hasMoreSearchResults = false;
-        isLoading = false;
-        isTimeOut = bangumiList.isEmpty;
         return;
       }
     }
-    var addedVisibleItems = false;
-    var fetchedAnyPage = false;
-    var pagesFetched = 0;
-    do {
-      final page = await BangumiApi.bangumiSearch(filterState.keyword,
-          tags: filterState.tags,
-          limit: _searchPageSize,
-          offset: _searchOffset,
-          sort: filterState.sort,
-          dateRange: filterState.effectiveDateRange,
-          rankRange: filterState.rankRange,
-          scoreRange: filterState.scoreRange,
-          weekdays: filterState.weekdays);
-      if (page == null) {
-        break;
+
+    late final SearchResultBuffer buffer;
+    buffer = SearchResultBuffer(
+      pageLoader: (offset) =>
+          _pageLoader(filterState.keyword, filterState, offset),
+      watchedIds: loadWatchedBangumiIds,
+      abandonedIds: loadAbandonedBangumiIds,
+      hideAbandoned: notShowAbandonedBangumis,
+      pageRequestInterval: _searchPageRequestInterval,
+      shouldContinue: () =>
+          generation == _queryGeneration && identical(_resultBuffer, buffer),
+    );
+    _resultBuffer = buffer;
+    await buffer.ensureReadyFor(SearchViewMode.all);
+    if (generation != _queryGeneration) return;
+    if (requestedMode == SearchViewMode.hideWatched) {
+      pendingViewMode = SearchViewMode.hideWatched;
+      await _startHiddenPreparation(generation);
+      if (generation != _queryGeneration) return;
+      isLoading = false;
+      isTimeOut = hiddenViewError != null;
+    } else {
+      _publishMode(SearchViewMode.all, minimumItems: _searchPageSize);
+      isLoading = false;
+      isTimeOut =
+          bangumiList.isEmpty && (buffer.error != null || buffer.isExhausted);
+      _startHiddenPreparation(generation);
+    }
+  }
+
+  @action
+  Future<void> requestViewMode(SearchViewMode mode) async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    if (mode == selectedViewMode && pendingViewMode == null) return;
+
+    pendingViewMode = mode;
+    if (mode == SearchViewMode.all) {
+      _publishMode(
+        SearchViewMode.all,
+        minimumItems: _minimumPublishedItems(SearchViewMode.all),
+      );
+      pendingViewMode = null;
+      return;
+    }
+
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
+    if (isHiddenViewReady && hiddenViewError == null) {
+      _publishMode(
+        SearchViewMode.hideWatched,
+        minimumItems: _minimumPublishedItems(SearchViewMode.hideWatched),
+      );
+      pendingViewMode = null;
+      return;
+    }
+    if (hiddenViewError == null) {
+      _startHiddenPreparation(_queryGeneration);
+    }
+  }
+
+  @action
+  Future<void> retryHiddenView() async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final retryingSelectedHiddenView =
+        selectedViewMode == SearchViewMode.hideWatched;
+    pendingViewMode = SearchViewMode.hideWatched;
+    hiddenViewError = null;
+    isHiddenViewPreparing = true;
+    if (retryingSelectedHiddenView) {
+      isLoading = true;
+      isTimeOut = false;
+    }
+    final generation = _queryGeneration;
+    final future = buffer.retry(minimumItems: _searchPageSize);
+    _backgroundPreparation = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_backgroundPreparation, future)) {
+        _backgroundPreparation = null;
       }
-      fetchedAnyPage = true;
-      pagesFetched++;
-      _searchOffset += page.rawCount;
-      hasMoreSearchResults = page.rawCount == _searchPageSize;
-      final existingIds = bangumiList.map((item) => item.id).toSet();
-      final newItems =
-          page.items.where((item) => existingIds.add(item.id)).toList();
-      if (newItems.isNotEmpty) {
-        bangumiList.addAll(newItems);
-        addedVisibleItems = true;
+    }
+    if (generation != _queryGeneration) return;
+    _finishHiddenPreparation(generation);
+    if (retryingSelectedHiddenView) {
+      isLoading = false;
+      isTimeOut = hiddenViewError != null;
+    }
+  }
+
+  Future<void> waitForBackgroundPreparation() async {
+    final preparation = _backgroundPreparation;
+    if (preparation == null) return;
+    await preparation;
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> _startHiddenPreparation(int generation) {
+    final buffer = _resultBuffer;
+    if (buffer == null || generation != _queryGeneration) {
+      return Future<void>.value();
+    }
+    final existing = _backgroundPreparation;
+    if (existing != null) return existing;
+    if (buffer.isReady(SearchViewMode.all) &&
+        buffer.isReady(SearchViewMode.hideWatched) &&
+        buffer.error == null) {
+      _finishHiddenPreparation(generation);
+      return Future<void>.value();
+    }
+
+    isHiddenViewPreparing = true;
+    hiddenViewError = null;
+    late final Future<void> preparation;
+    preparation =
+        buffer.ensureReady(minimumItems: _searchPageSize).whenComplete(() {
+      if (generation == _queryGeneration) {
+        _finishHiddenPreparation(generation);
       }
-    } while (!addedVisibleItems &&
-        hasMoreSearchResults &&
-        pagesFetched < _maxPagesPerSearch);
+      if (identical(_backgroundPreparation, preparation)) {
+        _backgroundPreparation = null;
+      }
+    });
+    _backgroundPreparation = preparation;
+    return preparation;
+  }
+
+  void _finishHiddenPreparation(int generation) {
+    final buffer = _resultBuffer;
+    if (buffer == null || generation != _queryGeneration) return;
+    isHiddenViewPreparing = false;
+    hiddenViewError = buffer.error;
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
+    if (hiddenViewError == null &&
+        pendingViewMode == SearchViewMode.hideWatched &&
+        isHiddenViewReady) {
+      _publishMode(
+        SearchViewMode.hideWatched,
+        minimumItems: _minimumPublishedItems(SearchViewMode.hideWatched),
+      );
+      pendingViewMode = null;
+    } else if (hiddenViewError == null &&
+        selectedViewMode == SearchViewMode.all &&
+        bangumiList.isEmpty &&
+        buffer.allItems.isNotEmpty) {
+      _publishMode(
+        SearchViewMode.all,
+        minimumItems: _minimumPublishedItems(SearchViewMode.all),
+      );
+      isTimeOut = false;
+    }
+    _updateHasMoreSearchResults();
+  }
+
+  Future<void> _loadMoreSearchResults() async {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final generation = _queryGeneration;
+    final mode = selectedViewMode;
+    final published = _minimumPublishedItems(mode);
+    final target = published + _searchPageSize;
+    isLoading = true;
+    final items =
+        mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
+    if (items.length < target && !buffer.isExhausted) {
+      await buffer.ensureReadyFor(mode, minimumItems: target);
+    }
+    if (generation != _queryGeneration) return;
+    final activeMode = selectedViewMode;
+    final activeMinimumItems =
+        activeMode == mode ? target : _minimumPublishedItems(activeMode);
+    _publishMode(activeMode, minimumItems: activeMinimumItems);
     isLoading = false;
-    isTimeOut =
-        bangumiList.isEmpty && (!fetchedAnyPage || !hasMoreSearchResults);
+    if (!isHiddenViewReady && !isHiddenViewPreparing) {
+      _startHiddenPreparation(generation);
+    }
+  }
+
+  void _publishMode(SearchViewMode mode, {required int minimumItems}) {
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final items =
+        mode == SearchViewMode.all ? buffer.allItems : buffer.hideWatchedItems;
+    final visibleCount =
+        items.length < minimumItems ? items.length : minimumItems;
+    _publishedCounts[mode] = minimumItems;
+    bangumiList = ObservableList.of(items.take(visibleCount));
+    selectedViewMode = mode;
+    isTimeOut = false;
+    _updateHasMoreSearchResults();
+    isHiddenViewReady = buffer.isReady(SearchViewMode.hideWatched);
+  }
+
+  int _minimumPublishedItems(SearchViewMode mode) {
+    final published = _publishedCounts[mode];
+    if (published == null || published < _searchPageSize) {
+      return _searchPageSize;
+    }
+    return published;
+  }
+
+  void _updateHasMoreSearchResults() {
+    final buffer = _resultBuffer;
+    if (buffer == null) {
+      hasMoreSearchResults = false;
+      return;
+    }
+    final items = selectedViewMode == SearchViewMode.all
+        ? buffer.allItems
+        : buffer.hideWatchedItems;
+    final published = _publishedCounts[selectedViewMode] ?? 0;
+    hasMoreSearchResults = published < items.length || !buffer.isExhausted;
   }
 
   @action
@@ -198,13 +490,72 @@ abstract class _SearchPageController with Store {
   }
 
   @action
-  Future<void> setNotShowWatchedBangumis(bool value) async {
-    notShowWatchedBangumis = value;
+  Future<void> setNotShowAbandonedBangumis(
+    bool value, {
+    bool prepare = true,
+  }) async {
+    notShowAbandonedBangumis = value;
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+
+    final mode = selectedViewMode;
+    final generation = _queryGeneration;
+    buffer.setHideAbandoned(value);
+    _publishMode(
+      mode,
+      minimumItems: _minimumPublishedItems(mode),
+    );
+    if (buffer.isReady(SearchViewMode.all) &&
+        buffer.isReady(SearchViewMode.hideWatched)) {
+      return;
+    }
+    if (!prepare) return;
+
+    await _startHiddenPreparation(generation);
+    if (generation != _queryGeneration || mode != selectedViewMode) return;
+    final minimumItems = _minimumPublishedItems(mode);
+    _publishMode(
+      mode,
+      minimumItems:
+          minimumItems < _searchPageSize ? _searchPageSize : minimumItems,
+    );
   }
 
   @action
-  Future<void> setNotShowAbandonedBangumis(bool value) async {
-    notShowAbandonedBangumis = value;
+  void refreshResultProjection() {
+    if (_disposed) return;
+    final buffer = _resultBuffer;
+    if (buffer == null) return;
+    final generation = _queryGeneration;
+    _publishMode(
+      selectedViewMode,
+      minimumItems: _minimumPublishedItems(selectedViewMode),
+    );
+    if (!isHiddenViewReady && !isHiddenViewPreparing) {
+      _startHiddenPreparation(generation);
+    }
+  }
+
+  void _scheduleResultProjectionRefresh() {
+    if (_disposed) return;
+    _collectiblesRefreshTimer?.cancel();
+    _collectiblesRefreshTimer = Timer(_collectionRefreshDebounce, () {
+      _collectiblesRefreshTimer = null;
+      refreshResultProjection();
+    });
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _queryGeneration++;
+    _resultBuffer = null;
+    _backgroundPreparation = null;
+    _collectiblesRefreshTimer?.cancel();
+    _collectiblesRefreshTimer = null;
+    bangumiList.clear();
+    _collectiblesSubscription.cancel();
   }
 
   Set<int> loadWatchedBangumiIds() {

--- a/lib/pages/search/search_controller.g.dart
+++ b/lib/pages/search/search_controller.g.dart
@@ -41,23 +41,6 @@ mixin _$SearchPageController on _SearchPageController, Store {
     });
   }
 
-  late final _$notShowWatchedBangumisAtom = Atom(
-      name: '_SearchPageController.notShowWatchedBangumis', context: context);
-
-  @override
-  bool get notShowWatchedBangumis {
-    _$notShowWatchedBangumisAtom.reportRead();
-    return super.notShowWatchedBangumis;
-  }
-
-  @override
-  set notShowWatchedBangumis(bool value) {
-    _$notShowWatchedBangumisAtom
-        .reportWrite(value, super.notShowWatchedBangumis, () {
-      super.notShowWatchedBangumis = value;
-    });
-  }
-
   late final _$notShowAbandonedBangumisAtom = Atom(
       name: '_SearchPageController.notShowAbandonedBangumis', context: context);
 
@@ -88,6 +71,87 @@ mixin _$SearchPageController on _SearchPageController, Store {
   set bangumiList(ObservableList<BangumiItem> value) {
     _$bangumiListAtom.reportWrite(value, super.bangumiList, () {
       super.bangumiList = value;
+    });
+  }
+
+  late final _$selectedViewModeAtom =
+      Atom(name: '_SearchPageController.selectedViewMode', context: context);
+
+  @override
+  SearchViewMode get selectedViewMode {
+    _$selectedViewModeAtom.reportRead();
+    return super.selectedViewMode;
+  }
+
+  @override
+  set selectedViewMode(SearchViewMode value) {
+    _$selectedViewModeAtom.reportWrite(value, super.selectedViewMode, () {
+      super.selectedViewMode = value;
+    });
+  }
+
+  late final _$pendingViewModeAtom =
+      Atom(name: '_SearchPageController.pendingViewMode', context: context);
+
+  @override
+  SearchViewMode? get pendingViewMode {
+    _$pendingViewModeAtom.reportRead();
+    return super.pendingViewMode;
+  }
+
+  @override
+  set pendingViewMode(SearchViewMode? value) {
+    _$pendingViewModeAtom.reportWrite(value, super.pendingViewMode, () {
+      super.pendingViewMode = value;
+    });
+  }
+
+  late final _$isHiddenViewPreparingAtom = Atom(
+      name: '_SearchPageController.isHiddenViewPreparing', context: context);
+
+  @override
+  bool get isHiddenViewPreparing {
+    _$isHiddenViewPreparingAtom.reportRead();
+    return super.isHiddenViewPreparing;
+  }
+
+  @override
+  set isHiddenViewPreparing(bool value) {
+    _$isHiddenViewPreparingAtom.reportWrite(value, super.isHiddenViewPreparing,
+        () {
+      super.isHiddenViewPreparing = value;
+    });
+  }
+
+  late final _$isHiddenViewReadyAtom =
+      Atom(name: '_SearchPageController.isHiddenViewReady', context: context);
+
+  @override
+  bool get isHiddenViewReady {
+    _$isHiddenViewReadyAtom.reportRead();
+    return super.isHiddenViewReady;
+  }
+
+  @override
+  set isHiddenViewReady(bool value) {
+    _$isHiddenViewReadyAtom.reportWrite(value, super.isHiddenViewReady, () {
+      super.isHiddenViewReady = value;
+    });
+  }
+
+  late final _$hiddenViewErrorAtom =
+      Atom(name: '_SearchPageController.hiddenViewError', context: context);
+
+  @override
+  Object? get hiddenViewError {
+    _$hiddenViewErrorAtom.reportRead();
+    return super.hiddenViewError;
+  }
+
+  @override
+  set hiddenViewError(Object? value) {
+    _$hiddenViewErrorAtom.reportWrite(value, super.hiddenViewError, () {
+      super.hiddenViewError = value;
     });
   }
 
@@ -164,6 +228,22 @@ mixin _$SearchPageController on _SearchPageController, Store {
         .run(() => super.searchBangumi(input, type: type));
   }
 
+  late final _$requestViewModeAsyncAction =
+      AsyncAction('_SearchPageController.requestViewMode', context: context);
+
+  @override
+  Future<void> requestViewMode(SearchViewMode mode) {
+    return _$requestViewModeAsyncAction.run(() => super.requestViewMode(mode));
+  }
+
+  late final _$retryHiddenViewAsyncAction =
+      AsyncAction('_SearchPageController.retryHiddenView', context: context);
+
+  @override
+  Future<void> retryHiddenView() {
+    return _$retryHiddenViewAsyncAction.run(() => super.retryHiddenView());
+  }
+
   late final _$deleteSearchHistoryAsyncAction = AsyncAction(
       '_SearchPageController.deleteSearchHistory',
       context: context);
@@ -201,24 +281,14 @@ mixin _$SearchPageController on _SearchPageController, Store {
         .run(() => super.searchImageByUrl(imageUrl));
   }
 
-  late final _$setNotShowWatchedBangumisAsyncAction = AsyncAction(
-      '_SearchPageController.setNotShowWatchedBangumis',
-      context: context);
-
-  @override
-  Future<void> setNotShowWatchedBangumis(bool value) {
-    return _$setNotShowWatchedBangumisAsyncAction
-        .run(() => super.setNotShowWatchedBangumis(value));
-  }
-
   late final _$setNotShowAbandonedBangumisAsyncAction = AsyncAction(
       '_SearchPageController.setNotShowAbandonedBangumis',
       context: context);
 
   @override
-  Future<void> setNotShowAbandonedBangumis(bool value) {
+  Future<void> setNotShowAbandonedBangumis(bool value, {bool prepare = true}) {
     return _$setNotShowAbandonedBangumisAsyncAction
-        .run(() => super.setNotShowAbandonedBangumis(value));
+        .run(() => super.setNotShowAbandonedBangumis(value, prepare: prepare));
   }
 
   late final _$_SearchPageControllerActionController =
@@ -247,13 +317,28 @@ mixin _$SearchPageController on _SearchPageController, Store {
   }
 
   @override
+  void refreshResultProjection() {
+    final _$actionInfo = _$_SearchPageControllerActionController.startAction(
+        name: '_SearchPageController.refreshResultProjection');
+    try {
+      return super.refreshResultProjection();
+    } finally {
+      _$_SearchPageControllerActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   String toString() {
     return '''
 isLoading: ${isLoading},
 isTimeOut: ${isTimeOut},
-notShowWatchedBangumis: ${notShowWatchedBangumis},
 notShowAbandonedBangumis: ${notShowAbandonedBangumis},
 bangumiList: ${bangumiList},
+selectedViewMode: ${selectedViewMode},
+pendingViewMode: ${pendingViewMode},
+isHiddenViewPreparing: ${isHiddenViewPreparing},
+isHiddenViewReady: ${isHiddenViewReady},
+hiddenViewError: ${hiddenViewError},
 searchHistories: ${searchHistories},
 isImageSearching: ${isImageSearching},
 imageSearchError: ${imageSearchError},

--- a/lib/pages/search/search_controller.g.dart
+++ b/lib/pages/search/search_controller.g.dart
@@ -9,6 +9,23 @@ part of 'search_controller.dart';
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$SearchPageController on _SearchPageController, Store {
+  late final _$hasMoreSearchResultsAtom = Atom(
+      name: '_SearchPageController.hasMoreSearchResults', context: context);
+
+  @override
+  bool get hasMoreSearchResults {
+    _$hasMoreSearchResultsAtom.reportRead();
+    return super.hasMoreSearchResults;
+  }
+
+  @override
+  set hasMoreSearchResults(bool value) {
+    _$hasMoreSearchResultsAtom.reportWrite(value, super.hasMoreSearchResults,
+        () {
+      super.hasMoreSearchResults = value;
+    });
+  }
+
   late final _$isLoadingAtom =
       Atom(name: '_SearchPageController.isLoading', context: context);
 
@@ -87,71 +104,6 @@ mixin _$SearchPageController on _SearchPageController, Store {
   set selectedViewMode(SearchViewMode value) {
     _$selectedViewModeAtom.reportWrite(value, super.selectedViewMode, () {
       super.selectedViewMode = value;
-    });
-  }
-
-  late final _$pendingViewModeAtom =
-      Atom(name: '_SearchPageController.pendingViewMode', context: context);
-
-  @override
-  SearchViewMode? get pendingViewMode {
-    _$pendingViewModeAtom.reportRead();
-    return super.pendingViewMode;
-  }
-
-  @override
-  set pendingViewMode(SearchViewMode? value) {
-    _$pendingViewModeAtom.reportWrite(value, super.pendingViewMode, () {
-      super.pendingViewMode = value;
-    });
-  }
-
-  late final _$isHiddenViewPreparingAtom = Atom(
-      name: '_SearchPageController.isHiddenViewPreparing', context: context);
-
-  @override
-  bool get isHiddenViewPreparing {
-    _$isHiddenViewPreparingAtom.reportRead();
-    return super.isHiddenViewPreparing;
-  }
-
-  @override
-  set isHiddenViewPreparing(bool value) {
-    _$isHiddenViewPreparingAtom.reportWrite(value, super.isHiddenViewPreparing,
-        () {
-      super.isHiddenViewPreparing = value;
-    });
-  }
-
-  late final _$isHiddenViewReadyAtom =
-      Atom(name: '_SearchPageController.isHiddenViewReady', context: context);
-
-  @override
-  bool get isHiddenViewReady {
-    _$isHiddenViewReadyAtom.reportRead();
-    return super.isHiddenViewReady;
-  }
-
-  @override
-  set isHiddenViewReady(bool value) {
-    _$isHiddenViewReadyAtom.reportWrite(value, super.isHiddenViewReady, () {
-      super.isHiddenViewReady = value;
-    });
-  }
-
-  late final _$hiddenViewErrorAtom =
-      Atom(name: '_SearchPageController.hiddenViewError', context: context);
-
-  @override
-  Object? get hiddenViewError {
-    _$hiddenViewErrorAtom.reportRead();
-    return super.hiddenViewError;
-  }
-
-  @override
-  set hiddenViewError(Object? value) {
-    _$hiddenViewErrorAtom.reportWrite(value, super.hiddenViewError, () {
-      super.hiddenViewError = value;
     });
   }
 
@@ -236,12 +188,14 @@ mixin _$SearchPageController on _SearchPageController, Store {
     return _$requestViewModeAsyncAction.run(() => super.requestViewMode(mode));
   }
 
-  late final _$retryHiddenViewAsyncAction =
-      AsyncAction('_SearchPageController.retryHiddenView', context: context);
+  late final _$loadMoreSearchResultsAsyncAction = AsyncAction(
+      '_SearchPageController.loadMoreSearchResults',
+      context: context);
 
   @override
-  Future<void> retryHiddenView() {
-    return _$retryHiddenViewAsyncAction.run(() => super.retryHiddenView());
+  Future<void> loadMoreSearchResults() {
+    return _$loadMoreSearchResultsAsyncAction
+        .run(() => super.loadMoreSearchResults());
   }
 
   late final _$deleteSearchHistoryAsyncAction = AsyncAction(
@@ -286,9 +240,9 @@ mixin _$SearchPageController on _SearchPageController, Store {
       context: context);
 
   @override
-  Future<void> setNotShowAbandonedBangumis(bool value, {bool prepare = true}) {
+  Future<void> setNotShowAbandonedBangumis(bool value) {
     return _$setNotShowAbandonedBangumisAsyncAction
-        .run(() => super.setNotShowAbandonedBangumis(value, prepare: prepare));
+        .run(() => super.setNotShowAbandonedBangumis(value));
   }
 
   late final _$_SearchPageControllerActionController =
@@ -330,15 +284,12 @@ mixin _$SearchPageController on _SearchPageController, Store {
   @override
   String toString() {
     return '''
+hasMoreSearchResults: ${hasMoreSearchResults},
 isLoading: ${isLoading},
 isTimeOut: ${isTimeOut},
 notShowAbandonedBangumis: ${notShowAbandonedBangumis},
 bangumiList: ${bangumiList},
 selectedViewMode: ${selectedViewMode},
-pendingViewMode: ${pendingViewMode},
-isHiddenViewPreparing: ${isHiddenViewPreparing},
-isHiddenViewReady: ${isHiddenViewReady},
-hiddenViewError: ${hiddenViewError},
 searchHistories: ${searchHistories},
 isImageSearching: ${isImageSearching},
 imageSearchError: ${imageSearchError},

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -81,6 +81,17 @@ class _SearchPageState extends State<SearchPage> {
     _syncingSearchText = false;
   }
 
+  void scrollListener() {
+    if (!scrollController.hasClients ||
+        scrollController.position.extentAfter > 200 ||
+        searchPageController.isLoading ||
+        !searchPageController.hasMoreSearchResults) {
+      return;
+    }
+    KazumiLogger().i('SearchController: search results is loading more');
+    searchPageController.loadMoreSearchResults();
+  }
+
   Future<void> _applyFilterState(
     SearchFilterState state, {
     bool search = false,
@@ -90,18 +101,6 @@ class _SearchPageState extends State<SearchPage> {
     if (search) {
       await searchPageController.searchBangumi(searchController.text,
           type: 'init');
-    }
-  }
-
-  void scrollListener() {
-    if (scrollController.position.pixels >=
-            scrollController.position.maxScrollExtent - 200 &&
-        !searchPageController.isLoading &&
-        (searchController.text.trim().isNotEmpty ||
-            filterState.hasAdvancedFilters) &&
-        searchPageController.hasMoreSearchResults) {
-      KazumiLogger().i('SearchController: search results is loading more');
-      searchPageController.searchBangumi(searchController.text, type: 'add');
     }
   }
 
@@ -122,9 +121,6 @@ class _SearchPageState extends State<SearchPage> {
     if (result == null) return;
     await searchPageController.setNotShowAbandonedBangumis(
       result.notShowAbandoned,
-      // A new query replaces this buffer, so there is no reason to wait for
-      // the previous query's background preparation first.
-      prepare: !result.shouldSearch,
     );
     await _applyFilterState(result.filterState, search: result.shouldSearch);
   }
@@ -217,10 +213,6 @@ class _SearchPageState extends State<SearchPage> {
             searchPageController.selectedViewMode == SearchViewMode.all) {
           return const SizedBox.shrink();
         }
-        final preparing = searchPageController.isHiddenViewPreparing;
-        final failed = searchPageController.hiddenViewError != null;
-        final canRetrySelectedHiddenView = failed &&
-            searchPageController.selectedViewMode == SearchViewMode.hideWatched;
         return Padding(
           padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
           child: Row(
@@ -230,11 +222,7 @@ class _SearchPageState extends State<SearchPage> {
                   selected: {searchPageController.selectedViewMode},
                   onSelectionChanged: (selection) {
                     final mode = selection.first;
-                    if (mode == SearchViewMode.hideWatched && failed) {
-                      searchPageController.retryHiddenView();
-                    } else {
-                      searchPageController.requestViewMode(mode);
-                    }
+                    searchPageController.requestViewMode(mode);
                   },
                   segments: [
                     const ButtonSegment(
@@ -244,31 +232,10 @@ class _SearchPageState extends State<SearchPage> {
                     ButtonSegment(
                       value: SearchViewMode.hideWatched,
                       label: const Text('隐藏已看'),
-                      icon: failed
-                          ? const Icon(Icons.error_outline)
-                          : preparing
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : null,
                     ),
                   ],
                 ),
               ),
-              if (canRetrySelectedHiddenView) ...[
-                const SizedBox(width: 4),
-                Tooltip(
-                  message: '重试准备隐藏已看',
-                  child: IconButton(
-                    icon: const Icon(Icons.refresh_rounded),
-                    onPressed: searchPageController.retryHiddenView,
-                  ),
-                ),
-              ],
             ],
           ),
         );
@@ -430,25 +397,90 @@ class _SearchPageState extends State<SearchPage> {
                 crossCount = 6;
               }
               final items = searchPageController.bangumiList.toList();
-              if (items.isEmpty) {
-                return const Center(child: Text('当前视图没有可显示的番剧'));
-              }
-              return SearchResultGrid(
-                items: items,
-                crossCount: crossCount,
-                cardExtent:
-                    MediaQuery.sizeOf(context).width / crossCount / 0.65 +
-                        MediaQuery.textScalerOf(context).scale(32.0),
-                itemBuilder: (context, item) => BangumiCardV(
-                  enableHero: false,
-                  bangumiItem: item,
-                ),
-                scrollController: scrollController,
-                spacing: StyleString.cardSpace,
-              );
+              final cardExtent =
+                  MediaQuery.sizeOf(context).width / crossCount / 0.65 +
+                      MediaQuery.textScalerOf(context).scale(32.0);
+              final canLoadMore = searchPageController.hasMoreSearchResults;
+              final resultView = items.isEmpty
+                  ? canLoadMore
+                      ? SearchResultGrid(
+                          items: items,
+                          crossCount: crossCount,
+                          cardExtent: cardExtent,
+                          itemBuilder: (context, item) => BangumiCardV(
+                            enableHero: false,
+                            bangumiItem: item,
+                          ),
+                          trailingItem: _buildLoadMoreTile(),
+                          scrollController: scrollController,
+                          spacing: StyleString.cardSpace,
+                        )
+                      : const Center(child: Text('当前视图没有可显示的番剧'))
+                  : SearchResultGrid(
+                      items: items,
+                      crossCount: crossCount,
+                      cardExtent: cardExtent,
+                      itemBuilder: (context, item) => BangumiCardV(
+                        enableHero: false,
+                        bangumiItem: item,
+                      ),
+                      trailingItem: canLoadMore ? _buildLoadMoreTile() : null,
+                      scrollController: scrollController,
+                      spacing: StyleString.cardSpace,
+                    );
+              return resultView;
             }),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildLoadMoreTile() {
+    final isLoading = searchPageController.isLoading;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      elevation: 0,
+      margin: EdgeInsets.zero,
+      clipBehavior: Clip.antiAlias,
+      color: colorScheme.surfaceContainerLow,
+      child: InkWell(
+        onTap: isLoading ? null : searchPageController.loadMoreSearchResults,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Semantics(
+                button: true,
+                label: isLoading ? '加载中' : '加载更多',
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.secondaryContainer,
+                  ),
+                  child: SizedBox(
+                    width: 52,
+                    height: 52,
+                    child: Center(
+                      child: isLoading
+                          ? const SizedBox(
+                              width: 22,
+                              height: 22,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Icon(
+                              Icons.arrow_forward,
+                              color: colorScheme.onSecondaryContainer,
+                            ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(isLoading ? '加载中' : '加载更多'),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -6,8 +6,9 @@ import 'package:kazumi/bean/dialog/material_bottom_sheet.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/bean/card/bangumi_card.dart';
 import 'package:kazumi/bean/widget/error_widget.dart';
-import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/pages/search/search_result_grid.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/utils/date_time.dart';
@@ -56,7 +57,7 @@ class _SearchPageState extends State<SearchPage> {
 
   @override
   void dispose() {
-    searchPageController.bangumiList.clear();
+    searchPageController.dispose();
     searchController.removeListener(_syncFilterFromSearchText);
     searchController.dispose();
     scrollController.removeListener(scrollListener);
@@ -112,7 +113,6 @@ class _SearchPageState extends State<SearchPage> {
       builder: (context) {
         return _SearchWorkbenchSheet(
           initialState: filterState,
-          initialNotShowWatched: searchPageController.notShowWatchedBangumis,
           initialNotShowAbandoned:
               searchPageController.notShowAbandonedBangumis,
         );
@@ -120,9 +120,12 @@ class _SearchPageState extends State<SearchPage> {
     );
 
     if (result == null) return;
-    await searchPageController.setNotShowWatchedBangumis(result.notShowWatched);
-    await searchPageController
-        .setNotShowAbandonedBangumis(result.notShowAbandoned);
+    await searchPageController.setNotShowAbandonedBangumis(
+      result.notShowAbandoned,
+      // A new query replaces this buffer, so there is no reason to wait for
+      // the previous query's background preparation first.
+      prepare: !result.shouldSearch,
+    );
     await _applyFilterState(result.filterState, search: result.shouldSearch);
   }
 
@@ -195,14 +198,6 @@ class _SearchPageState extends State<SearchPage> {
         ),
       ));
     }
-    if (searchPageController.notShowWatchedBangumis) {
-      chips.add(InputChip(
-        label: const Text('隐藏已看'),
-        onDeleted: () async {
-          await searchPageController.setNotShowWatchedBangumis(false);
-        },
-      ));
-    }
     if (searchPageController.notShowAbandonedBangumis) {
       chips.add(InputChip(
         label: const Text('隐藏已弃'),
@@ -213,6 +208,72 @@ class _SearchPageState extends State<SearchPage> {
     }
 
     return chips;
+  }
+
+  Widget buildViewModeControl() {
+    return Observer(
+      builder: (_) {
+        if (searchPageController.bangumiList.isEmpty &&
+            searchPageController.selectedViewMode == SearchViewMode.all) {
+          return const SizedBox.shrink();
+        }
+        final preparing = searchPageController.isHiddenViewPreparing;
+        final failed = searchPageController.hiddenViewError != null;
+        final canRetrySelectedHiddenView = failed &&
+            searchPageController.selectedViewMode == SearchViewMode.hideWatched;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: SegmentedButton<SearchViewMode>(
+                  selected: {searchPageController.selectedViewMode},
+                  onSelectionChanged: (selection) {
+                    final mode = selection.first;
+                    if (mode == SearchViewMode.hideWatched && failed) {
+                      searchPageController.retryHiddenView();
+                    } else {
+                      searchPageController.requestViewMode(mode);
+                    }
+                  },
+                  segments: [
+                    const ButtonSegment(
+                      value: SearchViewMode.all,
+                      label: Text('全部'),
+                    ),
+                    ButtonSegment(
+                      value: SearchViewMode.hideWatched,
+                      label: const Text('隐藏已看'),
+                      icon: failed
+                          ? const Icon(Icons.error_outline)
+                          : preparing
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : null,
+                    ),
+                  ],
+                ),
+              ),
+              if (canRetrySelectedHiddenView) ...[
+                const SizedBox(width: 4),
+                Tooltip(
+                  message: '重试准备隐藏已看',
+                  child: IconButton(
+                    icon: const Icon(Icons.refresh_rounded),
+                    onPressed: searchPageController.retryHiddenView,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _submitSearch(String value) async {
@@ -331,6 +392,7 @@ class _SearchPageState extends State<SearchPage> {
               );
             },
           ),
+          buildViewModeControl(),
           Expanded(
             child: Observer(builder: (context) {
               if (searchPageController.isTimeOut) {
@@ -367,45 +429,22 @@ class _SearchPageState extends State<SearchPage> {
                   LayoutBreakpoint.medium['width']!) {
                 crossCount = 6;
               }
-              List<BangumiItem> filteredList =
-                  searchPageController.bangumiList.toList();
-
-              if (searchPageController.notShowWatchedBangumis) {
-                final watchedBangumiIds =
-                    searchPageController.loadWatchedBangumiIds();
-                filteredList = filteredList
-                    .where((item) => !watchedBangumiIds.contains(item.id))
-                    .toList();
+              final items = searchPageController.bangumiList.toList();
+              if (items.isEmpty) {
+                return const Center(child: Text('当前视图没有可显示的番剧'));
               }
-
-              if (searchPageController.notShowAbandonedBangumis) {
-                final abandonedBangumiIds =
-                    searchPageController.loadAbandonedBangumiIds();
-                filteredList = filteredList
-                    .where((item) => !abandonedBangumiIds.contains(item.id))
-                    .toList();
-              }
-
-              return GridView.builder(
-                controller: scrollController,
-                padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  mainAxisSpacing: StyleString.cardSpace - 2,
-                  crossAxisSpacing: StyleString.cardSpace,
-                  crossAxisCount: crossCount,
-                  mainAxisExtent:
-                      MediaQuery.of(context).size.width / crossCount / 0.65 +
-                          MediaQuery.textScalerOf(context).scale(32.0),
+              return SearchResultGrid(
+                items: items,
+                crossCount: crossCount,
+                cardExtent:
+                    MediaQuery.sizeOf(context).width / crossCount / 0.65 +
+                        MediaQuery.textScalerOf(context).scale(32.0),
+                itemBuilder: (context, item) => BangumiCardV(
+                  enableHero: false,
+                  bangumiItem: item,
                 ),
-                itemCount: filteredList.isNotEmpty ? filteredList.length : 10,
-                itemBuilder: (context, index) {
-                  return filteredList.isNotEmpty
-                      ? BangumiCardV(
-                          enableHero: false,
-                          bangumiItem: filteredList[index],
-                        )
-                      : Container();
-                },
+                scrollController: scrollController,
+                spacing: StyleString.cardSpace,
               );
             }),
           ),
@@ -418,13 +457,11 @@ class _SearchPageState extends State<SearchPage> {
 class _SearchWorkbenchResult {
   const _SearchWorkbenchResult({
     required this.filterState,
-    required this.notShowWatched,
     required this.notShowAbandoned,
     required this.shouldSearch,
   });
 
   final SearchFilterState filterState;
-  final bool notShowWatched;
   final bool notShowAbandoned;
   final bool shouldSearch;
 }
@@ -432,12 +469,10 @@ class _SearchWorkbenchResult {
 class _SearchWorkbenchSheet extends StatefulWidget {
   const _SearchWorkbenchSheet({
     required this.initialState,
-    required this.initialNotShowWatched,
     required this.initialNotShowAbandoned,
   });
 
   final SearchFilterState initialState;
-  final bool initialNotShowWatched;
   final bool initialNotShowAbandoned;
 
   @override
@@ -446,7 +481,6 @@ class _SearchWorkbenchSheet extends StatefulWidget {
 
 class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
   late SearchFilterState draft = widget.initialState;
-  late bool notShowWatched = widget.initialNotShowWatched;
   late bool notShowAbandoned = widget.initialNotShowAbandoned;
   final TextEditingController tagController = TextEditingController();
 
@@ -840,17 +874,10 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                 const SizedBox(height: 12),
                 MaterialBottomSheetSection(
                   title: '过滤',
-                  description: '控制是否隐藏已经看过或放弃的番剧。',
+                  description: '控制是否隐藏已经放弃的番剧。',
                   icon: Icons.filter_alt_outlined,
                   child: Column(
                     children: [
-                      _SearchSwitchTile(
-                        title: '隐藏已看',
-                        value: notShowWatched,
-                        onChanged: (value) {
-                          setState(() => notShowWatched = value);
-                        },
-                      ),
                       _SearchSwitchTile(
                         title: '隐藏已弃',
                         value: notShowAbandoned,
@@ -872,7 +899,6 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                   onPressed: () {
                     setState(() {
                       draft = resetAdvancedFilters();
-                      notShowWatched = false;
                       notShowAbandoned = false;
                     });
                   },
@@ -886,7 +912,6 @@ class _SearchWorkbenchSheetState extends State<_SearchWorkbenchSheet> {
                       context,
                       _SearchWorkbenchResult(
                         filterState: draft,
-                        notShowWatched: notShowWatched,
                         notShowAbandoned: notShowAbandoned,
                         shouldSearch: true,
                       ),

--- a/lib/pages/search/search_result_buffer.dart
+++ b/lib/pages/search/search_result_buffer.dart
@@ -8,13 +8,6 @@ enum SearchViewMode {
 
 typedef SearchPageLoader = Future<BangumiSearchPage?> Function(int offset);
 
-class SearchPreparationLimitReached implements Exception {
-  const SearchPreparationLimitReached();
-
-  @override
-  String toString() => 'Search result preparation reached its request limit';
-}
-
 class SearchResultBuffer {
   SearchResultBuffer({
     required SearchPageLoader pageLoader,
@@ -23,7 +16,6 @@ class SearchResultBuffer {
     bool Function()? shouldContinue,
     this.hideAbandoned = false,
     this.pageSize = 20,
-    this.pageRequestInterval = Duration.zero,
   })  : _pageLoader = pageLoader,
         _watchedIds = watchedIds,
         _abandonedIds = abandonedIds,
@@ -34,24 +26,17 @@ class SearchResultBuffer {
   final Set<int> Function() _abandonedIds;
   final bool Function() _shouldContinue;
 
-  static bool _alwaysContinue() => true;
-
   final int pageSize;
-  final Duration pageRequestInterval;
   bool hideAbandoned;
-
-  static const int _maxPagesPerPreparation = 10;
-  static const int _maxConsecutiveDuplicatePages = 3;
 
   final List<BangumiItem> _rawItems = [];
   final Set<int> _rawIds = <int>{};
   int _offset = 0;
   bool _isExhausted = false;
-  bool _isPreparing = false;
   Object? _error;
-  Future<void>? _preparationFuture;
-  DateTime? _lastPageRequestAt;
-  int _consecutiveDuplicatePages = 0;
+  Future<void>? _loadFuture;
+
+  static bool _alwaysContinue() => true;
 
   List<BangumiItem> get allItems => List.unmodifiable(_projectAll());
 
@@ -60,63 +45,23 @@ class SearchResultBuffer {
 
   bool get isExhausted => _isExhausted;
 
-  bool get isPreparing => _isPreparing;
-
   Object? get error => _error;
 
   int get offset => _offset;
 
-  bool isReady(SearchViewMode mode, {int minimumItems = 20}) {
-    if (_isExhausted) return true;
-    final items = mode == SearchViewMode.all ? allItems : hideWatchedItems;
-    return items.length >= minimumItems;
-  }
+  /// Loads at most one remote page. Concurrent callers share the same request.
+  Future<void> loadNextPage() {
+    if (!_shouldContinue() || _isExhausted) return Future<void>.value();
+    final existing = _loadFuture;
+    if (existing != null) return existing;
 
-  Future<void> ensureReady({int minimumItems = 20}) async {
-    await ensureReadyFor(SearchViewMode.all, minimumItems: minimumItems);
-    if (_error != null) return;
-    await ensureReadyFor(SearchViewMode.hideWatched,
-        minimumItems: minimumItems);
-  }
-
-  Future<void> ensureReadyFor(
-    SearchViewMode mode, {
-    int minimumItems = 20,
-  }) async {
-    while (_shouldContinue() && !isReady(mode, minimumItems: minimumItems)) {
-      final existing = _preparationFuture;
-      if (existing != null) {
-        await existing;
-      } else {
-        final preparation = _prepare(mode, minimumItems);
-        _preparationFuture = preparation;
-        try {
-          await preparation;
-        } finally {
-          if (identical(_preparationFuture, preparation)) {
-            _preparationFuture = null;
-          }
-        }
-        return;
+    final load = _loadNextPage();
+    _loadFuture = load;
+    return load.whenComplete(() {
+      if (identical(_loadFuture, load)) {
+        _loadFuture = null;
       }
-      if (_error != null) return;
-    }
-  }
-
-  Future<void> ensureNextBatch(
-    SearchViewMode mode, {
-    int batchSize = 20,
-  }) async {
-    final currentCount =
-        mode == SearchViewMode.all ? allItems.length : hideWatchedItems.length;
-    await ensureReadyFor(mode, minimumItems: currentCount + batchSize);
-  }
-
-  Future<void> retry({int minimumItems = 20}) async {
-    if (_error == null) return;
-    _error = null;
-    _consecutiveDuplicatePages = 0;
-    await ensureReady(minimumItems: minimumItems);
+    });
   }
 
   void setHideAbandoned(bool value) {
@@ -137,78 +82,31 @@ class SearchResultBuffer {
         .toList(growable: false);
   }
 
-  bool _hasEnough(List<BangumiItem> items, int minimumItems) {
-    return items.length >= minimumItems;
-  }
-
-  Future<void> _prepare(SearchViewMode mode, int minimumItems) async {
-    _isPreparing = true;
-    _error = null;
-    var requestedPages = 0;
-    try {
-      while (_shouldContinue() && !_isExhausted) {
-        final items =
-            mode == SearchViewMode.all ? _projectAll() : _projectHideWatched();
-        if (_hasEnough(items, minimumItems)) break;
-        if (requestedPages >= _maxPagesPerPreparation) {
-          _error = const SearchPreparationLimitReached();
-          break;
-        }
-        final page = await _loadNextPage();
-        requestedPages++;
-        if (page == null || !_shouldContinue()) break;
-      }
-    } finally {
-      _isPreparing = false;
-    }
-  }
-
-  Future<BangumiSearchPage?> _loadNextPage() async {
-    if (!_shouldContinue()) return null;
+  Future<void> _loadNextPage() async {
+    if (!_shouldContinue()) return;
     final requestedOffset = _offset;
     try {
-      final lastRequestAt = _lastPageRequestAt;
-      if (lastRequestAt != null && pageRequestInterval > Duration.zero) {
-        final elapsed = DateTime.now().difference(lastRequestAt);
-        final remaining = pageRequestInterval - elapsed;
-        if (remaining > Duration.zero) {
-          await Future<void>.delayed(remaining);
-        }
-      }
-      if (!_shouldContinue()) return null;
-      _lastPageRequestAt = DateTime.now();
       final page = await _pageLoader(requestedOffset);
-      if (!_shouldContinue()) return null;
+      if (!_shouldContinue()) return;
       if (page == null) {
         _error = StateError('Search page request failed');
-        return null;
+        return;
       }
 
+      _error = null;
       _offset += page.rawCount;
       if (page.rawCount < pageSize || page.rawCount == 0) {
         _isExhausted = true;
       }
-
-      final previousCount = _rawIds.length;
       for (final item in page.items) {
         if (_rawIds.add(item.id)) {
           _rawItems.add(item);
         }
       }
-      if (_rawIds.length == previousCount) {
-        _consecutiveDuplicatePages++;
-      } else {
-        _consecutiveDuplicatePages = 0;
-      }
-      if (!_isExhausted &&
-          _consecutiveDuplicatePages >= _maxConsecutiveDuplicatePages) {
-        _error = const SearchPreparationLimitReached();
-        return null;
-      }
-      return page;
     } catch (error) {
-      _error = error;
-      return null;
+      if (_shouldContinue()) {
+        _error = error;
+      }
     }
   }
 }

--- a/lib/pages/search/search_result_buffer.dart
+++ b/lib/pages/search/search_result_buffer.dart
@@ -1,0 +1,214 @@
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+
+enum SearchViewMode {
+  all,
+  hideWatched,
+}
+
+typedef SearchPageLoader = Future<BangumiSearchPage?> Function(int offset);
+
+class SearchPreparationLimitReached implements Exception {
+  const SearchPreparationLimitReached();
+
+  @override
+  String toString() => 'Search result preparation reached its request limit';
+}
+
+class SearchResultBuffer {
+  SearchResultBuffer({
+    required SearchPageLoader pageLoader,
+    required Set<int> Function() watchedIds,
+    required Set<int> Function() abandonedIds,
+    bool Function()? shouldContinue,
+    this.hideAbandoned = false,
+    this.pageSize = 20,
+    this.pageRequestInterval = Duration.zero,
+  })  : _pageLoader = pageLoader,
+        _watchedIds = watchedIds,
+        _abandonedIds = abandonedIds,
+        _shouldContinue = shouldContinue ?? _alwaysContinue;
+
+  final SearchPageLoader _pageLoader;
+  final Set<int> Function() _watchedIds;
+  final Set<int> Function() _abandonedIds;
+  final bool Function() _shouldContinue;
+
+  static bool _alwaysContinue() => true;
+
+  final int pageSize;
+  final Duration pageRequestInterval;
+  bool hideAbandoned;
+
+  static const int _maxPagesPerPreparation = 10;
+  static const int _maxConsecutiveDuplicatePages = 3;
+
+  final List<BangumiItem> _rawItems = [];
+  final Set<int> _rawIds = <int>{};
+  int _offset = 0;
+  bool _isExhausted = false;
+  bool _isPreparing = false;
+  Object? _error;
+  Future<void>? _preparationFuture;
+  DateTime? _lastPageRequestAt;
+  int _consecutiveDuplicatePages = 0;
+
+  List<BangumiItem> get allItems => List.unmodifiable(_projectAll());
+
+  List<BangumiItem> get hideWatchedItems =>
+      List.unmodifiable(_projectHideWatched());
+
+  bool get isExhausted => _isExhausted;
+
+  bool get isPreparing => _isPreparing;
+
+  Object? get error => _error;
+
+  int get offset => _offset;
+
+  bool isReady(SearchViewMode mode, {int minimumItems = 20}) {
+    if (_isExhausted) return true;
+    final items = mode == SearchViewMode.all ? allItems : hideWatchedItems;
+    return items.length >= minimumItems;
+  }
+
+  Future<void> ensureReady({int minimumItems = 20}) async {
+    await ensureReadyFor(SearchViewMode.all, minimumItems: minimumItems);
+    if (_error != null) return;
+    await ensureReadyFor(SearchViewMode.hideWatched,
+        minimumItems: minimumItems);
+  }
+
+  Future<void> ensureReadyFor(
+    SearchViewMode mode, {
+    int minimumItems = 20,
+  }) async {
+    while (_shouldContinue() && !isReady(mode, minimumItems: minimumItems)) {
+      final existing = _preparationFuture;
+      if (existing != null) {
+        await existing;
+      } else {
+        final preparation = _prepare(mode, minimumItems);
+        _preparationFuture = preparation;
+        try {
+          await preparation;
+        } finally {
+          if (identical(_preparationFuture, preparation)) {
+            _preparationFuture = null;
+          }
+        }
+        return;
+      }
+      if (_error != null) return;
+    }
+  }
+
+  Future<void> ensureNextBatch(
+    SearchViewMode mode, {
+    int batchSize = 20,
+  }) async {
+    final currentCount =
+        mode == SearchViewMode.all ? allItems.length : hideWatchedItems.length;
+    await ensureReadyFor(mode, minimumItems: currentCount + batchSize);
+  }
+
+  Future<void> retry({int minimumItems = 20}) async {
+    if (_error == null) return;
+    _error = null;
+    _consecutiveDuplicatePages = 0;
+    await ensureReady(minimumItems: minimumItems);
+  }
+
+  void setHideAbandoned(bool value) {
+    hideAbandoned = value;
+  }
+
+  List<BangumiItem> _projectAll() {
+    final abandoned = _abandonedIds();
+    return _rawItems
+        .where((item) => !hideAbandoned || !abandoned.contains(item.id))
+        .toList(growable: false);
+  }
+
+  List<BangumiItem> _projectHideWatched() {
+    final watched = _watchedIds();
+    return _projectAll()
+        .where((item) => !watched.contains(item.id))
+        .toList(growable: false);
+  }
+
+  bool _hasEnough(List<BangumiItem> items, int minimumItems) {
+    return items.length >= minimumItems;
+  }
+
+  Future<void> _prepare(SearchViewMode mode, int minimumItems) async {
+    _isPreparing = true;
+    _error = null;
+    var requestedPages = 0;
+    try {
+      while (_shouldContinue() && !_isExhausted) {
+        final items =
+            mode == SearchViewMode.all ? _projectAll() : _projectHideWatched();
+        if (_hasEnough(items, minimumItems)) break;
+        if (requestedPages >= _maxPagesPerPreparation) {
+          _error = const SearchPreparationLimitReached();
+          break;
+        }
+        final page = await _loadNextPage();
+        requestedPages++;
+        if (page == null || !_shouldContinue()) break;
+      }
+    } finally {
+      _isPreparing = false;
+    }
+  }
+
+  Future<BangumiSearchPage?> _loadNextPage() async {
+    if (!_shouldContinue()) return null;
+    final requestedOffset = _offset;
+    try {
+      final lastRequestAt = _lastPageRequestAt;
+      if (lastRequestAt != null && pageRequestInterval > Duration.zero) {
+        final elapsed = DateTime.now().difference(lastRequestAt);
+        final remaining = pageRequestInterval - elapsed;
+        if (remaining > Duration.zero) {
+          await Future<void>.delayed(remaining);
+        }
+      }
+      if (!_shouldContinue()) return null;
+      _lastPageRequestAt = DateTime.now();
+      final page = await _pageLoader(requestedOffset);
+      if (!_shouldContinue()) return null;
+      if (page == null) {
+        _error = StateError('Search page request failed');
+        return null;
+      }
+
+      _offset += page.rawCount;
+      if (page.rawCount < pageSize || page.rawCount == 0) {
+        _isExhausted = true;
+      }
+
+      final previousCount = _rawIds.length;
+      for (final item in page.items) {
+        if (_rawIds.add(item.id)) {
+          _rawItems.add(item);
+        }
+      }
+      if (_rawIds.length == previousCount) {
+        _consecutiveDuplicatePages++;
+      } else {
+        _consecutiveDuplicatePages = 0;
+      }
+      if (!_isExhausted &&
+          _consecutiveDuplicatePages >= _maxConsecutiveDuplicatePages) {
+        _error = const SearchPreparationLimitReached();
+        return null;
+      }
+      return page;
+    } catch (error) {
+      _error = error;
+      return null;
+    }
+  }
+}

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -66,7 +66,15 @@ class _SearchResultGridState extends State<SearchResultGrid>
       oldWidget.scrollController.removeListener(_handleScroll);
       widget.scrollController.addListener(_handleScroll);
     }
-    if (_sameIds(widget.items, _toItems)) return;
+    if (_sameIds(widget.items, _toItems)) {
+      final refreshedItems = List<BangumiItem>.of(widget.items);
+      _toItems = refreshedItems;
+      if (!_animating) {
+        _visibleItems = refreshedItems;
+        _fromItems = refreshedItems;
+      }
+      return;
+    }
     _startTransition(List<BangumiItem>.of(widget.items));
   }
 

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -258,7 +258,10 @@ class _SearchResultGridState extends State<SearchResultGrid>
           ...toIndexes.keys,
         };
         final itemById = <int, BangumiItem>{
-          for (final item in [..._fromItems, ..._toItems]) item.id: item,
+          for (final item in _reversingToStart ? _toItems : _fromItems)
+            item.id: item,
+          for (final item in _reversingToStart ? _fromItems : _toItems)
+            item.id: item,
         };
         final maxRows = math.max(
           (_fromItems.length / crossCount).ceil(),

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -17,6 +17,7 @@ class SearchResultGrid extends StatefulWidget {
     required this.cardExtent,
     required this.itemBuilder,
     required this.scrollController,
+    this.trailingItem,
     this.spacing = 8,
     this.padding = const EdgeInsets.fromLTRB(8, 0, 8, 0),
     this.animate = true,
@@ -27,6 +28,7 @@ class SearchResultGrid extends StatefulWidget {
   final double cardExtent;
   final SearchResultItemBuilder itemBuilder;
   final ScrollController scrollController;
+  final Widget? trailingItem;
   final double spacing;
   final EdgeInsets padding;
   final bool animate;
@@ -40,6 +42,9 @@ class _SearchResultGridState extends State<SearchResultGrid>
   late List<BangumiItem> _visibleItems;
   List<BangumiItem> _fromItems = const [];
   List<BangumiItem> _toItems = const [];
+  Widget? _visibleTrailing;
+  Widget? _fromTrailing;
+  Widget? _toTrailing;
   late final AnimationController _animationController;
   bool _animating = false;
   bool _reversingToStart = false;
@@ -52,6 +57,9 @@ class _SearchResultGridState extends State<SearchResultGrid>
     _visibleItems = List<BangumiItem>.of(widget.items);
     _fromItems = _visibleItems;
     _toItems = _visibleItems;
+    _visibleTrailing = widget.trailingItem;
+    _fromTrailing = _visibleTrailing;
+    _toTrailing = _visibleTrailing;
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 420),
@@ -69,16 +77,22 @@ class _SearchResultGridState extends State<SearchResultGrid>
     if (_sameIds(widget.items, _toItems)) {
       final refreshedItems = List<BangumiItem>.of(widget.items);
       _toItems = refreshedItems;
+      _toTrailing = widget.trailingItem;
       if (_animating && _reversingToStart) {
         _reversingToStart = false;
         _animationController.forward();
       } else if (!_animating) {
         _visibleItems = refreshedItems;
         _fromItems = refreshedItems;
+        _visibleTrailing = widget.trailingItem;
+        _fromTrailing = _visibleTrailing;
       }
       return;
     }
-    _startTransition(List<BangumiItem>.of(widget.items));
+    _startTransition(
+      List<BangumiItem>.of(widget.items),
+      widget.trailingItem,
+    );
   }
 
   @override
@@ -94,9 +108,12 @@ class _SearchResultGridState extends State<SearchResultGrid>
     }
   }
 
-  void _startTransition(List<BangumiItem> nextItems) {
-    if (_animating && _sameIds(nextItems, _fromItems)) {
+  void _startTransition(List<BangumiItem> nextItems, Widget? nextTrailing) {
+    if (_animating &&
+        _sameIds(nextItems, _fromItems) &&
+        _hasTrailing(_fromTrailing) == _hasTrailing(nextTrailing)) {
       _fromItems = nextItems;
+      _fromTrailing = nextTrailing;
       _reversingToStart = true;
       _animationController.reverse();
       return;
@@ -104,7 +121,9 @@ class _SearchResultGridState extends State<SearchResultGrid>
 
     _animationController.stop();
     _fromItems = List<BangumiItem>.of(_visibleItems);
+    _fromTrailing = _visibleTrailing;
     _toItems = nextItems;
+    _toTrailing = nextTrailing;
     _reversingToStart = false;
 
     final reduceMotion =
@@ -113,6 +132,8 @@ class _SearchResultGridState extends State<SearchResultGrid>
       setState(() {
         _visibleItems = nextItems;
         _fromItems = nextItems;
+        _visibleTrailing = nextTrailing;
+        _fromTrailing = nextTrailing;
         _animating = false;
       });
       return;
@@ -130,10 +151,15 @@ class _SearchResultGridState extends State<SearchResultGrid>
     }
     final settledItems =
         status == AnimationStatus.completed ? _toItems : _fromItems;
+    final settledTrailing =
+        status == AnimationStatus.completed ? _toTrailing : _fromTrailing;
     setState(() {
       _visibleItems = List<BangumiItem>.of(settledItems);
       _fromItems = _visibleItems;
       _toItems = _visibleItems;
+      _visibleTrailing = settledTrailing;
+      _fromTrailing = settledTrailing;
+      _toTrailing = settledTrailing;
       _animating = false;
       _reversingToStart = false;
     });
@@ -146,6 +172,8 @@ class _SearchResultGridState extends State<SearchResultGrid>
     }
     return true;
   }
+
+  bool _hasTrailing(Widget? trailing) => trailing != null;
 
   Offset _positionFor(int index, double tileWidth, int crossCount) {
     final row = index ~/ crossCount;
@@ -207,6 +235,57 @@ class _SearchResultGridState extends State<SearchResultGrid>
     );
   }
 
+  Widget _buildAnimatedTrailing(
+    BuildContext context,
+    Widget trailing,
+    double tileWidth,
+    int crossCount,
+    int fromIndex,
+    int toIndex,
+  ) {
+    final startIndex = fromIndex >= 0 ? fromIndex : toIndex;
+    final endIndex = toIndex >= 0 ? toIndex : fromIndex;
+    final start = _positionFor(startIndex, tileWidth, crossCount);
+    final end = _positionFor(endIndex, tileWidth, crossCount);
+    final removed = toIndex < 0;
+    final added = fromIndex < 0;
+    return AnimatedBuilder(
+      key: const ValueKey('search-result-grid-trailing'),
+      animation: _animationController,
+      child: trailing,
+      builder: (context, child) {
+        final phase = _animationController.value;
+        final progress = Curves.easeInOut.transform(phase);
+        final position = Offset.lerp(start, end, progress) ?? end;
+        final opacity = removed
+            ? 1 - Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+            : added
+                ? Curves.easeOut
+                    .transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+                : 1.0;
+        final scale = removed
+            ? 1 - 0.08 * Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+            : added
+                ? 0.92 +
+                    0.08 *
+                        Curves.easeOut
+                            .transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+                : 1.0;
+
+        return Positioned(
+          left: position.dx,
+          top: position.dy,
+          width: tileWidth,
+          height: widget.cardExtent,
+          child: Opacity(
+            opacity: opacity,
+            child: Transform.scale(scale: scale, child: child),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -231,9 +310,15 @@ class _SearchResultGridState extends State<SearchResultGrid>
                     mainAxisExtent: widget.cardExtent,
                   ),
                   delegate: SliverChildBuilderDelegate(
-                    (context, index) =>
-                        widget.itemBuilder(context, _visibleItems[index]),
-                    childCount: _visibleItems.length,
+                    (context, index) {
+                      if (index == _visibleItems.length &&
+                          _visibleTrailing != null) {
+                        return _visibleTrailing;
+                      }
+                      return widget.itemBuilder(context, _visibleItems[index]);
+                    },
+                    childCount: _visibleItems.length +
+                        (_visibleTrailing == null ? 0 : 1),
                   ),
                 ),
               ),
@@ -264,8 +349,10 @@ class _SearchResultGridState extends State<SearchResultGrid>
             item.id: item,
         };
         final maxRows = math.max(
-          (_fromItems.length / crossCount).ceil(),
-          (_toItems.length / crossCount).ceil(),
+          ((_fromItems.length + (_fromTrailing == null ? 0 : 1)) / crossCount)
+              .ceil(),
+          ((_toItems.length + (_toTrailing == null ? 0 : 1)) / crossCount)
+              .ceil(),
         );
         final viewportHeight = widget.scrollController.hasClients
             ? widget.scrollController.position.viewportDimension
@@ -311,6 +398,17 @@ class _SearchResultGridState extends State<SearchResultGrid>
                           crossCount,
                           fromIndexes[id] ?? -1,
                           toIndexes[id] ?? -1,
+                        ),
+                      if (_fromTrailing != null || _toTrailing != null)
+                        _buildAnimatedTrailing(
+                          context,
+                          _reversingToStart
+                              ? (_fromTrailing ?? _toTrailing!)
+                              : (_toTrailing ?? _fromTrailing!),
+                          tileWidth,
+                          crossCount,
+                          _fromTrailing == null ? -1 : _fromItems.length,
+                          _toTrailing == null ? -1 : _toItems.length,
                         ),
                     ],
                   ),

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -69,7 +69,10 @@ class _SearchResultGridState extends State<SearchResultGrid>
     if (_sameIds(widget.items, _toItems)) {
       final refreshedItems = List<BangumiItem>.of(widget.items);
       _toItems = refreshedItems;
-      if (!_animating) {
+      if (_animating && _reversingToStart) {
+        _reversingToStart = false;
+        _animationController.forward();
+      } else if (!_animating) {
         _visibleItems = refreshedItems;
         _fromItems = refreshedItems;
       }
@@ -93,13 +96,9 @@ class _SearchResultGridState extends State<SearchResultGrid>
 
   void _startTransition(List<BangumiItem> nextItems) {
     if (_animating && _sameIds(nextItems, _fromItems)) {
+      _fromItems = nextItems;
       _reversingToStart = true;
       _animationController.reverse();
-      return;
-    }
-    if (_animating && _sameIds(nextItems, _toItems)) {
-      _reversingToStart = false;
-      _animationController.forward();
       return;
     }
 
@@ -134,6 +133,7 @@ class _SearchResultGridState extends State<SearchResultGrid>
     setState(() {
       _visibleItems = List<BangumiItem>.of(settledItems);
       _fromItems = _visibleItems;
+      _toItems = _visibleItems;
       _animating = false;
       _reversingToStart = false;
     });

--- a/lib/pages/search/search_result_grid.dart
+++ b/lib/pages/search/search_result_grid.dart
@@ -1,0 +1,314 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+
+typedef SearchResultItemBuilder = Widget Function(
+  BuildContext context,
+  BangumiItem item,
+);
+
+/// A fixed-format search grid that animates cards between two ordered views.
+class SearchResultGrid extends StatefulWidget {
+  const SearchResultGrid({
+    super.key,
+    required this.items,
+    required this.crossCount,
+    required this.cardExtent,
+    required this.itemBuilder,
+    required this.scrollController,
+    this.spacing = 8,
+    this.padding = const EdgeInsets.fromLTRB(8, 0, 8, 0),
+    this.animate = true,
+  });
+
+  final List<BangumiItem> items;
+  final int crossCount;
+  final double cardExtent;
+  final SearchResultItemBuilder itemBuilder;
+  final ScrollController scrollController;
+  final double spacing;
+  final EdgeInsets padding;
+  final bool animate;
+
+  @override
+  State<SearchResultGrid> createState() => _SearchResultGridState();
+}
+
+class _SearchResultGridState extends State<SearchResultGrid>
+    with SingleTickerProviderStateMixin {
+  late List<BangumiItem> _visibleItems;
+  List<BangumiItem> _fromItems = const [];
+  List<BangumiItem> _toItems = const [];
+  late final AnimationController _animationController;
+  bool _animating = false;
+  bool _reversingToStart = false;
+
+  double get _rowExtent => widget.cardExtent + widget.spacing;
+
+  @override
+  void initState() {
+    super.initState();
+    _visibleItems = List<BangumiItem>.of(widget.items);
+    _fromItems = _visibleItems;
+    _toItems = _visibleItems;
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 420),
+    )..addStatusListener(_handleAnimationStatus);
+    widget.scrollController.addListener(_handleScroll);
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchResultGrid oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.scrollController != widget.scrollController) {
+      oldWidget.scrollController.removeListener(_handleScroll);
+      widget.scrollController.addListener(_handleScroll);
+    }
+    if (_sameIds(widget.items, _toItems)) return;
+    _startTransition(List<BangumiItem>.of(widget.items));
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_handleScroll);
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _handleScroll() {
+    if (mounted && _animating) {
+      setState(() {});
+    }
+  }
+
+  void _startTransition(List<BangumiItem> nextItems) {
+    if (_animating && _sameIds(nextItems, _fromItems)) {
+      _reversingToStart = true;
+      _animationController.reverse();
+      return;
+    }
+    if (_animating && _sameIds(nextItems, _toItems)) {
+      _reversingToStart = false;
+      _animationController.forward();
+      return;
+    }
+
+    _animationController.stop();
+    _fromItems = List<BangumiItem>.of(_visibleItems);
+    _toItems = nextItems;
+    _reversingToStart = false;
+
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    if (!widget.animate || reduceMotion) {
+      setState(() {
+        _visibleItems = nextItems;
+        _fromItems = nextItems;
+        _animating = false;
+      });
+      return;
+    }
+
+    setState(() => _animating = true);
+    _animationController.forward(from: 0);
+  }
+
+  void _handleAnimationStatus(AnimationStatus status) {
+    if (!mounted ||
+        (status != AnimationStatus.completed &&
+            (status != AnimationStatus.dismissed || !_reversingToStart))) {
+      return;
+    }
+    final settledItems =
+        status == AnimationStatus.completed ? _toItems : _fromItems;
+    setState(() {
+      _visibleItems = List<BangumiItem>.of(settledItems);
+      _fromItems = _visibleItems;
+      _animating = false;
+      _reversingToStart = false;
+    });
+  }
+
+  bool _sameIds(List<BangumiItem> first, List<BangumiItem> second) {
+    if (first.length != second.length) return false;
+    for (var index = 0; index < first.length; index++) {
+      if (first[index].id != second[index].id) return false;
+    }
+    return true;
+  }
+
+  Offset _positionFor(int index, double tileWidth, int crossCount) {
+    final row = index ~/ crossCount;
+    final column = index % crossCount;
+    return Offset(
+      column * (tileWidth + widget.spacing),
+      row * _rowExtent,
+    );
+  }
+
+  Widget _buildAnimatedCard(
+    BuildContext context,
+    BangumiItem item,
+    double tileWidth,
+    int crossCount,
+    int fromIndex,
+    int toIndex,
+  ) {
+    final startIndex = fromIndex >= 0 ? fromIndex : toIndex;
+    final endIndex = toIndex >= 0 ? toIndex : fromIndex;
+    final start = _positionFor(startIndex, tileWidth, crossCount);
+    final end = _positionFor(endIndex, tileWidth, crossCount);
+    final removed = toIndex < 0;
+    final added = fromIndex < 0;
+    return AnimatedBuilder(
+      key: ValueKey(item.id),
+      animation: _animationController,
+      child: widget.itemBuilder(context, item),
+      builder: (context, child) {
+        final phase = _animationController.value;
+        final progress = Curves.easeInOut.transform(phase);
+        final position = Offset.lerp(start, end, progress) ?? end;
+        final opacity = removed
+            ? 1 - Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+            : added
+                ? Curves.easeOut
+                    .transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+                : 1.0;
+        final scale = removed
+            ? 1 - 0.08 * Curves.easeIn.transform((phase / 0.34).clamp(0.0, 1.0))
+            : added
+                ? 0.92 +
+                    0.08 *
+                        Curves.easeOut
+                            .transform(((phase - 0.78) / 0.22).clamp(0.0, 1.0))
+                : 1.0;
+
+        return Positioned(
+          left: position.dx,
+          top: position.dy,
+          width: tileWidth,
+          height: widget.cardExtent,
+          child: Opacity(
+            opacity: opacity,
+            child: Transform.scale(scale: scale, child: child),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossCount = math.max(1, widget.crossCount);
+        final width = math.max(
+          0.0,
+          constraints.maxWidth - widget.padding.horizontal,
+        );
+        if (!_animating) {
+          return CustomScrollView(
+            controller: widget.scrollController,
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: widget.padding,
+                sliver: SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossCount,
+                    mainAxisSpacing: widget.spacing,
+                    crossAxisSpacing: widget.spacing,
+                    mainAxisExtent: widget.cardExtent,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) =>
+                        widget.itemBuilder(context, _visibleItems[index]),
+                    childCount: _visibleItems.length,
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        final tileWidth = math.max(
+          0.0,
+          (width - widget.spacing * (crossCount - 1)) / crossCount,
+        );
+        final fromIndexes = <int, int>{
+          for (var index = 0; index < _fromItems.length; index++)
+            _fromItems[index].id: index,
+        };
+        final toIndexes = <int, int>{
+          for (var index = 0; index < _toItems.length; index++)
+            _toItems[index].id: index,
+        };
+        final ids = <int>{
+          ...fromIndexes.keys,
+          ...toIndexes.keys,
+        };
+        final itemById = <int, BangumiItem>{
+          for (final item in [..._fromItems, ..._toItems]) item.id: item,
+        };
+        final maxRows = math.max(
+          (_fromItems.length / crossCount).ceil(),
+          (_toItems.length / crossCount).ceil(),
+        );
+        final viewportHeight = widget.scrollController.hasClients
+            ? widget.scrollController.position.viewportDimension
+            : constraints.hasBoundedHeight
+                ? constraints.maxHeight
+                : MediaQuery.sizeOf(context).height;
+        final viewportTop = widget.scrollController.hasClients
+            ? widget.scrollController.offset
+            : 0.0;
+        final visibleTop = math.max(0.0, viewportTop - 2 * _rowExtent);
+        final visibleBottom = viewportTop + viewportHeight + 2 * _rowExtent;
+
+        bool isNearViewport(int id) {
+          final fromIndex = fromIndexes[id] ?? -1;
+          final toIndex = toIndexes[id] ?? -1;
+          final startIndex = fromIndex >= 0 ? fromIndex : toIndex;
+          final endIndex = toIndex >= 0 ? toIndex : fromIndex;
+          final start = _positionFor(startIndex, tileWidth, crossCount);
+          final end = _positionFor(endIndex, tileWidth, crossCount);
+          final top = math.min(start.dy, end.dy);
+          final bottom = math.max(start.dy, end.dy) + widget.cardExtent;
+          return bottom >= visibleTop && top <= visibleBottom;
+        }
+
+        return CustomScrollView(
+          controller: widget.scrollController,
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            SliverPadding(
+              padding: widget.padding,
+              sliver: SliverToBoxAdapter(
+                child: SizedBox(
+                  width: width,
+                  height: math.max(0.0, maxRows * _rowExtent - widget.spacing),
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      for (final id in ids.where(isNearViewport))
+                        _buildAnimatedCard(
+                          context,
+                          itemById[id]!,
+                          tileWidth,
+                          crossCount,
+                          fromIndexes[id] ?? -1,
+                          toIndexes[id] ?? -1,
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/repositories/collect_repository.dart
+++ b/lib/repositories/collect_repository.dart
@@ -6,6 +6,9 @@ import 'package:kazumi/services/logging/logger.dart';
 ///
 /// 提供收藏相关的数据访问抽象，解耦业务逻辑与数据存储
 abstract class ICollectRepository {
+  /// 收藏数据发生变化时发出通知，供依赖收藏状态的页面刷新投影。
+  Stream<void> get onCollectiblesChanged;
+
   /// 根据收藏类型获取番剧ID集合
   ///
   /// [type] 收藏类型
@@ -59,6 +62,10 @@ abstract class ICollectRepository {
 /// 基于Hive实现的收藏数据访问层
 class CollectRepository implements ICollectRepository {
   final _collectiblesBox = GStorage.collectibles;
+
+  @override
+  Stream<void> get onCollectiblesChanged =>
+      _collectiblesBox.watch().map<void>((_) {});
 
   @override
   Set<int> getBangumiIdsByType(CollectType type) {

--- a/test/search_controller_view_test.dart
+++ b/test/search_controller_view_test.dart
@@ -142,155 +142,88 @@ void main() {
     expect(receivedKeyword, '葬送的芙莉莲');
   });
 
-  test('initial search exposes all items before hidden view finishes',
-      () async {
-    final secondPage = Completer<BangumiSearchPage?>();
+  test('initial search requests only the first page', () async {
+    final calls = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+    }, _CollectRepository()..watched = {for (var i = 1; i < 20; i++) i});
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(calls, [0]);
+    expect(controller.bangumiList.length, 20);
+  });
+
+  test('switching views reuses the current cache without a request', () async {
     final calls = <int>[];
     final collect = _CollectRepository()
       ..watched = {for (var i = 1; i < 20; i++) i};
     final controller = _controller((keyword, filter, offset) {
       calls.add(offset);
-      return offset == 0
-          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
-          : secondPage.future;
+      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
     }, collect);
-
-    await controller.searchBangumi('alpha', type: 'init');
-
-    expect(controller.selectedViewMode, SearchViewMode.all);
-    expect(controller.bangumiList.map((item) => item.id),
-        Iterable<int>.generate(20, (i) => i + 1));
-    expect(controller.isHiddenViewPreparing, isTrue);
-    expect(calls, [0, 20]);
-
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await controller.waitForBackgroundPreparation();
-  });
-
-  test('requesting hidden view while preparing preserves all mode', () async {
-    final secondPage = Completer<BangumiSearchPage?>();
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 20; i++) i};
-    final controller = _controller(
-      (keyword, filter, offset) => offset == 0
-          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
-          : secondPage.future,
-      collect,
-    );
 
     await controller.searchBangumi('alpha', type: 'init');
     await controller.requestViewMode(SearchViewMode.hideWatched);
+    await controller.requestViewMode(SearchViewMode.all);
 
+    expect(calls, [0]);
     expect(controller.selectedViewMode, SearchViewMode.all);
-    expect(controller.pendingViewMode, SearchViewMode.hideWatched);
-    expect(controller.bangumiList.map((item) => item.id),
-        Iterable<int>.generate(20, (i) => i + 1));
-
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await controller.waitForBackgroundPreparation();
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
     expect(controller.bangumiList.length, 20);
-    expect(controller.bangumiList.first.id, 20);
   });
 
-  test('failed hidden prefetch exposes retry state without clearing all items',
-      () async {
-    var attempts = 0;
+  test('one load-more action requests only one page in hidden mode', () async {
+    final calls = <int>[];
     final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 20; i++) i};
+      ..watched = {for (var i = 1; i <= 40; i++) i};
     final controller = _controller((keyword, filter, offset) {
-      if (offset == 0) {
-        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
-      }
-      attempts++;
-      if (attempts == 1) {
-        return Future<BangumiSearchPage?>.error(StateError('offline'));
-      }
-      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
+      calls.add(offset);
+      return Future.value(
+        _page(Iterable<int>.generate(20, (i) => offset + i + 1)),
+      );
     }, collect);
 
     await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    await controller.searchBangumi('alpha', type: 'add');
 
-    expect(controller.selectedViewMode, SearchViewMode.all);
-    expect(controller.hiddenViewError, isA<StateError>());
-    expect(controller.isHiddenViewPreparing, isFalse);
-    expect(controller.bangumiList.length, 20);
-
-    await controller.retryHiddenView();
-
-    expect(controller.hiddenViewError, isNull);
+    expect(calls, [0, 20]);
     expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-    expect(controller.bangumiList.first.id, 20);
-  });
-
-  test('a failed search started from hidden mode can retry in place', () async {
-    var attempts = 0;
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 20; i++) i};
-    final controller = _controller((keyword, filter, offset) {
-      if (offset == 0) {
-        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
-      }
-      attempts++;
-      return attempts == 1
-          ? Future<BangumiSearchPage?>.error(StateError('offline'))
-          : Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    }, collect)
-      ..selectedViewMode = SearchViewMode.hideWatched;
-
-    await controller.searchBangumi('alpha', type: 'init');
-
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-    expect(controller.hiddenViewError, isA<StateError>());
     expect(controller.bangumiList, isEmpty);
-
-    await controller.retryHiddenView();
-
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-    expect(controller.hiddenViewError, isNull);
-    expect(controller.isTimeOut, isFalse);
-    expect(controller.bangumiList.first.id, 20);
   });
 
-  test('retry completion allows filters to prepare more hidden results',
-      () async {
-    var secondPageAttempts = 0;
+  test('a loaded page supplements both cached views', () async {
     final calls = <int>[];
     final collect = _CollectRepository()
       ..watched = {for (var i = 1; i < 20; i++) i};
     final controller = _controller((keyword, filter, offset) {
       calls.add(offset);
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => ++secondPageAttempts == 1
-            ? Future<BangumiSearchPage?>.error(StateError('offline'))
-            : Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
-        40 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 41))),
-        _ => Future.value(null),
-      };
+      return Future.value(
+        _page(Iterable<int>.generate(20, (i) => offset + i + 1)),
+      );
     }, collect);
 
     await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
-    await controller.retryHiddenView();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    await controller.searchBangumi('alpha', type: 'add');
 
-    collect.abandoned = {for (var i = 20; i < 40; i++) i};
-    await controller.setNotShowAbandonedBangumis(true);
+    expect(controller.bangumiList.length, 21);
+    await controller.requestViewMode(SearchViewMode.all);
 
-    expect(calls, [0, 20, 20, 40]);
-    expect(controller.bangumiList.length, 20);
-    expect(controller.bangumiList.first.id, 40);
+    expect(calls, [0, 20]);
+    expect(controller.bangumiList.length, 40);
   });
 
-  test('finishing a load more request preserves a newer view selection',
+  test('finishing a load-more request preserves a newer view selection',
       () async {
     final secondPage = Completer<BangumiSearchPage?>();
     final controller = _controller(
       (keyword, filter, offset) => offset == 0
           ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
           : secondPage.future,
-      _CollectRepository(),
+      _CollectRepository()..watched = {1},
     );
 
     await controller.searchBangumi('alpha', type: 'init');
@@ -301,15 +234,15 @@ void main() {
     await loadMore;
 
     expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.first.id, 2);
   });
 
-  test('late pages from an old query cannot replace the new query', () async {
+  test('late pages from an old query cannot replace a new query', () async {
     final oldPage = Completer<BangumiSearchPage?>();
-    final collect = _CollectRepository();
     final controller = _controller((keyword, filter, offset) {
       if (keyword == 'old') return oldPage.future;
       return Future.value(_page([99]));
-    }, collect);
+    }, _CollectRepository());
 
     final oldSearch = controller.searchBangumi('old', type: 'init');
     await Future<void>.delayed(Duration.zero);
@@ -320,134 +253,21 @@ void main() {
     expect(controller.bangumiList.map((item) => item.id), [99]);
   });
 
-  test('cached raw pages are reused when revealing the next all batch',
-      () async {
-    final calls = <int>[];
-    final secondPage = Completer<BangumiSearchPage?>();
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 20; i++) i};
-    final controller = _controller((keyword, filter, offset) {
-      calls.add(offset);
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => secondPage.future,
-        _ => Future.value(null),
-      };
-    }, collect);
-
-    await controller.searchBangumi('alpha', type: 'init');
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await controller.waitForBackgroundPreparation();
-    await controller.searchBangumi('alpha', type: 'add');
-
-    expect(controller.bangumiList.length, 40);
-    expect(calls, [0, 20]);
-  });
-
-  test('returning to hidden view restores its published result count',
-      () async {
-    final controller = _controller((keyword, filter, offset) {
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
-        _ => Future.value(null),
-      };
-    }, _CollectRepository());
-
-    await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
-    await controller.requestViewMode(SearchViewMode.hideWatched);
-    await controller.searchBangumi('alpha', type: 'add');
-    expect(controller.bangumiList.length, 40);
-
-    await controller.requestViewMode(SearchViewMode.all);
-    await controller.requestViewMode(SearchViewMode.hideWatched);
-
-    expect(controller.bangumiList.length, 40);
-  });
-
-  test('restores hidden view depth after a collection update is reversed',
-      () async {
-    final changes = StreamController<void>.broadcast();
-    final collect = _CollectRepository(changes: changes.stream);
-    final controller = _controller((keyword, filter, offset) {
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
-        _ => Future.value(const BangumiSearchPage(items: [], rawCount: 0)),
-      };
-    }, collect);
-
-    await controller.searchBangumi('alpha', type: 'init');
-    await controller.requestViewMode(SearchViewMode.hideWatched);
-    await controller.searchBangumi('alpha', type: 'add');
-    expect(controller.bangumiList.length, 40);
-
-    collect.watched = {for (var i = 1; i <= 25; i++) i};
-    changes.add(null);
-    await Future<void>.delayed(const Duration(milliseconds: 80));
-    expect(controller.bangumiList.length, 15);
-
-    collect.watched = <int>{};
-    changes.add(null);
-    await Future<void>.delayed(const Duration(milliseconds: 80));
-    expect(controller.bangumiList.length, 40);
-
-    controller.dispose();
-    await changes.close();
-  });
-
-  test('changing a filter before a new search does not await old preparation',
-      () async {
-    final secondPage = Completer<BangumiSearchPage?>();
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i <= 40; i++) i};
-    final controller = _controller((keyword, filter, offset) {
-      if (keyword == 'old') {
-        return switch (offset) {
-          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-          20 => secondPage.future,
-          _ => Future.value(null),
-        };
-      }
-      return Future.value(_page([100]));
-    }, collect);
-
-    await controller.searchBangumi('old', type: 'init');
-    var filterApplied = false;
-    controller
-        .setNotShowAbandonedBangumis(true, prepare: false)
-        .then((_) => filterApplied = true);
-    await Future<void>.delayed(Duration.zero);
-
-    expect(filterApplied, isTrue);
-    await controller.searchBangumi('new', type: 'init');
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await Future<void>.delayed(Duration.zero);
-
-    expect(controller.bangumiList.map((item) => item.id), [100]);
-  });
-
-  test('refreshes the active projection when collection state changes',
-      () async {
+  test('collection changes refresh the active projection from cache', () async {
     final changes = StreamController<void>.broadcast();
     final collect = _CollectRepository(changes: changes.stream);
     final controller = _controller(
-      (keyword, filter, offset) => Future.value(
-        offset == 0 ? _page(Iterable<int>.generate(20, (i) => i + 1)) : null,
-      ),
+      (keyword, filter, offset) => Future.value(_page([1, 2, 3])),
       collect,
     );
 
     await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
     await controller.requestViewMode(SearchViewMode.hideWatched);
-
     collect.watched = {1};
     changes.add(null);
     await Future<void>.delayed(const Duration(milliseconds: 80));
 
-    expect(controller.bangumiList.first.id, 2);
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
     controller.dispose();
     await changes.close();
   });
@@ -457,16 +277,13 @@ void main() {
     final changes = StreamController<void>.broadcast();
     final collect = _CollectRepository(changes: changes.stream);
     final controller = _controller(
-      (keyword, filter, offset) => Future.value(
-        offset == 0 ? _page(Iterable<int>.generate(20, (i) => i + 1)) : null,
-      ),
+      (keyword, filter, offset) => Future.value(_page([1, 2, 3])),
       collect,
     );
 
     await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
     collect.watchedIdQueryCount = 0;
-
     changes
       ..add(null)
       ..add(null)
@@ -478,191 +295,111 @@ void main() {
     await changes.close();
   });
 
-  test('disposing the controller cancels old query pagination', () async {
-    final secondPage = Completer<BangumiSearchPage?>();
-    final offsets = <int>[];
-    final controller = _controller((keyword, filter, offset) {
-      offsets.add(offset);
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => secondPage.future,
-        _ => Future.value(_page([100])),
-      };
-    }, _CollectRepository()..watched = {for (var i = 1; i <= 40; i++) i});
-
-    await controller.searchBangumi('alpha', type: 'init');
-    controller.dispose();
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await Future<void>.delayed(Duration.zero);
-
-    expect(offsets, [0, 20]);
-  });
-
-  test('changing hide abandoned rebuilds both projections from raw order',
+  test('hide-abandoned updates both projections without loading another page',
       () async {
-    final collect = _CollectRepository()..abandoned = {1};
-    final controller = _controller(
-      (keyword, filter, offset) =>
-          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
-      collect,
-    );
-
-    await controller.searchBangumi('alpha', type: 'init');
-    await controller.setNotShowAbandonedBangumis(true);
-
-    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
-    await controller.requestViewMode(SearchViewMode.hideWatched);
-    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
-  });
-
-  test('hiding abandoned items refills the prepared views', () async {
-    final collect = _CollectRepository()
-      ..abandoned = {for (var i = 1; i < 20; i++) i};
     final calls = <int>[];
+    final collect = _CollectRepository()
+      ..watched = {2}
+      ..abandoned = {1};
     final controller = _controller((keyword, filter, offset) {
       calls.add(offset);
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
-        _ => Future.value(null),
-      };
+      return Future.value(_page([1, 2, 3]));
     }, collect);
 
     await controller.searchBangumi('alpha', type: 'init');
     await controller.setNotShowAbandonedBangumis(true);
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
 
-    expect(calls, [0, 20]);
-    expect(controller.bangumiList.length, 20);
-    expect(controller.bangumiList.first.id, 20);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id), [3]);
+    expect(calls, [0]);
   });
 
-  test('an empty hidden view can switch back to all results', () async {
+  test('an empty hidden view can switch back to all cached results', () async {
     final collect = _CollectRepository()..watched = {1, 2, 3};
     final controller = _controller(
-      (keyword, filter, offset) =>
-          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
+      (keyword, filter, offset) => Future.value(_page([1, 2, 3])),
       collect,
     );
 
     await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
     await controller.requestViewMode(SearchViewMode.hideWatched);
-
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
     expect(controller.bangumiList, isEmpty);
 
     await controller.requestViewMode(SearchViewMode.all);
 
-    expect(controller.selectedViewMode, SearchViewMode.all);
     expect(controller.bangumiList.map((item) => item.id), [1, 2, 3]);
   });
 
-  test('new search from hidden mode never publishes watched items first',
+  test('a new search begun in hidden mode projects its first page only',
       () async {
-    final hiddenPage = Completer<BangumiSearchPage?>();
+    final calls = <int>[];
     final collect = _CollectRepository()
       ..watched = {for (var i = 1; i < 20; i++) i};
     final controller = _controller((keyword, filter, offset) {
-      if (offset == 0) {
-        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
-      }
-      return hiddenPage.future;
-    }, collect);
-    controller.selectedViewMode = SearchViewMode.hideWatched;
-
-    final search = controller.searchBangumi('new', type: 'init');
-    await Future<void>.delayed(Duration.zero);
-    expect(controller.bangumiList, isEmpty);
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-
-    hiddenPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-    await search;
-    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-    expect(controller.bangumiList.first.id, 20);
-  });
-
-  test('new search begun in hidden mode can reveal all results', () async {
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 20; i++) i};
-    final controller = _controller((keyword, filter, offset) {
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
-        _ => Future.value(null),
-      };
-    }, collect)
-      ..selectedViewMode = SearchViewMode.hideWatched;
-
-    await controller.searchBangumi('new', type: 'init');
-    await controller.requestViewMode(SearchViewMode.all);
-
-    expect(controller.selectedViewMode, SearchViewMode.all);
-    expect(controller.bangumiList.map((item) => item.id),
-        Iterable<int>.generate(20, (i) => i + 1));
-  });
-
-  test('hidden view can reveal cached final-page results after exhaustion',
-      () async {
-    final collect = _CollectRepository()
-      ..watched = {for (var i = 1; i < 11; i++) i};
-    final controller = _controller((keyword, filter, offset) {
-      return switch (offset) {
-        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-        20 => Future.value(
-            _page(Iterable<int>.generate(15, (i) => i + 21), rawCount: 15)),
-        _ => Future.value(null),
-      };
+      calls.add(offset);
+      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
     }, collect)
       ..selectedViewMode = SearchViewMode.hideWatched;
 
     await controller.searchBangumi('alpha', type: 'init');
 
+    expect(calls, [0]);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id), [20]);
+  });
+
+  test('a short first page disables load more', () async {
+    final controller = _controller(
+      (keyword, filter, offset) => Future.value(_page([1, 2, 3])),
+      _CollectRepository(),
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.hasMoreSearchResults, isFalse);
+  });
+
+  test('a failed load-more request can retry the same page', () async {
+    var secondPageAttempts = 0;
+    final offsets = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      offsets.add(offset);
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      secondPageAttempts++;
+      if (secondPageAttempts == 1) {
+        return Future<BangumiSearchPage?>.error(StateError('offline'));
+      }
+      return Future.value(_page([21]));
+    }, _CollectRepository());
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.searchBangumi('alpha', type: 'add');
     expect(controller.bangumiList.length, 20);
     expect(controller.hasMoreSearchResults, isTrue);
 
     await controller.searchBangumi('alpha', type: 'add');
 
-    expect(controller.bangumiList.length, 25);
+    expect(offsets, [0, 20, 20]);
+    expect(controller.bangumiList.last.id, 21);
     expect(controller.hasMoreSearchResults, isFalse);
   });
 
-  test('successful background retry restores the selected all view', () async {
-    var attempts = 0;
-    final controller = _controller((keyword, filter, offset) async {
-      attempts++;
-      if (attempts == 1) throw StateError('temporary failure');
-      return _page([1]);
-    }, _CollectRepository());
+  test('disposing the controller discards an in-flight page', () async {
+    final firstPage = Completer<BangumiSearchPage?>();
+    final controller = _controller(
+      (keyword, filter, offset) => firstPage.future,
+      _CollectRepository(),
+    );
 
-    await controller.searchBangumi('alpha', type: 'init');
-    await controller.waitForBackgroundPreparation();
-
-    expect(controller.bangumiList.map((item) => item.id), [1]);
-    expect(controller.isTimeOut, isFalse);
-  });
-
-  test('a replaced query stops the old hidden-view prefetch', () async {
-    final secondOldPage = Completer<BangumiSearchPage?>();
-    final oldOffsets = <int>[];
-    final controller = _controller((keyword, filter, offset) {
-      if (keyword == 'old') {
-        oldOffsets.add(offset);
-        return switch (offset) {
-          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-          20 => secondOldPage.future,
-          _ => Future.value(const BangumiSearchPage(items: [], rawCount: 0)),
-        };
-      }
-      return Future.value(_page([100]));
-    }, _CollectRepository()..watched = {for (var i = 1; i < 41; i++) i});
-
-    await controller.searchBangumi('old', type: 'init');
-    expect(oldOffsets, [0, 20]);
-
-    await controller.searchBangumi('new', type: 'init');
-    secondOldPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    final search = controller.searchBangumi('alpha', type: 'init');
     await Future<void>.delayed(Duration.zero);
+    controller.dispose();
+    firstPage.complete(_page([1]));
+    await search;
 
-    expect(oldOffsets, [0, 20]);
+    expect(controller.bangumiList, isEmpty);
   });
 }

--- a/test/search_controller_view_test.dart
+++ b/test/search_controller_view_test.dart
@@ -1,0 +1,668 @@
+import 'dart:async';
+
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/modules/search/search_history_module.dart';
+import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+import 'package:kazumi/repositories/search_history_repository.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+BangumiSearchPage _page(Iterable<int> ids, {int? rawCount}) {
+  final items = ids.map(_item).toList();
+  return BangumiSearchPage(items: items, rawCount: rawCount ?? items.length);
+}
+
+class _CollectRepository implements ICollectRepository {
+  _CollectRepository({Stream<void>? changes})
+      : _changes = changes ?? const Stream<void>.empty();
+
+  Set<int> watched = <int>{};
+  Set<int> abandoned = <int>{};
+  int watchedIdQueryCount = 0;
+  final Stream<void> _changes;
+
+  @override
+  Stream<void> get onCollectiblesChanged => _changes;
+
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) {
+    if (type == CollectType.watched) {
+      watchedIdQueryCount++;
+      return watched;
+    }
+    if (type == CollectType.abandoned) return abandoned;
+    return <int>{};
+  }
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => <int>{};
+
+  @override
+  bool getPrivateMode() => true;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}
+
+class _SearchHistoryRepository implements ISearchHistoryRepository {
+  @override
+  Future<void> clearAllHistories() async {}
+
+  @override
+  Future<void> deleteHistory(SearchHistory history) async {}
+
+  @override
+  Future<void> deleteDuplicates(String keyword) async {}
+
+  @override
+  Future<void> deleteOldest() async {}
+
+  @override
+  List<SearchHistory> getAllHistories() => <SearchHistory>[];
+
+  @override
+  bool isHistoryFull(int maxCount) => false;
+
+  @override
+  Future<bool> saveHistory(String keyword) async => true;
+}
+
+SearchPageController _controller(
+  SearchPageRequestLoader loader,
+  _CollectRepository collect,
+) {
+  return SearchPageController.withPageLoader(
+    collect,
+    _SearchHistoryRepository(),
+    loader,
+  );
+}
+
+void main() {
+  test('is disposable for scoped routes', () {
+    final controller = _controller(
+      (keyword, filter, offset) =>
+          Future.value(const BangumiSearchPage(items: [], rawCount: 0)),
+      _CollectRepository(),
+    );
+
+    expect(controller, isA<Disposable>());
+    controller.dispose();
+  });
+
+  test('page loader receives the parsed search keyword', () async {
+    String? receivedKeyword;
+    final controller = _controller((keyword, filter, offset) {
+      receivedKeyword = keyword;
+      expect(filter.tags, ['奇幻']);
+      return Future.value(const BangumiSearchPage(items: [], rawCount: 0));
+    }, _CollectRepository());
+
+    await controller.searchBangumi('葬送的芙莉莲 tag:奇幻', type: 'init');
+
+    expect(receivedKeyword, '葬送的芙莉莲');
+  });
+
+  test('initial search exposes all items before hidden view finishes',
+      () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final calls = <int>[];
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future;
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.bangumiList.map((item) => item.id),
+        Iterable<int>.generate(20, (i) => i + 1));
+    expect(controller.isHiddenViewPreparing, isTrue);
+    expect(calls, [0, 20]);
+
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+  });
+
+  test('requesting hidden view while preparing preserves all mode', () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller(
+      (keyword, filter, offset) => offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future,
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.pendingViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id),
+        Iterable<int>.generate(20, (i) => i + 1));
+
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.length, 20);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('failed hidden prefetch exposes retry state without clearing all items',
+      () async {
+    var attempts = 0;
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      attempts++;
+      if (attempts == 1) {
+        return Future<BangumiSearchPage?>.error(StateError('offline'));
+      }
+      return Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.hiddenViewError, isA<StateError>());
+    expect(controller.isHiddenViewPreparing, isFalse);
+    expect(controller.bangumiList.length, 20);
+
+    await controller.retryHiddenView();
+
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('a failed search started from hidden mode can retry in place', () async {
+    var attempts = 0;
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      attempts++;
+      return attempts == 1
+          ? Future<BangumiSearchPage?>.error(StateError('offline'))
+          : Future.value(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    }, collect)
+      ..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.hiddenViewError, isA<StateError>());
+    expect(controller.bangumiList, isEmpty);
+
+    await controller.retryHiddenView();
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.isTimeOut, isFalse);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('retry completion allows filters to prepare more hidden results',
+      () async {
+    var secondPageAttempts = 0;
+    final calls = <int>[];
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => ++secondPageAttempts == 1
+            ? Future<BangumiSearchPage?>.error(StateError('offline'))
+            : Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        40 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 41))),
+        _ => Future.value(null),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    await controller.retryHiddenView();
+
+    collect.abandoned = {for (var i = 20; i < 40; i++) i};
+    await controller.setNotShowAbandonedBangumis(true);
+
+    expect(calls, [0, 20, 20, 40]);
+    expect(controller.bangumiList.length, 20);
+    expect(controller.bangumiList.first.id, 40);
+  });
+
+  test('finishing a load more request preserves a newer view selection',
+      () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final controller = _controller(
+      (keyword, filter, offset) => offset == 0
+          ? Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)))
+          : secondPage.future,
+      _CollectRepository(),
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    final loadMore = controller.searchBangumi('alpha', type: 'add');
+    await Future<void>.delayed(Duration.zero);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await loadMore;
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+  });
+
+  test('late pages from an old query cannot replace the new query', () async {
+    final oldPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository();
+    final controller = _controller((keyword, filter, offset) {
+      if (keyword == 'old') return oldPage.future;
+      return Future.value(_page([99]));
+    }, collect);
+
+    final oldSearch = controller.searchBangumi('old', type: 'init');
+    await Future<void>.delayed(Duration.zero);
+    await controller.searchBangumi('new', type: 'init');
+    oldPage.complete(_page([1]));
+    await oldSearch;
+
+    expect(controller.bangumiList.map((item) => item.id), [99]);
+  });
+
+  test('cached raw pages are reused when revealing the next all batch',
+      () async {
+    final calls = <int>[];
+    final secondPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => secondPage.future,
+        _ => Future.value(null),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await controller.waitForBackgroundPreparation();
+    await controller.searchBangumi('alpha', type: 'add');
+
+    expect(controller.bangumiList.length, 40);
+    expect(calls, [0, 20]);
+  });
+
+  test('returning to hidden view restores its published result count',
+      () async {
+    final controller = _controller((keyword, filter, offset) {
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        _ => Future.value(null),
+      };
+    }, _CollectRepository());
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    await controller.searchBangumi('alpha', type: 'add');
+    expect(controller.bangumiList.length, 40);
+
+    await controller.requestViewMode(SearchViewMode.all);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    expect(controller.bangumiList.length, 40);
+  });
+
+  test('restores hidden view depth after a collection update is reversed',
+      () async {
+    final changes = StreamController<void>.broadcast();
+    final collect = _CollectRepository(changes: changes.stream);
+    final controller = _controller((keyword, filter, offset) {
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        _ => Future.value(const BangumiSearchPage(items: [], rawCount: 0)),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    await controller.searchBangumi('alpha', type: 'add');
+    expect(controller.bangumiList.length, 40);
+
+    collect.watched = {for (var i = 1; i <= 25; i++) i};
+    changes.add(null);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(controller.bangumiList.length, 15);
+
+    collect.watched = <int>{};
+    changes.add(null);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(controller.bangumiList.length, 40);
+
+    controller.dispose();
+    await changes.close();
+  });
+
+  test('changing a filter before a new search does not await old preparation',
+      () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i <= 40; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (keyword == 'old') {
+        return switch (offset) {
+          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+          20 => secondPage.future,
+          _ => Future.value(null),
+        };
+      }
+      return Future.value(_page([100]));
+    }, collect);
+
+    await controller.searchBangumi('old', type: 'init');
+    var filterApplied = false;
+    controller
+        .setNotShowAbandonedBangumis(true, prepare: false)
+        .then((_) => filterApplied = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(filterApplied, isTrue);
+    await controller.searchBangumi('new', type: 'init');
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.bangumiList.map((item) => item.id), [100]);
+  });
+
+  test('refreshes the active projection when collection state changes',
+      () async {
+    final changes = StreamController<void>.broadcast();
+    final collect = _CollectRepository(changes: changes.stream);
+    final controller = _controller(
+      (keyword, filter, offset) => Future.value(
+        offset == 0 ? _page(Iterable<int>.generate(20, (i) => i + 1)) : null,
+      ),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    collect.watched = {1};
+    changes.add(null);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(controller.bangumiList.first.id, 2);
+    controller.dispose();
+    await changes.close();
+  });
+
+  test('coalesces rapid collection changes into one projection refresh',
+      () async {
+    final changes = StreamController<void>.broadcast();
+    final collect = _CollectRepository(changes: changes.stream);
+    final controller = _controller(
+      (keyword, filter, offset) => Future.value(
+        offset == 0 ? _page(Iterable<int>.generate(20, (i) => i + 1)) : null,
+      ),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    collect.watchedIdQueryCount = 0;
+
+    changes
+      ..add(null)
+      ..add(null)
+      ..add(null);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(collect.watchedIdQueryCount, 1);
+    controller.dispose();
+    await changes.close();
+  });
+
+  test('disposing the controller cancels old query pagination', () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final offsets = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => secondPage.future,
+        _ => Future.value(_page([100])),
+      };
+    }, _CollectRepository()..watched = {for (var i = 1; i <= 40; i++) i});
+
+    await controller.searchBangumi('alpha', type: 'init');
+    controller.dispose();
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(offsets, [0, 20]);
+  });
+
+  test('changing hide abandoned rebuilds both projections from raw order',
+      () async {
+    final collect = _CollectRepository()..abandoned = {1};
+    final controller = _controller(
+      (keyword, filter, offset) =>
+          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.setNotShowAbandonedBangumis(true);
+
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
+  });
+
+  test('hiding abandoned items refills the prepared views', () async {
+    final collect = _CollectRepository()
+      ..abandoned = {for (var i = 1; i < 20; i++) i};
+    final calls = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      calls.add(offset);
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        _ => Future.value(null),
+      };
+    }, collect);
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.setNotShowAbandonedBangumis(true);
+
+    expect(calls, [0, 20]);
+    expect(controller.bangumiList.length, 20);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('an empty hidden view can switch back to all results', () async {
+    final collect = _CollectRepository()..watched = {1, 2, 3};
+    final controller = _controller(
+      (keyword, filter, offset) =>
+          offset == 0 ? Future.value(_page([1, 2, 3])) : Future.value(null),
+      collect,
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList, isEmpty);
+
+    await controller.requestViewMode(SearchViewMode.all);
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.bangumiList.map((item) => item.id), [1, 2, 3]);
+  });
+
+  test('new search from hidden mode never publishes watched items first',
+      () async {
+    final hiddenPage = Completer<BangumiSearchPage?>();
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      if (offset == 0) {
+        return Future.value(_page(Iterable<int>.generate(20, (i) => i + 1)));
+      }
+      return hiddenPage.future;
+    }, collect);
+    controller.selectedViewMode = SearchViewMode.hideWatched;
+
+    final search = controller.searchBangumi('new', type: 'init');
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.bangumiList, isEmpty);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+
+    hiddenPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await search;
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(controller.bangumiList.first.id, 20);
+  });
+
+  test('new search begun in hidden mode can reveal all results', () async {
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 20; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 21))),
+        _ => Future.value(null),
+      };
+    }, collect)
+      ..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('new', type: 'init');
+    await controller.requestViewMode(SearchViewMode.all);
+
+    expect(controller.selectedViewMode, SearchViewMode.all);
+    expect(controller.bangumiList.map((item) => item.id),
+        Iterable<int>.generate(20, (i) => i + 1));
+  });
+
+  test('hidden view can reveal cached final-page results after exhaustion',
+      () async {
+    final collect = _CollectRepository()
+      ..watched = {for (var i = 1; i < 11; i++) i};
+    final controller = _controller((keyword, filter, offset) {
+      return switch (offset) {
+        0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+        20 => Future.value(
+            _page(Iterable<int>.generate(15, (i) => i + 21), rawCount: 15)),
+        _ => Future.value(null),
+      };
+    }, collect)
+      ..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('alpha', type: 'init');
+
+    expect(controller.bangumiList.length, 20);
+    expect(controller.hasMoreSearchResults, isTrue);
+
+    await controller.searchBangumi('alpha', type: 'add');
+
+    expect(controller.bangumiList.length, 25);
+    expect(controller.hasMoreSearchResults, isFalse);
+  });
+
+  test('successful background retry restores the selected all view', () async {
+    var attempts = 0;
+    final controller = _controller((keyword, filter, offset) async {
+      attempts++;
+      if (attempts == 1) throw StateError('temporary failure');
+      return _page([1]);
+    }, _CollectRepository());
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.waitForBackgroundPreparation();
+
+    expect(controller.bangumiList.map((item) => item.id), [1]);
+    expect(controller.isTimeOut, isFalse);
+  });
+
+  test('a replaced query stops the old hidden-view prefetch', () async {
+    final secondOldPage = Completer<BangumiSearchPage?>();
+    final oldOffsets = <int>[];
+    final controller = _controller((keyword, filter, offset) {
+      if (keyword == 'old') {
+        oldOffsets.add(offset);
+        return switch (offset) {
+          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+          20 => secondOldPage.future,
+          _ => Future.value(const BangumiSearchPage(items: [], rawCount: 0)),
+        };
+      }
+      return Future.value(_page([100]));
+    }, _CollectRepository()..watched = {for (var i = 1; i < 41; i++) i});
+
+    await controller.searchBangumi('old', type: 'init');
+    expect(oldOffsets, [0, 20]);
+
+    await controller.searchBangumi('new', type: 'init');
+    secondOldPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(oldOffsets, [0, 20]);
+  });
+}

--- a/test/search_page_test.dart
+++ b/test/search_page_test.dart
@@ -1,0 +1,225 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/modules/search/search_history_module.dart';
+import 'package:kazumi/pages/search/search_controller.dart';
+import 'package:kazumi/pages/search/search_page.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+import 'package:kazumi/repositories/search_history_repository.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+import 'package:kazumi/services/storage/storage.dart';
+
+class _CollectRepository implements ICollectRepository {
+  @override
+  Stream<void> get onCollectiblesChanged => const Stream<void>.empty();
+
+  Set<int> watched = <int>{};
+
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) {
+    return type == CollectType.watched ? watched : <int>{};
+  }
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => <int>{};
+
+  @override
+  bool getPrivateMode() => true;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}
+
+class _SearchHistoryRepository implements ISearchHistoryRepository {
+  @override
+  Future<void> clearAllHistories() async {}
+
+  @override
+  Future<void> deleteHistory(SearchHistory history) async {}
+
+  @override
+  Future<void> deleteDuplicates(String keyword) async {}
+
+  @override
+  Future<void> deleteOldest() async {}
+
+  @override
+  List<SearchHistory> getAllHistories() => <SearchHistory>[];
+
+  @override
+  bool isHistoryFull(int maxCount) => false;
+
+  @override
+  Future<bool> saveHistory(String keyword) async => true;
+}
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('kazumi_search_page_test_');
+    Hive.init(tempDir.path);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async => tempDir.path,
+    );
+    await GStorage.init();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('opens with an empty result state without a framework exception',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('搜索'), findsOneWidget);
+  });
+
+  testWidgets('opens when the hidden view is selected before it has results',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    )..selectedViewMode = SearchViewMode.hideWatched;
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('隐藏已看'), findsOneWidget);
+  });
+
+  testWidgets('retries failed hidden view preparation from the control',
+      (tester) async {
+    var attempts = 0;
+    final controller = SearchPageController.withPageLoader(
+      _CollectRepository()..watched = {for (var i = 1; i < 20; i++) i},
+      _SearchHistoryRepository(),
+      (keyword, filter, offset) {
+        if (offset == 0) {
+          return Future.value(
+            BangumiSearchPage(
+              items: List<BangumiItem>.generate(20, (i) => _item(i + 1)),
+              rawCount: 40,
+            ),
+          );
+        }
+        attempts++;
+        return attempts == 1
+            ? Future<BangumiSearchPage?>.error(StateError('offline'))
+            : Future.value(
+                BangumiSearchPage(
+                  items: List<BangumiItem>.generate(20, (i) => _item(i + 21)),
+                  rawCount: 40,
+                ),
+              );
+      },
+    )..selectedViewMode = SearchViewMode.hideWatched;
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(find.byTooltip('重试准备隐藏已看'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('重试准备隐藏已看'));
+    await tester.pumpAndSettle();
+
+    expect(controller.hiddenViewError, isNull);
+    expect(controller.selectedViewMode, SearchViewMode.hideWatched);
+    expect(find.text('name-20'), findsOneWidget);
+  });
+
+  testWidgets('opens a populated result grid without a framework exception',
+      (tester) async {
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    )..bangumiList.addAll([_item(1), _item(2), _item(3)]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('name-1'), findsOneWidget);
+  });
+
+  testWidgets('opens the search input view without a framework exception',
+      (tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+    final controller = SearchPageController(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.tap(find.byType(SearchBar));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/search_page_test.dart
+++ b/test/search_page_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import 'package:kazumi/modules/search/search_history_module.dart';
 import 'package:kazumi/pages/search/search_controller.dart';
 import 'package:kazumi/pages/search/search_page.dart';
 import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/pages/search/search_result_grid.dart';
 import 'package:kazumi/repositories/collect_repository.dart';
 import 'package:kazumi/repositories/search_history_repository.dart';
 import 'package:kazumi/request/apis/bangumi_api.dart';
@@ -145,32 +147,22 @@ void main() {
     expect(find.text('隐藏已看'), findsOneWidget);
   });
 
-  testWidgets('retries failed hidden view preparation from the control',
+  testWidgets('view control switches cached results without loading a page',
       (tester) async {
-    var attempts = 0;
+    final offsets = <int>[];
     final controller = SearchPageController.withPageLoader(
-      _CollectRepository()..watched = {for (var i = 1; i < 20; i++) i},
+      _CollectRepository()..watched = {1},
       _SearchHistoryRepository(),
       (keyword, filter, offset) {
-        if (offset == 0) {
-          return Future.value(
-            BangumiSearchPage(
-              items: List<BangumiItem>.generate(20, (i) => _item(i + 1)),
-              rawCount: 40,
-            ),
-          );
-        }
-        attempts++;
-        return attempts == 1
-            ? Future<BangumiSearchPage?>.error(StateError('offline'))
-            : Future.value(
-                BangumiSearchPage(
-                  items: List<BangumiItem>.generate(20, (i) => _item(i + 21)),
-                  rawCount: 40,
-                ),
-              );
+        offsets.add(offset);
+        return Future.value(
+          BangumiSearchPage(
+            items: List<BangumiItem>.generate(3, (i) => _item(i + 1)),
+            rawCount: 3,
+          ),
+        );
       },
-    )..selectedViewMode = SearchViewMode.hideWatched;
+    );
 
     await controller.searchBangumi('alpha', type: 'init');
     await tester.pumpWidget(
@@ -178,14 +170,101 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.byTooltip('重试准备隐藏已看'), findsOneWidget);
-
-    await tester.tap(find.byTooltip('重试准备隐藏已看'));
+    await tester.tap(find.text('隐藏已看'));
     await tester.pumpAndSettle();
 
-    expect(controller.hiddenViewError, isNull);
     expect(controller.selectedViewMode, SearchViewMode.hideWatched);
-    expect(find.text('name-20'), findsOneWidget);
+    expect(controller.bangumiList.map((item) => item.id), [2, 3]);
+    expect(offsets, [0]);
+    expect(find.text('name-1'), findsNothing);
+    expect(find.text('name-2'), findsOneWidget);
+  });
+
+  testWidgets('load-more control requests one page per tap', (tester) async {
+    final offsets = <int>[];
+    final controller = SearchPageController.withPageLoader(
+      _CollectRepository()..watched = {for (var i = 1; i < 20; i++) i},
+      _SearchHistoryRepository(),
+      (keyword, filter, offset) {
+        offsets.add(offset);
+        return Future.value(
+          BangumiSearchPage(
+            items: List<BangumiItem>.generate(
+              20,
+              (i) => _item(offset + i + 1),
+            ),
+            rawCount: 20,
+          ),
+        );
+      },
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await controller.requestViewMode(SearchViewMode.hideWatched);
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    expect(offsets, [0]);
+    expect(find.text('加载更多'), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text('加载更多'),
+        matching: find.byType(SearchResultGrid),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('加载更多'));
+    await tester.pumpAndSettle();
+
+    expect(offsets, [0, 20]);
+    expect(controller.bangumiList.length, 21);
+  });
+
+  testWidgets('scrolling to the grid bottom loads the next page',
+      (tester) async {
+    tester.view.physicalSize = const Size(1080, 1800);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+    final offsets = <int>[];
+    final secondPage = Completer<BangumiSearchPage?>();
+    final controller = SearchPageController.withPageLoader(
+      _CollectRepository(),
+      _SearchHistoryRepository(),
+      (keyword, filter, offset) {
+        offsets.add(offset);
+        if (offset == 0) {
+          return Future.value(
+            BangumiSearchPage(
+              items: List<BangumiItem>.generate(60, (i) => _item(i + 1)),
+              rawCount: 20,
+            ),
+          );
+        }
+        return secondPage.future;
+      },
+    );
+
+    await controller.searchBangumi('alpha', type: 'init');
+    await tester.pumpWidget(
+      MaterialApp(home: SearchPage(controller: controller)),
+    );
+    await tester.pump();
+
+    await tester.drag(
+      find.byType(CustomScrollView),
+      const Offset(0, -5000),
+    );
+    await tester.pump();
+
+    expect(offsets, [0, 20]);
+
+    secondPage.complete(
+      BangumiSearchPage(items: [_item(61)], rawCount: 1),
+    );
+    await tester.pumpAndSettle();
   });
 
   testWidgets('opens a populated result grid without a framework exception',

--- a/test/search_result_buffer_test.dart
+++ b/test/search_result_buffer_test.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
-import 'package:kazumi/request/apis/bangumi_api.dart';
 import 'package:kazumi/pages/search/search_result_buffer.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
 
 BangumiItem _item(int id) {
   return BangumiItem(
@@ -31,236 +31,179 @@ BangumiSearchPage _page(Iterable<int> ids, {int? rawCount}) {
 }
 
 void main() {
-  test(
-      'fills hidden view from later raw pages when first page is mostly watched',
-      () async {
-    final offsets = <int>[];
-    Future<BangumiSearchPage?> loader(int offset) async {
-      offsets.add(offset);
-      return switch (offset) {
-        0 => _page(Iterable<int>.generate(20, (index) => index + 1)),
-        20 => _page(Iterable<int>.generate(20, (index) => index + 21)),
-        _ => null,
-      };
-    }
-
-    final buffer = SearchResultBuffer(
-      pageLoader: loader,
-      watchedIds: () => Set<int>.from(Iterable<int>.generate(19, (i) => i + 1)),
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady();
-
-    expect(buffer.allItems.take(20).map((item) => item.id),
-        Iterable<int>.generate(20, (index) => index + 1));
-    expect(buffer.hideWatchedItems.take(20).map((item) => item.id),
-        [20, ...Iterable<int>.generate(19, (index) => index + 21)]);
-    expect(offsets, [0, 20]);
-    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
-  });
-
-  test('advances offset by raw count instead of filtered item count', () async {
-    final offsets = <int>[];
-    Future<BangumiSearchPage?> loader(int offset) async {
-      offsets.add(offset);
-      return switch (offset) {
-        0 => _page([1, 2], rawCount: 5),
-        5 => _page([3, 4], rawCount: 2),
-        _ => null,
-      };
-    }
-
-    final buffer = SearchResultBuffer(
-      pageLoader: loader,
-      watchedIds: () => <int>{},
-      abandonedIds: () => <int>{},
-      pageSize: 5,
-    );
-
-    await buffer.ensureReady();
-
-    expect(offsets, [0, 5]);
-    expect(buffer.allItems.map((item) => item.id), [1, 2, 3, 4]);
-  });
-
-  test('continues after a full page adds no new item', () async {
-    final offsets = <int>[];
-    Future<BangumiSearchPage?> loader(int offset) async {
-      offsets.add(offset);
-      return switch (offset) {
-        0 => _page([1, 2], rawCount: 20),
-        20 => _page([1, 2], rawCount: 20),
-        40 => _page([3], rawCount: 1),
-        _ => null,
-      };
-    }
-
-    final buffer = SearchResultBuffer(
-      pageLoader: loader,
-      watchedIds: () => <int>{},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady();
-
-    expect(offsets, [0, 20, 40]);
-    expect(buffer.allItems.map((item) => item.id), [1, 2, 3]);
-    expect(buffer.isExhausted, isTrue);
-  });
-
-  test('reports a retryable error after consecutive full pages add no new item',
-      () async {
-    final offsets = <int>[];
-    final buffer = SearchResultBuffer(
-      pageLoader: (offset) async {
-        offsets.add(offset);
-        return switch (offset) {
-          0 || 20 || 40 || 60 => _page([1, 2], rawCount: 20),
-          80 => _page(Iterable<int>.generate(18, (index) => index + 3)),
-          _ => _page([], rawCount: 0),
-        };
-      },
-      watchedIds: () => <int>{},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady(minimumItems: 20);
-
-    expect(offsets, [0, 20, 40, 60]);
-    expect(buffer.allItems.map((item) => item.id), [1, 2]);
-    expect(buffer.error, isA<SearchPreparationLimitReached>());
-    expect(buffer.isExhausted, isFalse);
-
-    await buffer.retry();
-
-    expect(offsets, [0, 20, 40, 60, 80]);
-    expect(buffer.allItems.length, 20);
-    expect(buffer.error, isNull);
-  });
-
-  test('treats a short duplicate page as exhausted instead of retryable',
-      () async {
-    final buffer = SearchResultBuffer(
-      pageLoader: (offset) async {
-        return switch (offset) {
-          0 || 20 || 40 => _page([1, 2], rawCount: 20),
-          60 => _page([1, 2], rawCount: 1),
-          _ => _page([], rawCount: 0),
-        };
-      },
-      watchedIds: () => <int>{},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady(minimumItems: 20);
-
-    expect(buffer.isExhausted, isTrue);
-    expect(buffer.error, isNull);
-  });
-
-  test(
-      'marks filtered view ready with fewer items when raw results are exhausted',
-      () async {
-    final buffer = SearchResultBuffer(
-      pageLoader: (int offset) async => offset == 0 ? _page([1, 2]) : null,
-      watchedIds: () => <int>{1},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady();
-
-    expect(buffer.hideWatchedItems.map((item) => item.id), [2]);
-    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
-  });
-
-  test('retries a failed page without discarding existing results', () async {
-    var attempts = 0;
-    final buffer = SearchResultBuffer(
-      pageLoader: (int offset) async {
-        attempts++;
-        if (attempts == 1) throw StateError('temporary failure');
-        return _page([1]);
-      },
-      watchedIds: () => <int>{},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReady();
-    expect(buffer.error, isA<StateError>());
-    expect(buffer.allItems, isEmpty);
-
-    await buffer.retry();
-
-    expect(buffer.error, isNull);
-    expect(buffer.allItems.map((item) => item.id), [1]);
-  });
-
-  test('applies hide abandoned to both views before hide watched', () async {
-    final buffer = SearchResultBuffer(
-      pageLoader: (int offset) async => offset == 0 ? _page([1, 2, 3]) : null,
-      watchedIds: () => <int>{2},
-      abandonedIds: () => <int>{1},
-      hideAbandoned: true,
-    );
-
-    await buffer.ensureReady();
-
-    expect(buffer.allItems.map((item) => item.id), [2, 3]);
-    expect(buffer.hideWatchedItems.map((item) => item.id), [3]);
-  });
-
-  test('waits for a larger concurrent preparation target', () async {
-    final secondPage = Completer<BangumiSearchPage?>();
-    final offsets = <int>[];
-    final buffer = SearchResultBuffer(
-      pageLoader: (offset) {
-        offsets.add(offset);
-        return switch (offset) {
-          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
-          20 => secondPage.future,
-          40 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 41))),
-          _ => Future.value(null),
-        };
-      },
-      watchedIds: () => {for (var i = 1; i < 11; i++) i},
-      abandonedIds: () => <int>{},
-    );
-
-    await buffer.ensureReadyFor(SearchViewMode.all);
-    final initialPreparation =
-        buffer.ensureReadyFor(SearchViewMode.hideWatched, minimumItems: 20);
-    final largerPreparation =
-        buffer.ensureReadyFor(SearchViewMode.hideWatched, minimumItems: 40);
-    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
-
-    await Future.wait([initialPreparation, largerPreparation]);
-
-    expect(offsets, [0, 20, 40]);
-    expect(buffer.hideWatchedItems.length, 50);
-  });
-
-  test('caps one preparation batch and can continue on retry', () async {
+  test('loads exactly one raw page per explicit call', () async {
     final offsets = <int>[];
     final buffer = SearchResultBuffer(
       pageLoader: (offset) async {
         offsets.add(offset);
         return _page(Iterable<int>.generate(20, (i) => offset + i + 1));
       },
-      watchedIds: () => {for (var i = 1; i <= 200; i++) i},
+      watchedIds: () => {for (var i = 1; i < 20; i++) i},
       abandonedIds: () => <int>{},
     );
 
-    await buffer.ensureReadyFor(SearchViewMode.hideWatched);
+    await buffer.loadNextPage();
 
-    expect(offsets, Iterable<int>.generate(10, (i) => i * 20));
-    expect(buffer.error, isNotNull);
-    expect(buffer.isReady(SearchViewMode.hideWatched), isFalse);
+    expect(offsets, [0]);
+    expect(buffer.allItems.length, 20);
+    expect(buffer.hideWatchedItems.map((item) => item.id), [20]);
 
-    await buffer.retry();
+    await buffer.loadNextPage();
 
-    expect(offsets.last, 200);
+    expect(offsets, [0, 20]);
+    expect(buffer.allItems.length, 40);
+    expect(buffer.hideWatchedItems.length, 21);
+  });
+
+  test('advances offset by raw count instead of projected item count',
+      () async {
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        offsets.add(offset);
+        return switch (offset) {
+          0 => _page([1, 2], rawCount: 5),
+          5 => _page([3], rawCount: 1),
+          _ => null,
+        };
+      },
+      watchedIds: () => <int>{1},
+      abandonedIds: () => <int>{},
+      pageSize: 5,
+    );
+
+    await buffer.loadNextPage();
+    await buffer.loadNextPage();
+
+    expect(offsets, [0, 5]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2, 3]);
+    expect(buffer.hideWatchedItems.map((item) => item.id), [2, 3]);
+  });
+
+  test('marks a short page as exhausted', () async {
+    var calls = 0;
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        calls++;
+        return _page([1, 2]);
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.loadNextPage();
+    await buffer.loadNextPage();
+
+    expect(calls, 1);
+    expect(buffer.isExhausted, isTrue);
+  });
+
+  test('deduplicates items while preserving raw pagination offsets', () async {
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        offsets.add(offset);
+        return switch (offset) {
+          0 => _page([1, 2], rawCount: 20),
+          20 => _page([2, 3], rawCount: 20),
+          _ => null,
+        };
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.loadNextPage();
+    await buffer.loadNextPage();
+
+    expect(offsets, [0, 20]);
+    expect(buffer.offset, 40);
+    expect(buffer.allItems.map((item) => item.id), [1, 2, 3]);
+  });
+
+  test('applies hide abandoned to both cached projections', () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async => _page([1, 2, 3]),
+      watchedIds: () => <int>{2},
+      abandonedIds: () => <int>{1},
+    );
+
+    await buffer.loadNextPage();
+    buffer.setHideAbandoned(true);
+
+    expect(buffer.allItems.map((item) => item.id), [2, 3]);
+    expect(buffer.hideWatchedItems.map((item) => item.id), [3]);
+  });
+
+  test('retries a failed page at the same offset without clearing cache',
+      () async {
+    var attemptsAtTwenty = 0;
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        offsets.add(offset);
+        if (offset == 0) {
+          return _page(Iterable<int>.generate(20, (i) => i + 1));
+        }
+        attemptsAtTwenty++;
+        if (attemptsAtTwenty == 1) throw StateError('temporary failure');
+        return _page([21]);
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.loadNextPage();
+    await buffer.loadNextPage();
+
+    expect(buffer.error, isA<StateError>());
+    expect(buffer.offset, 20);
+    expect(buffer.allItems.length, 20);
+
+    await buffer.loadNextPage();
+
+    expect(offsets, [0, 20, 20]);
     expect(buffer.error, isNull);
-    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+    expect(buffer.allItems.last.id, 21);
+  });
+
+  test('coalesces concurrent next-page calls into one request', () async {
+    final page = Completer<BangumiSearchPage?>();
+    var calls = 0;
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) {
+        calls++;
+        return page.future;
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    final first = buffer.loadNextPage();
+    final second = buffer.loadNextPage();
+    page.complete(_page([1]));
+    await Future.wait([first, second]);
+
+    expect(calls, 1);
+    expect(buffer.allItems.single.id, 1);
+  });
+
+  test('discards a response after its query is replaced', () async {
+    final page = Completer<BangumiSearchPage?>();
+    var active = true;
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) => page.future,
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+      shouldContinue: () => active,
+    );
+
+    final load = buffer.loadNextPage();
+    active = false;
+    page.complete(_page([1]));
+    await load;
+
+    expect(buffer.allItems, isEmpty);
+    expect(buffer.offset, 0);
   });
 }

--- a/test/search_result_buffer_test.dart
+++ b/test/search_result_buffer_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/request/apis/bangumi_api.dart';
+import 'package:kazumi/pages/search/search_result_buffer.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+BangumiSearchPage _page(Iterable<int> ids, {int? rawCount}) {
+  final items = ids.map(_item).toList();
+  return BangumiSearchPage(items: items, rawCount: rawCount ?? items.length);
+}
+
+void main() {
+  test(
+      'fills hidden view from later raw pages when first page is mostly watched',
+      () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page(Iterable<int>.generate(20, (index) => index + 1)),
+        20 => _page(Iterable<int>.generate(20, (index) => index + 21)),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => Set<int>.from(Iterable<int>.generate(19, (i) => i + 1)),
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.allItems.take(20).map((item) => item.id),
+        Iterable<int>.generate(20, (index) => index + 1));
+    expect(buffer.hideWatchedItems.take(20).map((item) => item.id),
+        [20, ...Iterable<int>.generate(19, (index) => index + 21)]);
+    expect(offsets, [0, 20]);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+  });
+
+  test('advances offset by raw count instead of filtered item count', () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page([1, 2], rawCount: 5),
+        5 => _page([3, 4], rawCount: 2),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+      pageSize: 5,
+    );
+
+    await buffer.ensureReady();
+
+    expect(offsets, [0, 5]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2, 3, 4]);
+  });
+
+  test('continues after a full page adds no new item', () async {
+    final offsets = <int>[];
+    Future<BangumiSearchPage?> loader(int offset) async {
+      offsets.add(offset);
+      return switch (offset) {
+        0 => _page([1, 2], rawCount: 20),
+        20 => _page([1, 2], rawCount: 20),
+        40 => _page([3], rawCount: 1),
+        _ => null,
+      };
+    }
+
+    final buffer = SearchResultBuffer(
+      pageLoader: loader,
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(offsets, [0, 20, 40]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2, 3]);
+    expect(buffer.isExhausted, isTrue);
+  });
+
+  test('reports a retryable error after consecutive full pages add no new item',
+      () async {
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        offsets.add(offset);
+        return switch (offset) {
+          0 || 20 || 40 || 60 => _page([1, 2], rawCount: 20),
+          80 => _page(Iterable<int>.generate(18, (index) => index + 3)),
+          _ => _page([], rawCount: 0),
+        };
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady(minimumItems: 20);
+
+    expect(offsets, [0, 20, 40, 60]);
+    expect(buffer.allItems.map((item) => item.id), [1, 2]);
+    expect(buffer.error, isA<SearchPreparationLimitReached>());
+    expect(buffer.isExhausted, isFalse);
+
+    await buffer.retry();
+
+    expect(offsets, [0, 20, 40, 60, 80]);
+    expect(buffer.allItems.length, 20);
+    expect(buffer.error, isNull);
+  });
+
+  test('treats a short duplicate page as exhausted instead of retryable',
+      () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        return switch (offset) {
+          0 || 20 || 40 => _page([1, 2], rawCount: 20),
+          60 => _page([1, 2], rawCount: 1),
+          _ => _page([], rawCount: 0),
+        };
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady(minimumItems: 20);
+
+    expect(buffer.isExhausted, isTrue);
+    expect(buffer.error, isNull);
+  });
+
+  test(
+      'marks filtered view ready with fewer items when raw results are exhausted',
+      () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async => offset == 0 ? _page([1, 2]) : null,
+      watchedIds: () => <int>{1},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.hideWatchedItems.map((item) => item.id), [2]);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+  });
+
+  test('retries a failed page without discarding existing results', () async {
+    var attempts = 0;
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async {
+        attempts++;
+        if (attempts == 1) throw StateError('temporary failure');
+        return _page([1]);
+      },
+      watchedIds: () => <int>{},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReady();
+    expect(buffer.error, isA<StateError>());
+    expect(buffer.allItems, isEmpty);
+
+    await buffer.retry();
+
+    expect(buffer.error, isNull);
+    expect(buffer.allItems.map((item) => item.id), [1]);
+  });
+
+  test('applies hide abandoned to both views before hide watched', () async {
+    final buffer = SearchResultBuffer(
+      pageLoader: (int offset) async => offset == 0 ? _page([1, 2, 3]) : null,
+      watchedIds: () => <int>{2},
+      abandonedIds: () => <int>{1},
+      hideAbandoned: true,
+    );
+
+    await buffer.ensureReady();
+
+    expect(buffer.allItems.map((item) => item.id), [2, 3]);
+    expect(buffer.hideWatchedItems.map((item) => item.id), [3]);
+  });
+
+  test('waits for a larger concurrent preparation target', () async {
+    final secondPage = Completer<BangumiSearchPage?>();
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) {
+        offsets.add(offset);
+        return switch (offset) {
+          0 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 1))),
+          20 => secondPage.future,
+          40 => Future.value(_page(Iterable<int>.generate(20, (i) => i + 41))),
+          _ => Future.value(null),
+        };
+      },
+      watchedIds: () => {for (var i = 1; i < 11; i++) i},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReadyFor(SearchViewMode.all);
+    final initialPreparation =
+        buffer.ensureReadyFor(SearchViewMode.hideWatched, minimumItems: 20);
+    final largerPreparation =
+        buffer.ensureReadyFor(SearchViewMode.hideWatched, minimumItems: 40);
+    secondPage.complete(_page(Iterable<int>.generate(20, (i) => i + 21)));
+
+    await Future.wait([initialPreparation, largerPreparation]);
+
+    expect(offsets, [0, 20, 40]);
+    expect(buffer.hideWatchedItems.length, 50);
+  });
+
+  test('caps one preparation batch and can continue on retry', () async {
+    final offsets = <int>[];
+    final buffer = SearchResultBuffer(
+      pageLoader: (offset) async {
+        offsets.add(offset);
+        return _page(Iterable<int>.generate(20, (i) => offset + i + 1));
+      },
+      watchedIds: () => {for (var i = 1; i <= 200; i++) i},
+      abandonedIds: () => <int>{},
+    );
+
+    await buffer.ensureReadyFor(SearchViewMode.hideWatched);
+
+    expect(offsets, Iterable<int>.generate(10, (i) => i * 20));
+    expect(buffer.error, isNotNull);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isFalse);
+
+    await buffer.retry();
+
+    expect(offsets.last, 200);
+    expect(buffer.error, isNull);
+    expect(buffer.isReady(SearchViewMode.hideWatched), isTrue);
+  });
+}

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -1,0 +1,312 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/pages/search/search_result_grid.dart';
+
+BangumiItem _item(int id) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'name-$id',
+    nameCn: 'name-$id',
+    summary: '',
+    airDate: '',
+    airWeekday: 0,
+    rank: id,
+    images: const {},
+    tags: const [],
+    alias: const [],
+    ratingScore: 0,
+    votes: 0,
+    votesCount: const [],
+    info: '',
+  );
+}
+
+Widget _card(BuildContext context, BangumiItem item) {
+  return ColoredBox(
+    key: ValueKey(item.id),
+    color: Colors.blueGrey,
+    child: Center(child: Text('item-${item.id}')),
+  );
+}
+
+void main() {
+  testWidgets('renders items in the supplied order', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchResultGrid(
+            items: [_item(1), _item(2), _item(3)],
+            crossCount: 2,
+            cardExtent: 100,
+            itemBuilder: _card,
+            scrollController: ScrollController(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('item-1'), findsOneWidget);
+    expect(find.text('item-2'), findsOneWidget);
+    expect(find.text('item-3'), findsOneWidget);
+  });
+
+  testWidgets('animates removed cards before settling on the hidden list',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    final initialPosition = tester.getTopLeft(find.text('item-3'));
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+
+    expect(find.text('item-2'), findsOneWidget);
+    final middlePosition = tester.getTopLeft(find.text('item-3'));
+    await tester.pumpAndSettle();
+
+    final finalPosition = tester.getTopLeft(find.text('item-3'));
+    expect(middlePosition.dy, lessThan(initialPosition.dy));
+    expect(middlePosition.dy, greaterThan(finalPosition.dy));
+    expect(find.text('item-2'), findsNothing);
+    expect(find.text('item-3'), findsOneWidget);
+  });
+
+  testWidgets('reverses an in-progress view transition without snapping',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    final initialPosition = tester.getTopLeft(find.text('item-3'));
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+    final hiddenPosition = tester.getTopLeft(find.text('item-3'));
+
+    update(() => items = [_item(1), _item(2), _item(3), _item(4)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 105));
+    final returningPosition = tester.getTopLeft(find.text('item-3'));
+
+    expect(returningPosition.dy, greaterThan(hiddenPosition.dy));
+    expect(returningPosition.dy, lessThan(initialPosition.dy));
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('item-3')).dy,
+        closeTo(initialPosition.dy, 0.1));
+  });
+
+  testWidgets('keeps the current scroll position when switching views',
+      (tester) async {
+    late StateSetter update;
+    var items = List<BangumiItem>.generate(12, (index) => _item(index + 1));
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    scrollController.jumpTo(208);
+    await tester.pump();
+    update(() => items = [
+          _item(1),
+          _item(2),
+          _item(5),
+          _item(6),
+          _item(7),
+          _item(8),
+          _item(9),
+          _item(10),
+          _item(11),
+          _item(12),
+        ]);
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, closeTo(208, 2));
+
+    update(() =>
+        items = List<BangumiItem>.generate(12, (index) => _item(index + 1)));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, closeTo(208, 2));
+    expect(find.text('item-5'), findsOneWidget);
+  });
+
+  testWidgets('lazily builds a settled large result list', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 250,
+            child: SearchResultGrid(
+              items: List<BangumiItem>.generate(100, (i) => _item(i + 1)),
+              crossCount: 2,
+              cardExtent: 100,
+              itemBuilder: _card,
+              scrollController: ScrollController(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('item-1'), findsOneWidget);
+    expect(find.text('item-100'), findsNothing);
+  });
+
+  testWidgets('uses one column when cross count is zero', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchResultGrid(
+            items: [_item(1)],
+            crossCount: 0,
+            cardExtent: 100,
+            itemBuilder: _card,
+            scrollController: ScrollController(),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('item-1'), findsOneWidget);
+  });
+
+  testWidgets('allows scrolling while a view transition is running',
+      (tester) async {
+    late StateSetter update;
+    var items = List<BangumiItem>.generate(60, (i) => _item(i + 1));
+    final scrollController = ScrollController();
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = items.where((item) => item.id.isOdd).toList());
+    await tester.pump();
+    await tester.drag(
+      find.byType(CustomScrollView),
+      const Offset(0, -180),
+    );
+    await tester.pump();
+
+    expect(scrollController.offset, greaterThan(0));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('does not rebuild card contents on each animation frame',
+      (tester) async {
+    late StateSetter update;
+    var items = List<BangumiItem>.generate(12, (i) => _item(i + 1));
+    var cardBuilds = 0;
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: (context, item) {
+                    cardBuilds++;
+                    return _card(context, item);
+                  },
+                  scrollController: ScrollController(),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = items.where((item) => item.id.isOdd).toList());
+    await tester.pump();
+    final buildsAtTransitionStart = cardBuilds;
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(cardBuilds, buildsAtTransitionStart);
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -52,6 +52,38 @@ void main() {
     expect(find.text('item-3'), findsOneWidget);
   });
 
+  testWidgets('refreshes card content when item ids stay unchanged',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1)];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SearchResultGrid(
+                items: items,
+                crossCount: 1,
+                cardExtent: 100,
+                itemBuilder: (context, item) => Text(item.nameCn),
+                scrollController: scrollController,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    final refreshedItem = _item(1)..nameCn = 'updated-name';
+    update(() => items = [refreshedItem]);
+    await tester.pump();
+
+    expect(find.text('updated-name'), findsOneWidget);
+  });
+
   testWidgets('animates removed cards before settling on the hidden list',
       (tester) async {
     late StateSetter update;

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -172,6 +172,138 @@ void main() {
         closeTo(initialPosition.dy, 0.1));
   });
 
+  testWidgets('animates the next switch after a reversed transition settles',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+    update(() => items = [_item(1), _item(2), _item(3), _item(4)]);
+    await tester.pumpAndSettle();
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+
+    expect(find.text('item-2'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('item-2'), findsNothing);
+  });
+
+  testWidgets('preserves refreshed card content while reversing',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: (context, item) => Text(item.nameCn),
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+    update(() => items = [_item(1), _item(2), _item(3), _item(4)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 105));
+
+    final refreshedItems = [_item(1), _item(2), _item(3), _item(4)];
+    refreshedItems.first.nameCn = 'updated-name';
+    update(() => items = refreshedItems);
+    await tester.pumpAndSettle();
+
+    expect(find.text('updated-name'), findsOneWidget);
+  });
+
+  testWidgets('resumes toward the target when toggled during a reverse',
+      (tester) async {
+    late StateSetter update;
+    var items = [_item(1), _item(2), _item(3), _item(4)];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          update = setState;
+          return MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 250,
+                child: SearchResultGrid(
+                  items: items,
+                  crossCount: 2,
+                  cardExtent: 100,
+                  itemBuilder: _card,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 210));
+    update(() => items = [_item(1), _item(2), _item(3), _item(4)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 105));
+    final reversingPosition = tester.getTopLeft(find.text('item-3'));
+
+    update(() => items = [_item(1), _item(3)]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 105));
+    final resumedPosition = tester.getTopLeft(find.text('item-3'));
+
+    expect(resumedPosition.dy, lessThan(reversingPosition.dy));
+    await tester.pumpAndSettle();
+    expect(find.text('item-2'), findsNothing);
+  });
+
   testWidgets('keeps the current scroll position when switching views',
       (tester) async {
     late StateSetter update;

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -253,9 +253,10 @@ void main() {
     final refreshedItems = [_item(1), _item(2), _item(3), _item(4)];
     refreshedItems.first.nameCn = 'updated-name';
     update(() => items = refreshedItems);
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('updated-name'), findsOneWidget);
+    await tester.pumpAndSettle();
   });
 
   testWidgets('resumes toward the target when toggled during a reverse',

--- a/test/search_result_grid_test.dart
+++ b/test/search_result_grid_test.dart
@@ -52,6 +52,35 @@ void main() {
     expect(find.text('item-3'), findsOneWidget);
   });
 
+  testWidgets('places the trailing control in the next grid slot',
+      (tester) async {
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchResultGrid(
+            items: [_item(1), _item(2), _item(3)],
+            crossCount: 2,
+            cardExtent: 100,
+            itemBuilder: _card,
+            trailingItem: const SizedBox(
+              key: ValueKey('load-more-slot'),
+              child: Text('加载更多'),
+            ),
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('load-more-slot')), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('load-more-slot'))).dy,
+      closeTo(108, 0.1),
+    );
+  });
+
   testWidgets('refreshes card content when item ids stay unchanged',
       (tester) async {
     late StateSetter update;


### PR DESCRIPTION
Fixes #2304

## 问题

搜索页原先先加载有限的原始结果，再在界面端隐藏已看条目。

当搜索结果前段大多已看时，例如《名侦探柯南》的剧场版，开启“隐藏已看”后只会剩下一两项；后续页仍存在未看的 TV 版或特别篇，但页面因结果过少无法继续触发加载，导致这些结果无法展示。

## 修改内容

- 使用同一份原始搜索页缓存，同时准备“全部”和“隐藏已看”两个结果视图。
- “全部”视图先展示首批结果；“隐藏已看”视图在后台继续加载后续页，直到获得 20 项未看结果，或确认搜索结果已耗尽。
- 将“全部 / 隐藏已看”放到搜索结果顶部，便于反复切换和比较。
- 切换时保留卡片连续移动；已看卡片淡出，恢复时淡入，避免列表突然跳变。

## 验证

- 覆盖“首批 20 项中 19 项已看，后续页补足未看结果”的回归测试。
- 覆盖搜索结果耗尽、异步分页竞争和快速反向切换。
- `flutter test --no-pub`（152 项通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无错误或警告；17 条仓库原有 info）
- Android 独立测试包已真机回归。