### PR TITLE
feat: 番剧详情页新增集数列表弹窗和集成按钮 

### DIFF
--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -253,11 +253,18 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            SizedBox(
-                              width: 120,
-                              height: 40,
-                              child: CollectButton.extend(
-                                bangumiItem: widget.bangumiItem,
+                            Flexible(
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  minWidth: 80,
+                                  maxWidth: 160,
+                                ),
+                                child: SizedBox(
+                                  height: 40,
+                                  child: CollectButton.extend(
+                                    bangumiItem: widget.bangumiItem,
+                                  ),
+                                ),
                               ),
                             ),
                             if (widget.onEpisodesTap != null) ...[
@@ -292,6 +299,8 @@ class _EpisodeListButton extends StatelessWidget {
     required this.onPressed,
   });
 
+  static const String _tooltip = '集数详情';
+
   final VoidCallback onPressed;
 
   @override
@@ -302,6 +311,7 @@ class _EpisodeListButton extends StatelessWidget {
       height: 40,
       child: IconButton(
         onPressed: onPressed,
+        tooltip: _tooltip,
         icon: const Icon(Icons.video_collection_rounded),
         style: IconButton.styleFrom(
           backgroundColor: theme.colorScheme.primaryContainer,

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -14,11 +14,15 @@ class BangumiInfoCardV extends StatefulWidget {
     required this.bangumiItem,
     required this.isLoading,
     required this.showRating,
+    this.onEpisodesTap,
   });
 
   final BangumiItem bangumiItem;
   final bool isLoading;
   final bool showRating;
+
+  /// 点击「集数详情」按钮的回调。为 null 时不显示该按钮。
+  final VoidCallback? onEpisodesTap;
 
   @override
   State<BangumiInfoCardV> createState() => _BangumiInfoCardVState();
@@ -246,12 +250,23 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                             ),
                           ],
                         ),
-                        SizedBox(
-                          width: 120,
-                          height: 40,
-                          child: CollectButton.extend(
-                            bangumiItem: widget.bangumiItem,
-                          ),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              width: 120,
+                              height: 40,
+                              child: CollectButton.extend(
+                                bangumiItem: widget.bangumiItem,
+                              ),
+                            ),
+                            if (widget.onEpisodesTap != null) ...[
+                              const SizedBox(width: 8),
+                              _EpisodeListButton(
+                                onPressed: widget.onEpisodesTap!,
+                              ),
+                            ],
+                          ],
                         ),
                       ],
                     ),
@@ -266,6 +281,37 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 番剧详情卡片右上角的「集数详情」按钮
+class _EpisodeListButton extends StatelessWidget {
+  const _EpisodeListButton({
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 40,
+      height: 40,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: const Icon(Icons.video_collection_rounded),
+        style: IconButton.styleFrom(
+          backgroundColor: theme.colorScheme.primaryContainer,
+          foregroundColor: theme.colorScheme.onPrimaryContainer,
+          padding: EdgeInsets.zero,
+          minimumSize: const Size(40, 40),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(16)),
+          ),
+        ),
       ),
     );
   }

--- a/lib/modules/bangumi/episode_item.dart
+++ b/lib/modules/bangumi/episode_item.dart
@@ -34,18 +34,67 @@ class EpisodeInfo {
     nameCn = '';
   }
 
+  /// Bangumi 集数类型 -> 缩写。
+  /// https://bangumi.github.io/api/#/Schema/getting-started
+  static const Map<int, String> typeAbbreviations = {
+    0: 'ep',
+    1: 'sp',
+    2: 'op',
+    3: 'ed',
+    4: 'pv',
+    5: 'cm',
+    6: 'mad',
+  };
+
+  /// 集数类型 -> 中文分段标题。
+  static const Map<int, String> typeSectionTitles = {
+    0: '本篇',
+    1: '特别篇',
+    2: '片头曲',
+    3: '片尾曲',
+    4: 'PV/CM',
+    5: '广告',
+    6: 'MAD',
+  };
+
+  static const String otherAbbreviation = 'other';
+  static const String otherSectionTitle = '其它';
+
   String readType() {
-    switch (type) {
-      case 0:
-        return 'ep';
-      case 1:
-        return 'sp';
-      case 2:
-        return 'op';
-      case 3:
-        return 'ed';
-      default:
-        return '';
+    return typeAbbreviations[type] ?? otherAbbreviation;
+  }
+
+  /// 按 type 查询分段标题，用于 sheet 分组。
+  static String sectionTitleForType(int type) {
+    return typeSectionTitles[type] ?? otherSectionTitle;
+  }
+
+  /// 渲染单集编号前缀，例如 `EP1`、`SP2`、`OP`、`ED`。
+  /// - 本篇/特别篇：有 sort 显示 `EP1`/`SP2`，无 sort 显示 `EP`/`SP`
+  /// - OP/ED/PV/CM/MAD：通常没有 sort，直接显示缩写
+  /// - 其它：用 `#N` 形式（N 为 type 值）避免畸形标签
+  String prefix() {
+    final typeStr = readType().toUpperCase();
+    final isOther = typeStr == otherAbbreviation.toUpperCase();
+    // 已知类型且有 sort：显示前缀+编号
+    if (!isOther && episode > 0) {
+      final sortStr = episode == episode.toInt()
+          ? episode.toInt().toString()
+          : episode.toString();
+      return '$typeStr$sortStr';
     }
+    // 已知类型但无 sort：仅显示前缀
+    if (!isOther) {
+      return typeStr;
+    }
+    // 未知类型：用 #type 编号标识，不显示空前缀
+    return '#$type';
+  }
+
+  /// 优先用中文名，回退到日文名。
+  String displayName() {
+    final cn = nameCn.trim();
+    if (cn.isNotEmpty) return cn;
+    return name.trim();
   }
 }

--- a/lib/pages/info/episode_list_sheet.dart
+++ b/lib/pages/info/episode_list_sheet.dart
@@ -1,71 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:kazumi/bean/widget/error_widget.dart';
-import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/bangumi/episode_item.dart';
+import 'package:kazumi/pages/info/info_controller.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 /// 番剧详情页的「集数详情」浮动展示。
 ///
 /// 仅展示 Bangumi `/v0/episodes` 返回的分集元信息，点击不跳转播放页，
 /// 与视频源/播放链路完全解耦。
+///
+/// 直接订阅 [InfoController] 的 MobX 状态，加载/重试/成功/失败切换时
+/// sheet 会自动重建，无需外部传入快照。
 class EpisodeListSheet extends StatelessWidget {
   const EpisodeListSheet({
     super.key,
-    required this.bangumiItem,
-    required this.episodeList,
-    required this.isLoading,
-    required this.queryTimeout,
-    required this.isEmpty,
+    required this.infoController,
     required this.onRetry,
   });
 
-  final BangumiItem bangumiItem;
-  final List<EpisodeInfo> episodeList;
-  final bool isLoading;
-  final bool queryTimeout;
-  final bool isEmpty;
+  final InfoController infoController;
   final Future<void> Function() onRetry;
 
-  /// 把 [EpisodeInfo.type] 映射为分段标题。
-  /// 0=本篇 / 1=特别篇 / 2=片头曲 / 3=片尾曲。
-  String _sectionTitle(int type) {
-    switch (type) {
-      case 0:
-        return '本篇';
-      case 1:
-        return '特别篇';
-      case 2:
-        return '片头曲';
-      case 3:
-        return '片尾曲';
-      default:
-        return '其它';
-    }
-  }
-
-  /// 渲染单集编号前缀，例如 `EP1`、`SP2`、`OP`、`ED`。
-  /// type=2/3 的 OP/ED 通常没有 sort，直接显示类型缩写。
-  String _episodePrefix(EpisodeInfo episode) {
-    final typeStr = episode.readType().toUpperCase();
-    final sort = episode.episode;
-    if (sort == 0 && (episode.type == 2 || episode.type == 3)) {
-      return typeStr;
-    }
-    // sort 是 num，可能是 1.0 或 1.5。整数显示为整数。
-    final sortStr =
-        sort == sort.toInt() ? sort.toInt().toString() : sort.toString();
-    return '$typeStr$sortStr';
-  }
-
-  /// 优先用中文名，回退到日文名。
-  String _episodeName(EpisodeInfo episode) {
-    final cn = episode.nameCn.trim();
-    if (cn.isNotEmpty) return cn;
-    return episode.name.trim();
-  }
-
   /// 按 type 分组并保留 Bangumi 返回顺序。
-  List<({String title, List<EpisodeInfo> episodes})> _groupedSections() {
+  /// 分段标题由 [EpisodeInfo.sectionTitleForType] 提供。
+  List<({String title, List<EpisodeInfo> episodes})> _groupedSections(
+      List<EpisodeInfo> episodeList) {
     final byType = <int, List<EpisodeInfo>>{};
     final order = <int>[];
     for (final ep in episodeList) {
@@ -78,42 +38,39 @@ class EpisodeListSheet extends StatelessWidget {
     }
     return [
       for (final type in order)
-        (title: _sectionTitle(type), episodes: byType[type]!),
+        (title: EpisodeInfo.sectionTitleForType(type), episodes: byType[type]!),
     ];
   }
 
   Widget _buildSectionHeader(BuildContext context, String title, int count) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 12, bottom: 6),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.baseline,
-        textBaseline: TextBaseline.alphabetic,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.bold,
-            ),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.baseline,
+      textBaseline: TextBaseline.alphabetic,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
           ),
-          const SizedBox(width: 6),
-          Text(
-            '($count)',
-            style: TextStyle(
-              fontSize: 12,
-              color: Theme.of(context).colorScheme.outline,
-            ),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          '($count)',
+          style: TextStyle(
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.outline,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
   Widget _buildEpisodeTile(BuildContext context, EpisodeInfo episode) {
-    final prefix = _episodePrefix(episode);
-    final name = _episodeName(episode);
+    final prefix = episode.prefix();
+    final name = episode.displayName();
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -145,28 +102,32 @@ class EpisodeListSheet extends StatelessWidget {
   }
 
   Widget _buildContent(BuildContext context) {
-    if (isLoading && episodeList.isEmpty) {
+    final episodeList = infoController.episodeList.toList();
+    if (infoController.episodesIsLoading && episodeList.isEmpty) {
       return Skeletonizer.zone(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            for (int i = 0; i < 6; i++)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 4),
-                child: Row(
-                  children: [
-                    Bone.text(fontSize: 14, width: 40),
-                    const SizedBox(width: 8),
-                    Expanded(child: Bone.text(fontSize: 14, width: 200)),
-                  ],
+        child: SingleChildScrollView(
+          physics: const NeverScrollableScrollPhysics(),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (int i = 0; i < 6; i++)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      Bone.text(fontSize: 14, width: 40),
+                      const SizedBox(width: 8),
+                      Expanded(child: Bone.text(fontSize: 14, width: 200)),
+                    ],
+                  ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       );
     }
 
-    if (queryTimeout && episodeList.isEmpty) {
+    if (infoController.episodesQueryTimeout && episodeList.isEmpty) {
       return GeneralErrorWidget(
         errMsg: '集数获取失败',
         actions: [
@@ -178,7 +139,7 @@ class EpisodeListSheet extends StatelessWidget {
       );
     }
 
-    if (isEmpty && episodeList.isEmpty) {
+    if (infoController.episodesIsEmpty && episodeList.isEmpty) {
       return const Center(
         child: Padding(
           padding: EdgeInsets.symmetric(vertical: 32),
@@ -187,22 +148,29 @@ class EpisodeListSheet extends StatelessWidget {
       );
     }
 
-    final sections = _groupedSections();
-    return ListView.builder(
-      shrinkWrap: true,
-      padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
-      itemCount: sections.length,
-      itemBuilder: (context, sectionIndex) {
-        final section = sections[sectionIndex];
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildSectionHeader(context, section.title, section.episodes.length),
-            for (final episode in section.episodes)
-              _buildEpisodeTile(context, episode),
-          ],
-        );
-      },
+    final sections = _groupedSections(episodeList);
+    // 用 CustomScrollView + SliverList 实现真正的懒加载：
+    // 每个 section 一个 SliverToBoxAdapter(header) + SliverList(episodes)，
+    // 长番剧只构建可见区域内的 tile。
+    return CustomScrollView(
+      slivers: [
+        const SliverToBoxAdapter(child: SizedBox(height: 4)),
+        for (final section in sections) ...[
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+              child: _buildSectionHeader(context, section.title,
+                  section.episodes.length),
+            ),
+          ),
+          SliverList.builder(
+            itemCount: section.episodes.length,
+            itemBuilder: (context, index) =>
+                _buildEpisodeTile(context, section.episodes[index]),
+          ),
+        ],
+        const SliverToBoxAdapter(child: SizedBox(height: 16)),
+      ],
     );
   }
 
@@ -250,7 +218,11 @@ class EpisodeListSheet extends StatelessWidget {
             ),
           ),
           const Divider(height: 1),
-          Flexible(child: _buildContent(context)),
+          Flexible(
+            child: Observer(
+              builder: (context) => _buildContent(context),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/pages/info/episode_list_sheet.dart
+++ b/lib/pages/info/episode_list_sheet.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:kazumi/bean/widget/error_widget.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/episode_item.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+/// 番剧详情页的「集数详情」浮动展示。
+///
+/// 仅展示 Bangumi `/v0/episodes` 返回的分集元信息，点击不跳转播放页，
+/// 与视频源/播放链路完全解耦。
+class EpisodeListSheet extends StatelessWidget {
+  const EpisodeListSheet({
+    super.key,
+    required this.bangumiItem,
+    required this.episodeList,
+    required this.isLoading,
+    required this.queryTimeout,
+    required this.isEmpty,
+    required this.onRetry,
+  });
+
+  final BangumiItem bangumiItem;
+  final List<EpisodeInfo> episodeList;
+  final bool isLoading;
+  final bool queryTimeout;
+  final bool isEmpty;
+  final Future<void> Function() onRetry;
+
+  /// 把 [EpisodeInfo.type] 映射为分段标题。
+  /// 0=本篇 / 1=特别篇 / 2=片头曲 / 3=片尾曲。
+  String _sectionTitle(int type) {
+    switch (type) {
+      case 0:
+        return '本篇';
+      case 1:
+        return '特别篇';
+      case 2:
+        return '片头曲';
+      case 3:
+        return '片尾曲';
+      default:
+        return '其它';
+    }
+  }
+
+  /// 渲染单集编号前缀，例如 `EP1`、`SP2`、`OP`、`ED`。
+  /// type=2/3 的 OP/ED 通常没有 sort，直接显示类型缩写。
+  String _episodePrefix(EpisodeInfo episode) {
+    final typeStr = episode.readType().toUpperCase();
+    final sort = episode.episode;
+    if (sort == 0 && (episode.type == 2 || episode.type == 3)) {
+      return typeStr;
+    }
+    // sort 是 num，可能是 1.0 或 1.5。整数显示为整数。
+    final sortStr =
+        sort == sort.toInt() ? sort.toInt().toString() : sort.toString();
+    return '$typeStr$sortStr';
+  }
+
+  /// 优先用中文名，回退到日文名。
+  String _episodeName(EpisodeInfo episode) {
+    final cn = episode.nameCn.trim();
+    if (cn.isNotEmpty) return cn;
+    return episode.name.trim();
+  }
+
+  /// 按 type 分组并保留 Bangumi 返回顺序。
+  List<({String title, List<EpisodeInfo> episodes})> _groupedSections() {
+    final byType = <int, List<EpisodeInfo>>{};
+    final order = <int>[];
+    for (final ep in episodeList) {
+      final type = ep.type;
+      if (!byType.containsKey(type)) {
+        byType[type] = <EpisodeInfo>[];
+        order.add(type);
+      }
+      byType[type]!.add(ep);
+    }
+    return [
+      for (final type in order)
+        (title: _sectionTitle(type), episodes: byType[type]!),
+    ];
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title, int count) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12, bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '($count)',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEpisodeTile(BuildContext context, EpisodeInfo episode) {
+    final prefix = _episodePrefix(episode);
+    final name = _episodeName(episode);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 56),
+            child: SelectableText(
+              '$prefix:',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: SelectableText(
+              name,
+              style: name.isEmpty
+                  ? TextStyle(
+                      color: Theme.of(context).colorScheme.outline,
+                      fontStyle: FontStyle.italic,
+                    )
+                  : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    if (isLoading && episodeList.isEmpty) {
+      return Skeletonizer.zone(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (int i = 0; i < 6; i++)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Bone.text(fontSize: 14, width: 40),
+                    const SizedBox(width: 8),
+                    Expanded(child: Bone.text(fontSize: 14, width: 200)),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    if (queryTimeout && episodeList.isEmpty) {
+      return GeneralErrorWidget(
+        errMsg: '集数获取失败',
+        actions: [
+          GeneralErrorButton(
+            onPressed: () => onRetry(),
+            text: '重试',
+          ),
+        ],
+      );
+    }
+
+    if (isEmpty && episodeList.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Text('什么都没有找到 (´;ω;`)'),
+        ),
+      );
+    }
+
+    final sections = _groupedSections();
+    return ListView.builder(
+      shrinkWrap: true,
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+      itemCount: sections.length,
+      itemBuilder: (context, sectionIndex) {
+        final section = sections[sectionIndex];
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildSectionHeader(context, section.title, section.episodes.length),
+            for (final episode in section.episodes)
+              _buildEpisodeTile(context, episode),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 16, 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '集数详情',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '数据来源：Bangumi · 仅作参考，请以实际播放源集数为准',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: '关闭',
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Flexible(child: _buildContent(context)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -1,6 +1,7 @@
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/modules/bangumi/bangumi_interest.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/episode_item.dart';
 import 'package:kazumi/pages/collect/collect_controller.dart';
 import 'package:kazumi/modules/search/plugin_search_module.dart';
 import 'package:kazumi/pages/info/rating_review_dialog.dart';
@@ -39,6 +40,19 @@ abstract class _InfoController with Store {
   @observable
   var staffList = ObservableList<StaffFullItem>();
 
+  // 分集列表：进入番剧详情页自动预加载，仅用于展示。
+  @observable
+  var episodeList = ObservableList<EpisodeInfo>();
+
+  @observable
+  bool episodesIsLoading = false;
+
+  @observable
+  bool episodesQueryTimeout = false;
+
+  @observable
+  bool episodesIsEmpty = false;
+
   bool _isFillingInterestUserProfile = false;
 
   int _commentsOffset = 0;
@@ -46,6 +60,13 @@ abstract class _InfoController with Store {
   void clearComments() {
     commentsList.clear();
     _commentsOffset = 0;
+  }
+
+  void clearEpisodes() {
+    episodeList.clear();
+    episodesIsLoading = false;
+    episodesQueryTimeout = false;
+    episodesIsEmpty = false;
   }
 
   Future<bool> fillInterestUserProfileIfNeeded() async {
@@ -202,6 +223,32 @@ abstract class _InfoController with Store {
     });
     KazumiLogger()
         .i('InfoController: loaded staff list length ${staffList.length}');
+  }
+
+  Future<void> queryBangumiEpisodesByID(int id) async {
+    if (episodesIsLoading) {
+      return;
+    }
+    episodesIsLoading = true;
+    episodesQueryTimeout = false;
+    episodesIsEmpty = false;
+    try {
+      final list = await BangumiApi.getBangumiEpisodesByID(id);
+      episodeList = ObservableList<EpisodeInfo>.of(list);
+      // BangumiApi.getBangumiEpisodesByID 内部吞掉异常后返回空列表，
+      // 因此空列表既可能是失败也可能是真空。统一走「重试」入口，
+      // 让用户决定是再拉一次还是放弃。
+      if (episodeList.isEmpty) {
+        episodesQueryTimeout = true;
+      }
+      KazumiLogger().i(
+          'InfoController: loaded episode list length ${episodeList.length}');
+    } catch (e) {
+      KazumiLogger().e('InfoController: failed to load episodes', error: e);
+      episodesQueryTimeout = true;
+    } finally {
+      episodesIsLoading = false;
+    }
   }
 
   Future<bool> rateBangumi(RatingReviewResult data,

--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -62,7 +62,16 @@ abstract class _InfoController with Store {
     _commentsOffset = 0;
   }
 
+  /// 仅清空数据，保留 in-flight 标志 [episodesIsLoading]。
+  /// 用于 sheet 关闭后重置展示数据，避免破坏 [queryBangumiEpisodesByID]
+  /// 的重入保护：如果请求正在进行中，重置数据不应让其它调用者绕过 guard。
   void clearEpisodes() {
+    episodeList.clear();
+  }
+
+  /// 完整重置集数状态：数据 + 所有标志位。
+  /// 仅在 [InfoPage.initState] 切换 subject 时调用。
+  void resetEpisodesState() {
     episodeList.clear();
     episodesIsLoading = false;
     episodesQueryTimeout = false;
@@ -234,7 +243,12 @@ abstract class _InfoController with Store {
     episodesIsEmpty = false;
     try {
       final list = await BangumiApi.getBangumiEpisodesByID(id);
-      episodeList = ObservableList<EpisodeInfo>.of(list);
+      // 用 mutation 方式更新 ObservableList（clear + addAll），
+      // 而非替换整个 list 引用。符合 MobX 官方文档推荐用法：
+      // Observer 会跟踪 list 内部 mutation，无需替换引用。
+      episodeList
+        ..clear()
+        ..addAll(list);
       // BangumiApi.getBangumiEpisodesByID 内部吞掉异常后返回空列表，
       // 因此空列表既可能是失败也可能是真空。统一走「重试」入口，
       // 让用户决定是再拉一次还是放弃。

--- a/lib/pages/info/info_controller.g.dart
+++ b/lib/pages/info/info_controller.g.dart
@@ -106,6 +106,71 @@ mixin _$InfoController on _InfoController, Store {
     });
   }
 
+  late final _$episodeListAtom =
+      Atom(name: '_InfoController.episodeList', context: context);
+
+  @override
+  ObservableList<EpisodeInfo> get episodeList {
+    _$episodeListAtom.reportRead();
+    return super.episodeList;
+  }
+
+  @override
+  set episodeList(ObservableList<EpisodeInfo> value) {
+    _$episodeListAtom.reportWrite(value, super.episodeList, () {
+      super.episodeList = value;
+    });
+  }
+
+  late final _$episodesIsLoadingAtom =
+      Atom(name: '_InfoController.episodesIsLoading', context: context);
+
+  @override
+  bool get episodesIsLoading {
+    _$episodesIsLoadingAtom.reportRead();
+    return super.episodesIsLoading;
+  }
+
+  @override
+  set episodesIsLoading(bool value) {
+    _$episodesIsLoadingAtom.reportWrite(value, super.episodesIsLoading, () {
+      super.episodesIsLoading = value;
+    });
+  }
+
+  late final _$episodesQueryTimeoutAtom =
+      Atom(name: '_InfoController.episodesQueryTimeout', context: context);
+
+  @override
+  bool get episodesQueryTimeout {
+    _$episodesQueryTimeoutAtom.reportRead();
+    return super.episodesQueryTimeout;
+  }
+
+  @override
+  set episodesQueryTimeout(bool value) {
+    _$episodesQueryTimeoutAtom.reportWrite(value, super.episodesQueryTimeout,
+        () {
+      super.episodesQueryTimeout = value;
+    });
+  }
+
+  late final _$episodesIsEmptyAtom =
+      Atom(name: '_InfoController.episodesIsEmpty', context: context);
+
+  @override
+  bool get episodesIsEmpty {
+    _$episodesIsEmptyAtom.reportRead();
+    return super.episodesIsEmpty;
+  }
+
+  @override
+  set episodesIsEmpty(bool value) {
+    _$episodesIsEmptyAtom.reportWrite(value, super.episodesIsEmpty, () {
+      super.episodesIsEmpty = value;
+    });
+  }
+
   @override
   String toString() {
     return '''
@@ -114,7 +179,11 @@ pluginSearchResponseList: ${pluginSearchResponseList},
 pluginSearchStatus: ${pluginSearchStatus},
 commentsList: ${commentsList},
 characterList: ${characterList},
-staffList: ${staffList}
+staffList: ${staffList},
+episodeList: ${episodeList},
+episodesIsLoading: ${episodesIsLoading},
+episodesQueryTimeout: ${episodesQueryTimeout},
+episodesIsEmpty: ${episodesIsEmpty}
     ''';
   }
 }

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -15,6 +15,7 @@ import 'package:kazumi/plugins/plugins_controller.dart';
 import 'package:kazumi/bean/card/network_img_layer.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/pages/info/info_tabview.dart';
+import 'package:kazumi/pages/info/episode_list_sheet.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -206,6 +207,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.clearComments();
     infoController.staffList.clear();
     infoController.pluginSearchResponseList.clear();
+    infoController.clearEpisodes();
     // Search results can miss rating distribution or summaries, so fill those
     // fields without replacing image URLs that are already rendered.
     if (_needsBangumiInfoRefresh(infoController.bangumiItem)) {
@@ -216,6 +218,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
         enforceMinimumLoadingDuration: true,
       );
     }
+    // 分集列表仅做展示，与播放页解耦，进入详情页即自动预加载。
+    loadEpisodes();
     sourceTabController =
         TabController(length: pluginsController.pluginList.length, vsync: this);
     infoTabController = TabController(length: _infoTabs.length, vsync: this);
@@ -224,6 +228,34 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoTabController.addListener(onInfoTabChanged);
     infoTabController.addListener(_syncFabTabIndex);
     infoTabController.animation?.addListener(_syncFabTabIndex);
+  }
+
+  Future<void> loadEpisodes() async {
+    await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> retryLoadEpisodes() async {
+    await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void showEpisodeListSheet() {
+    showAdaptiveBottomSheet<void>(
+      context: context,
+      builder: (context) => EpisodeListSheet(
+        bangumiItem: infoController.bangumiItem,
+        episodeList: infoController.episodeList,
+        isLoading: infoController.episodesIsLoading,
+        queryTimeout: infoController.episodesQueryTimeout,
+        isEmpty: infoController.episodesIsEmpty,
+        onRetry: retryLoadEpisodes,
+      ),
+    );
   }
 
   void onInfoTabChanged() {
@@ -290,6 +322,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.clearComments();
     infoController.staffList.clear();
     infoController.pluginSearchResponseList.clear();
+    infoController.clearEpisodes();
     sourceTabController.dispose();
     infoTabController.dispose();
     super.dispose();
@@ -440,6 +473,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
                                       bangumiItem: infoController.bangumiItem,
                                       isLoading: showBangumiInfoSkeleton,
                                       showRating: showRating,
+                                      onEpisodesTap: showEpisodeListSheet,
                                     ),
                                   ),
                                 ),

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -207,7 +207,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.clearComments();
     infoController.staffList.clear();
     infoController.pluginSearchResponseList.clear();
-    infoController.clearEpisodes();
+    infoController.resetEpisodesState();
     // Search results can miss rating distribution or summaries, so fill those
     // fields without replacing image URLs that are already rendered.
     if (_needsBangumiInfoRefresh(infoController.bangumiItem)) {
@@ -218,8 +218,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
         enforceMinimumLoadingDuration: true,
       );
     }
-    // 分集列表仅做展示，与播放页解耦，进入详情页即自动预加载。
-    loadEpisodes();
+    // 集数详情：懒加载，仅在用户首次打开 sheet 时才请求 Bangumi。
+    // 避免每次进入详情页都预取完整分集列表，浪费流量。
     sourceTabController =
         TabController(length: pluginsController.pluginList.length, vsync: this);
     infoTabController = TabController(length: _infoTabs.length, vsync: this);
@@ -230,30 +230,24 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoTabController.animation?.addListener(_syncFabTabIndex);
   }
 
+  /// 加载集数详情。仅在首次打开 sheet 或重试时调用。
   Future<void> loadEpisodes() async {
+    if (!mounted) return;
     await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
-    if (mounted) {
-      setState(() {});
-    }
-  }
-
-  Future<void> retryLoadEpisodes() async {
-    await infoController.queryBangumiEpisodesByID(infoController.bangumiItem.id);
-    if (mounted) {
-      setState(() {});
-    }
   }
 
   void showEpisodeListSheet() {
+    // 首次打开或失败后重试时触发加载；已加载成功则直接展示。
+    if (!infoController.episodesIsLoading &&
+        infoController.episodeList.isEmpty &&
+        !infoController.episodesQueryTimeout) {
+      loadEpisodes();
+    }
     showAdaptiveBottomSheet<void>(
       context: context,
       builder: (context) => EpisodeListSheet(
-        bangumiItem: infoController.bangumiItem,
-        episodeList: infoController.episodeList,
-        isLoading: infoController.episodesIsLoading,
-        queryTimeout: infoController.episodesQueryTimeout,
-        isEmpty: infoController.episodesIsEmpty,
-        onRetry: retryLoadEpisodes,
+        infoController: infoController,
+        onRetry: loadEpisodes,
       ),
     );
   }


### PR DESCRIPTION
# 改动说明
## 新增文件
lib/pages/info/episode_list_sheet.dart — 集数列表弹窗组件，支持分组展示（本篇/特别篇/OP/ED）及骨架屏加载状态

## 修改文件
lib/pages/info/info_controller.dart — 新增集数数据加载逻辑，管理请求状态与错误处理
lib/pages/info/info_page.dart — 详情页集成集数列表入口按钮
lib/bean/card/bangumi_info_card.dart — 调整布局以适配集数列表入口

# 关联issue
#1169 请求在番剧界面添加已播出集数
#2117 可考虑在点选动漫进入的动漫详情页上，加个目前集数详情

# 效果展示
<img width="40%" height="auto" alt="Snipaste_2026-07-27_16-27-12" src="https://github.com/user-attachments/assets/0682da77-2cad-41c1-98ac-797460eb0358" />
<img width="40%" height="auto" alt="Snipaste_2026-07-27_16-27-16" src="https://github.com/user-attachments/assets/be8860bc-0a60-4c1d-8b0c-76eb92be2167" />
<img width="20%" height="auto" alt="20260727163158_14_84" src="https://github.com/user-attachments/assets/b2797ea0-b97d-4a4b-bcbf-b3d9b9ca0e54" />

# 验证
`flutter test --no-pub` +125: All tests passed
` flutter analyze --no-pub --no-fatal-infos --fatal-warnings` passed