### PR TITLE
refactor: dispose 和清理路径中的错误不再静默丢弃

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -160,8 +160,7 @@ class _PlayerItemState extends State<PlayerItem>
         playerController.danmaku.canvasController.resume();
       }
     } catch (e) {
-      KazumiLogger()
-          .w('Player: danmaku resume on lifecycle resumed failed', error: e);
+      KazumiLogger().w('Player: danmaku resume on $state failed', error: e);
     }
   }
 

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -150,14 +150,19 @@ class _PlayerItemState extends State<PlayerItem>
         playerController.playback.playerPlaying) {
       try {
         await playerController.pause(enableSync: false);
-      } catch (_) {}
+      } catch (e) {
+        KazumiLogger().w('Player: pause on lifecycle paused failed', error: e);
+      }
       return;
     }
     try {
       if (playerController.playback.playerPlaying) {
         playerController.danmaku.canvasController.resume();
       }
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger()
+          .w('Player: danmaku resume on lifecycle resumed failed', error: e);
+    }
   }
 
   Future<void> _syncAndroidAutoEnterPIPSetting() async {
@@ -353,7 +358,10 @@ class _PlayerItemState extends State<PlayerItem>
     if (videoPageController.isFullscreen && !isTablet()) {
       try {
         playerController.danmaku.canvasController.clear();
-      } catch (_) {}
+      } catch (e) {
+        KazumiLogger()
+            .w('Player: danmaku clear on exit fullscreen failed', error: e);
+      }
       DisplayModeService.exitFullScreen();
       videoPageController.isFullscreen = !videoPageController.isFullscreen;
     } else if (!Platform.isMacOS) {
@@ -1037,7 +1045,9 @@ class _PlayerItemState extends State<PlayerItem>
           }
           try {
             playerTimer!.cancel();
-          } catch (_) {}
+          } catch (e) {
+            KazumiLogger().w('Player: cancel playerTimer failed', error: e);
+          }
           widget.changeEpisode(playingSelection.episode + 1,
               currentRoad: playingSelection.road);
         }

--- a/lib/webview/captcha/impl/captcha_webview_inappwebview_impl.dart
+++ b/lib/webview/captcha/impl/captcha_webview_inappwebview_impl.dart
@@ -306,7 +306,11 @@ if (!_checkForCaptcha()) {
       await PlatformCookieManager(const PlatformCookieManagerCreationParams())
           .deleteAllCookies();
       logEventController.add('[Captcha WebView] Cookies cleared before load');
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger().w(
+          'CaptchaWebView: failed to clear cookies before custom script load',
+          error: e);
+    }
     await webviewController?.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
   }
 
@@ -498,13 +502,13 @@ if (!_checkAndClick()) {
     captchaWasFound = false;
     buttonWasClicked = false;
     _handlersRegistered = false;
-    try {
-      PlatformCookieManager(const PlatformCookieManagerCreationParams())
-          .deleteAllCookies();
-    } catch (e) {
+    PlatformCookieManager(const PlatformCookieManagerCreationParams())
+        .deleteAllCookies()
+        // ignore: body_might_complete_normally_catch_error
+        .catchError((e) {
       KazumiLogger()
           .w('CaptchaWebView: failed to clear cookies on dispose', error: e);
-    }
+    });
     try {
       captchaImageFoundController.close();
       captchaDisappearedController.close();

--- a/lib/webview/captcha/impl/captcha_webview_inappwebview_impl.dart
+++ b/lib/webview/captcha/impl/captcha_webview_inappwebview_impl.dart
@@ -268,7 +268,10 @@ if (!_checkForCaptcha()) {
       await PlatformCookieManager(const PlatformCookieManagerCreationParams())
           .deleteAllCookies();
       logEventController.add('[Captcha WebView] Cookies cleared before load');
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger()
+          .w('CaptchaWebView: failed to clear cookies before load', error: e);
+    }
     await webviewController?.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
   }
 
@@ -284,7 +287,10 @@ if (!_checkForCaptcha()) {
       await PlatformCookieManager(const PlatformCookieManagerCreationParams())
           .deleteAllCookies();
       logEventController.add('[Captcha WebView] Cookies cleared before load');
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger()
+          .w('CaptchaWebView: failed to clear cookies before load', error: e);
+    }
     await webviewController?.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
   }
 
@@ -480,7 +486,9 @@ if (!_checkAndClick()) {
     try {
       await webviewController?.loadUrl(
           urlRequest: URLRequest(url: WebUri('about:blank')));
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger().w('CaptchaWebView: failed to load about:blank', error: e);
+    }
   }
 
   @override
@@ -493,13 +501,19 @@ if (!_checkAndClick()) {
     try {
       PlatformCookieManager(const PlatformCookieManagerCreationParams())
           .deleteAllCookies();
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger()
+          .w('CaptchaWebView: failed to clear cookies on dispose', error: e);
+    }
     try {
       captchaImageFoundController.close();
       captchaDisappearedController.close();
       initEventController.close();
       logEventController.close();
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger().w('CaptchaWebView: failed to close controllers on dispose',
+          error: e);
+    }
     _headlessWebView?.dispose();
     _headlessWebView = null;
     webviewController = null;

--- a/lib/webview/captcha/impl/captcha_webview_linux_impl.dart
+++ b/lib/webview/captcha/impl/captcha_webview_linux_impl.dart
@@ -433,7 +433,10 @@ $script
     if (_navigationListener != null) {
       try {
         webviewController?.isNavigating.removeListener(_navigationListener!);
-      } catch (_) {}
+      } catch (e) {
+        KazumiLogger().w('CaptchaWebView: failed to remove navigation listener',
+            error: e);
+      }
       _navigationListener = null;
     }
     try {
@@ -441,7 +444,10 @@ $script
       captchaDisappearedController.close();
       initEventController.close();
       logEventController.close();
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger().w('CaptchaWebView: failed to close controllers on dispose',
+          error: e);
+    }
     webviewController?.close();
     webviewController = null;
   }

--- a/lib/webview/captcha/impl/captcha_webview_windows_impl.dart
+++ b/lib/webview/captcha/impl/captcha_webview_windows_impl.dart
@@ -458,12 +458,10 @@ $script
     buttonWasClicked = false;
     _currentPageUrl = '';
     for (final s in _subscriptions) {
-      try {
-        s.cancel();
-      } catch (e) {
+      s.cancel().catchError((e) {
         KazumiLogger()
             .w('CaptchaWebView: failed to cancel subscription', error: e);
-      }
+      });
     }
     _subscriptions.clear();
     try {

--- a/lib/webview/captcha/impl/captcha_webview_windows_impl.dart
+++ b/lib/webview/captcha/impl/captcha_webview_windows_impl.dart
@@ -460,7 +460,10 @@ $script
     for (final s in _subscriptions) {
       try {
         s.cancel();
-      } catch (_) {}
+      } catch (e) {
+        KazumiLogger()
+            .w('CaptchaWebView: failed to cancel subscription', error: e);
+      }
     }
     _subscriptions.clear();
     try {
@@ -468,7 +471,10 @@ $script
       captchaDisappearedController.close();
       initEventController.close();
       logEventController.close();
-    } catch (_) {}
+    } catch (e) {
+      KazumiLogger().w('CaptchaWebView: failed to close controllers on dispose',
+          error: e);
+    }
     _headlessWebview?.dispose();
     _headlessWebview = null;
   }


### PR DESCRIPTION
## 改动说明

将 captcha WebView dispose/清理路径和 player 生命周期中的 13 处 `catch(_){}` 改为记录 KazumiLogger warning。

## 验证

```
flutter analyze — 0 新增 warning
flutter test   — 125 全部通过
```

## 影响范围

4 个文件，49 行新增，13 行删除。均为 dispose/清理路径的日志增强，无行为变更。