### PR TITLE
refactor(staff): switch to v0 persons API with role priority

### DIFF
--- a/lib/bean/card/staff_card.dart
+++ b/lib/bean/card/staff_card.dart
@@ -24,8 +24,8 @@ class StaffCard extends StatelessWidget {
       subtitle: staffFullItem.staff.nameCN.isNotEmpty
           ? Text(staffFullItem.staff.nameCN)
           : null,
-      trailing: Text(staffFullItem.positions.isNotEmpty
-          ? (staffFullItem.positions[0].type.cn)
+      trailing: Text(staffFullItem.relations.isNotEmpty
+          ? staffFullItem.relations.first
           : ''),
     );
   }

--- a/lib/modules/staff/staff_item.dart
+++ b/lib/modules/staff/staff_item.dart
@@ -1,51 +1,23 @@
 class StaffFullItem {
   final Staff staff;
-  final List<Position> positions;
+  final List<String> relations;
 
   StaffFullItem({
     required this.staff,
-    required this.positions,
+    required this.relations,
   });
-
-  factory StaffFullItem.fromJson(Map<String, dynamic> json) {
-    return StaffFullItem(
-      staff: json['staff'] != null
-          ? Staff.fromJson(json['staff'] as Map<String, dynamic>)
-          : Staff.fromTemplate(),
-      positions: (json['positions'] as List<dynamic>? ?? [])
-          .map((item) => Position.fromJson(item as Map<String, dynamic>))
-          .toList(),
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'staff': staff.toJson(),
-      'positions': positions.map((item) => item.toJson()).toList(),
-    };
-  }
 }
 
 class Staff {
   final int id;
   final String name;
   final String nameCN;
-  final int type;
-  final String info;
-  final int comment;
-  final bool lock;
-  final bool nsfw;
   final Images? images;
 
   Staff({
     required this.id,
     required this.name,
     required this.nameCN,
-    required this.type,
-    required this.info,
-    required this.comment,
-    required this.lock,
-    required this.nsfw,
     this.images,
   });
 
@@ -54,46 +26,10 @@ class Staff {
       id: json['id'] is int ? json['id'] as int : 0,
       name: json['name'] as String? ?? '',
       nameCN: json['nameCN'] as String? ?? '',
-      type: json['type'] is int ? json['type'] as int : 0,
-      info: json['info'] as String? ?? '',
-      comment: json['comment'] is int ? json['comment'] as int : 0,
-      lock: json['lock'] as bool? ?? false,
-      nsfw: json['nsfw'] as bool? ?? false,
       images: json['images'] != null
           ? Images.fromJson(json['images'] as Map<String, dynamic>)
           : null,
     );
-  }
-
-  factory Staff.fromTemplate() {
-    return Staff(
-      id: 0,
-      name: '',
-      nameCN: '',
-      type: 0,
-      info: '',
-      comment: 0,
-      lock: false,
-      nsfw: false,
-      images: null,
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    final data = <String, dynamic>{
-      'id': id,
-      'name': name,
-      'nameCN': nameCN,
-      'type': type,
-      'info': info,
-      'comment': comment,
-      'lock': lock,
-      'nsfw': nsfw,
-    };
-    if (images != null) {
-      data['images'] = images!.toJson();
-    }
-    return data;
   }
 }
 
@@ -117,85 +53,5 @@ class Images {
       small: json['small'] as String? ?? '',
       grid: json['grid'] as String? ?? '',
     );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'large': large,
-      'medium': medium,
-      'small': small,
-      'grid': grid,
-    };
-  }
-}
-
-class Position {
-  final PositionType type;
-  final String summary;
-  final String appearEps;
-
-  Position({
-    required this.type,
-    required this.summary,
-    required this.appearEps,
-  });
-
-  factory Position.fromJson(Map<String, dynamic> json) {
-    return Position(
-      type: json['type'] != null
-          ? PositionType.fromJson(json['type'] as Map<String, dynamic>)
-          : PositionType.fromTemplate(),
-      summary: json['summary'] as String? ?? '',
-      appearEps: json['appearEps'] as String? ?? '',
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'type': type.toJson(),
-      'summary': summary,
-      'appearEps': appearEps,
-    };
-  }
-}
-
-class PositionType {
-  final int id;
-  final String en;
-  final String cn;
-  final String jp;
-
-  PositionType({
-    required this.id,
-    required this.en,
-    required this.cn,
-    required this.jp,
-  });
-
-  factory PositionType.fromJson(Map<String, dynamic> json) {
-    return PositionType(
-      id: json['id'] is int ? json['id'] as int : 0,
-      en: json['en'] as String? ?? '',
-      cn: json['cn'] as String? ?? '',
-      jp: json['jp'] as String? ?? '',
-    );
-  }
-
-  factory PositionType.fromTemplate() {
-    return PositionType(
-      id: 0,
-      en: '',
-      cn: '',
-      jp: '',
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'en': en,
-      'cn': cn,
-      'jp': jp,
-    };
   }
 }

--- a/lib/modules/staff/staff_response.dart
+++ b/lib/modules/staff/staff_response.dart
@@ -2,112 +2,56 @@ import 'package:kazumi/modules/staff/staff_item.dart';
 
 class StaffResponse {
   final List<StaffFullItem> data;
-  final int total;
 
   StaffResponse({
     required this.data,
-    required this.total,
   });
 
-  /// Parses the full response of `GET /v0/subjects/{id}/persons`.
-  ///
-  /// The v0 API returns a flat (person × relation) list, so entries are
-  /// merged by person id and prioritized roles are sorted to the front
-  /// via [_staffRelationPriority].
-  factory StaffResponse.fromJson(List<dynamic> persons) {
-    final positionsById = <int, List<Position>>{};
-    final staffById = <int, Staff>{};
-    for (final raw in persons) {
-      try {
-        final json = raw as Map<String, dynamic>;
-        final id = int.tryParse('${json['id']}');
-        if (id == null) continue;
-        positionsById.putIfAbsent(id, () => []).add(_positionFrom(json));
-        staffById.putIfAbsent(id, () => Staff.fromJson(json));
-      } catch (_) {
-        // Skip malformed entries instead of failing the whole list.
-      }
+  /// Parses `GET /v0/subjects/{id}/persons`, which returns a flat
+  /// (person × relation) list, so entries are merged by person id.
+  factory StaffResponse.fromJson(List list) {
+    final Map<int, Staff> staffById = {};
+    final Map<int, List<String>> relationsById = {};
+    for (final item in list) {
+      final json = item as Map<String, dynamic>;
+      final staff = Staff.fromJson(json);
+      staffById.putIfAbsent(staff.id, () => staff);
+      relationsById
+          .putIfAbsent(staff.id, () => [])
+          .add(json['relation'] as String? ?? '');
     }
 
-    final items = <({StaffFullItem item, int priority})>[];
-    for (final entry in staffById.entries) {
-      final positions = _sortedByPriority(positionsById[entry.key]!);
-      items.add((
-        item: StaffFullItem(staff: entry.value, positions: positions),
-        priority: _relationPriority(positions.first.type.cn),
-      ));
-    }
-    return StaffResponse(
-      data: _stableSortedBy(items, (a, b) => a.priority.compareTo(b.priority))
-          .map((e) => e.item)
-          .toList(),
-      total: items.length,
-    );
+    final data = staffById.entries.map((entry) {
+      final relations = relationsById[entry.key]!
+        ..sort((a, b) => _priorityOf(a).compareTo(_priorityOf(b)));
+      return StaffFullItem(staff: entry.value, relations: relations);
+    }).toList()
+      ..sort((a, b) => _priorityOf(a.relations.first)
+          .compareTo(_priorityOf(b.relations.first)));
+
+    return StaffResponse(data: data);
   }
 
-  factory StaffResponse.fromTemplate() {
-    return StaffResponse(
-      data: [],
-      total: 0,
-    );
+  static int _priorityOf(String relation) {
+    final index = _staffRelationPriority.indexOf(relation);
+    return index < 0 ? _staffRelationPriority.length : index;
   }
 
-  static Position _positionFrom(Map<String, dynamic> json) {
-    return Position(
-      type: PositionType(
-        id: 0,
-        en: '',
-        cn: json['relation'] as String? ?? '',
-        jp: '',
-      ),
-      summary: '',
-      appearEps: json['eps']?.toString() ?? '',
-    );
-  }
-
-  static int _relationPriority(String cn) =>
-      _staffRelationPriority[cn] ?? 0x7fffffff;
-
-  static List<Position> _sortedByPriority(List<Position> positions) {
-    return _stableSortedBy(
-      positions,
-      (a, b) =>
-          _relationPriority(a.type.cn).compareTo(_relationPriority(b.type.cn)),
-    );
-  }
-
-  // [List.sort] is not stable, so keep the original index as a tie-breaker.
-  static List<T> _stableSortedBy<T>(List<T> list, int Function(T, T) compare) {
-    final indexed = list.asMap().entries.toList()
-      ..sort((a, b) {
-        final byCompare = compare(a.value, b.value);
-        return byCompare != 0 ? byCompare : a.key.compareTo(b.key);
-      });
-    return [for (final entry in indexed) entry.value];
-  }
-
-  // Lower value sorts first; unlisted roles keep their original order.
-  static const Map<String, int> _staffRelationPriority = {
-    '动画制作': 0,
-    '原作': 10,
-    '总导演': 20,
-    '导演': 30,
-    '系列构成': 40,
-    '脚本': 50,
-    '人物设定': 60,
-    '总作画监督': 70,
-    '作画监督': 80,
-    '美术监督': 90,
-    '色彩设计': 100,
-    '音乐': 110,
-    '音响监督': 120,
-    '摄影监督': 130,
-  };
-
-  Map<String, dynamic> toJson() {
-    return {
-      'data': data.map((item) => item.toJson()).toList(),
-      'total': total,
-    };
-  }
+  /// Key roles pinned to the top of the staff list, in this order.
+  static const List<String> _staffRelationPriority = [
+    '动画制作',
+    '原作',
+    '总导演',
+    '导演',
+    '系列构成',
+    '脚本',
+    '人物设定',
+    '总作画监督',
+    '作画监督',
+    '美术监督',
+    '色彩设计',
+    '音乐',
+    '音响监督',
+    '摄影监督',
+  ];
 }

--- a/lib/modules/staff/staff_response.dart
+++ b/lib/modules/staff/staff_response.dart
@@ -9,37 +9,24 @@ class StaffResponse {
     required this.total,
   });
 
-  factory StaffResponse.fromJson(Map<String, dynamic> json) {
-    return StaffResponse(
-      data: (json['data'] as List<dynamic>? ?? [])
-          .map((item) => StaffFullItem.fromJson(item as Map<String, dynamic>))
-          .toList(),
-      total: json['total'] is int ? json['total'] as int : 0,
-    );
-  }
-
-  factory StaffResponse.fromTemplate() {
-    return StaffResponse(
-      data: [],
-      total: 0,
-    );
-  }
-
-  /// 解析 api.bgm.tv `/v0/subjects/{id}/persons` 的完整返回。
+  /// Parses the full response of `GET /v0/subjects/{id}/persons`.
   ///
-  /// v0 接口按 (人物 × 关系) 返回扁平数组,这里按人物 ID 合并为
-  /// [StaffFullItem],并按 [_staffRelationPriority] 把重要职位
-  /// (动画制作、原作、导演、脚本等)前置,未收录的职位保持 v0
-  /// 原始顺序排在后面;每个条目内的职位也按同一优先级排列,
-  /// 保证行首职位与排序依据一致。
-  factory StaffResponse.fromV0Persons(List<dynamic> persons) {
+  /// The v0 API returns a flat (person × relation) list, so entries are
+  /// merged by person id and prioritized roles are sorted to the front
+  /// via [_staffRelationPriority].
+  factory StaffResponse.fromJson(List<dynamic> persons) {
     final positionsById = <int, List<Position>>{};
     final staffById = <int, Staff>{};
     for (final raw in persons) {
-      final json = raw as Map<String, dynamic>;
-      final id = json['id'] as int? ?? 0;
-      positionsById.putIfAbsent(id, () => []).add(_positionFrom(json));
-      staffById.putIfAbsent(id, () => Staff.fromJson(json));
+      try {
+        final json = raw as Map<String, dynamic>;
+        final id = int.tryParse('${json['id']}');
+        if (id == null) continue;
+        positionsById.putIfAbsent(id, () => []).add(_positionFrom(json));
+        staffById.putIfAbsent(id, () => Staff.fromJson(json));
+      } catch (_) {
+        // Skip malformed entries instead of failing the whole list.
+      }
     }
 
     final items = <({StaffFullItem item, int priority})>[];
@@ -58,7 +45,13 @@ class StaffResponse {
     );
   }
 
-  /// v0 人物行 → [Position],职位名取自 `relation`。
+  factory StaffResponse.fromTemplate() {
+    return StaffResponse(
+      data: [],
+      total: 0,
+    );
+  }
+
   static Position _positionFrom(Map<String, dynamic> json) {
     return Position(
       type: PositionType(
@@ -68,15 +61,13 @@ class StaffResponse {
         jp: '',
       ),
       summary: '',
-      appearEps: json['eps'] as String? ?? '',
+      appearEps: json['eps']?.toString() ?? '',
     );
   }
 
-  /// 职位名 → 优先级,越小越靠前;未收录的职位返回最大值,排在最后。
   static int _relationPriority(String cn) =>
       _staffRelationPriority[cn] ?? 0x7fffffff;
 
-  /// 职位按优先级稳定排序(同优先级保持原顺序)。
   static List<Position> _sortedByPriority(List<Position> positions) {
     return _stableSortedBy(
       positions,
@@ -85,9 +76,8 @@ class StaffResponse {
     );
   }
 
-  /// Dart 的 [List.sort] 不稳定,这里用原序号兜底实现稳定排序。
-  static List<T> _stableSortedBy<T>(
-      List<T> list, int Function(T, T) compare) {
+  // [List.sort] is not stable, so keep the original index as a tie-breaker.
+  static List<T> _stableSortedBy<T>(List<T> list, int Function(T, T) compare) {
     final indexed = list.asMap().entries.toList()
       ..sort((a, b) {
         final byCompare = compare(a.value, b.value);
@@ -96,7 +86,7 @@ class StaffResponse {
     return [for (final entry in indexed) entry.value];
   }
 
-  /// 职位 → 排序优先级,越小越靠前;未收录的职位为普通级别。
+  // Lower value sorts first; unlisted roles keep their original order.
   static const Map<String, int> _staffRelationPriority = {
     '动画制作': 0,
     '原作': 10,

--- a/lib/modules/staff/staff_response.dart
+++ b/lib/modules/staff/staff_response.dart
@@ -25,6 +25,95 @@ class StaffResponse {
     );
   }
 
+  /// 解析 api.bgm.tv `/v0/subjects/{id}/persons` 的完整返回。
+  ///
+  /// v0 接口按 (人物 × 关系) 返回扁平数组,这里按人物 ID 合并为
+  /// [StaffFullItem],并按 [_staffRelationPriority] 把重要职位
+  /// (动画制作、原作、导演、脚本等)前置,未收录的职位保持 v0
+  /// 原始顺序排在后面;每个条目内的职位也按同一优先级排列,
+  /// 保证行首职位与排序依据一致。
+  factory StaffResponse.fromV0Persons(List<dynamic> persons) {
+    final positionsById = <int, List<Position>>{};
+    final staffById = <int, Staff>{};
+    for (final raw in persons) {
+      final json = raw as Map<String, dynamic>;
+      final id = json['id'] as int? ?? 0;
+      positionsById.putIfAbsent(id, () => []).add(_positionFrom(json));
+      staffById.putIfAbsent(id, () => Staff.fromJson(json));
+    }
+
+    final items = <({StaffFullItem item, int priority})>[];
+    for (final entry in staffById.entries) {
+      final positions = _sortedByPriority(positionsById[entry.key]!);
+      items.add((
+        item: StaffFullItem(staff: entry.value, positions: positions),
+        priority: _relationPriority(positions.first.type.cn),
+      ));
+    }
+    return StaffResponse(
+      data: _stableSortedBy(items, (a, b) => a.priority.compareTo(b.priority))
+          .map((e) => e.item)
+          .toList(),
+      total: items.length,
+    );
+  }
+
+  /// v0 人物行 → [Position],职位名取自 `relation`。
+  static Position _positionFrom(Map<String, dynamic> json) {
+    return Position(
+      type: PositionType(
+        id: 0,
+        en: '',
+        cn: json['relation'] as String? ?? '',
+        jp: '',
+      ),
+      summary: '',
+      appearEps: json['eps'] as String? ?? '',
+    );
+  }
+
+  /// 职位名 → 优先级,越小越靠前;未收录的职位返回最大值,排在最后。
+  static int _relationPriority(String cn) =>
+      _staffRelationPriority[cn] ?? 0x7fffffff;
+
+  /// 职位按优先级稳定排序(同优先级保持原顺序)。
+  static List<Position> _sortedByPriority(List<Position> positions) {
+    return _stableSortedBy(
+      positions,
+      (a, b) =>
+          _relationPriority(a.type.cn).compareTo(_relationPriority(b.type.cn)),
+    );
+  }
+
+  /// Dart 的 [List.sort] 不稳定,这里用原序号兜底实现稳定排序。
+  static List<T> _stableSortedBy<T>(
+      List<T> list, int Function(T, T) compare) {
+    final indexed = list.asMap().entries.toList()
+      ..sort((a, b) {
+        final byCompare = compare(a.value, b.value);
+        return byCompare != 0 ? byCompare : a.key.compareTo(b.key);
+      });
+    return [for (final entry in indexed) entry.value];
+  }
+
+  /// 职位 → 排序优先级,越小越靠前;未收录的职位为普通级别。
+  static const Map<String, int> _staffRelationPriority = {
+    '动画制作': 0,
+    '原作': 10,
+    '总导演': 20,
+    '导演': 30,
+    '系列构成': 40,
+    '脚本': 50,
+    '人物设定': 60,
+    '总作画监督': 70,
+    '作画监督': 80,
+    '美术监督': 90,
+    '色彩设计': 100,
+    '音乐': 110,
+    '音响监督': 120,
+    '摄影监督': 130,
+  };
+
   Map<String, dynamic> toJson() {
     return {
       'data': data.map((item) => item.toJson()).toList(),

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -491,7 +491,7 @@ class BangumiApi {
       ApiEndpoints.formatUrl(
           ApiEndpoints.bangumiAPIDomain + ApiEndpoints.bangumiStaffByID, [id]),
     );
-    return StaffResponse.fromV0Persons(jsonData as List<dynamic>);
+    return StaffResponse.fromJson(jsonData as List<dynamic>);
   }
 
   static Future<CharactersResponse> getCharatersByBangumiID(int id) async {

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -491,7 +491,7 @@ class BangumiApi {
       ApiEndpoints.formatUrl(
           ApiEndpoints.bangumiAPIDomain + ApiEndpoints.bangumiStaffByID, [id]),
     );
-    return StaffResponse.fromJson(jsonData as List<dynamic>);
+    return StaffResponse.fromJson(jsonData);
   }
 
   static Future<CharactersResponse> getCharatersByBangumiID(int id) async {

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -28,7 +28,6 @@ class BangumiSearchPage {
 
 class BangumiApi {
   static final BangumiClient _client = BangumiClient.instance;
-  static const int _animationProductionPositionId = 67;
 
   static Future<List<List<BangumiItem>>> getCalendar() async {
     List<List<BangumiItem>> bangumiCalendar = [];
@@ -488,29 +487,11 @@ class BangumiApi {
   }
 
   static Future<StaffResponse> getBangumiStaffByID(int id) async {
-    final url = ApiEndpoints.formatUrl(
-      ApiEndpoints.bangumiAPINextDomain + ApiEndpoints.bangumiStaffByIDNext,
-      [id],
+    final jsonData = await _client.get(
+      ApiEndpoints.formatUrl(
+          ApiEndpoints.bangumiAPIDomain + ApiEndpoints.bangumiStaffByID, [id]),
     );
-    final responses = await Future.wait([
-      _client.get(url),
-      _client.get(
-        url,
-        queryParameters: const {
-          'position': _animationProductionPositionId,
-        },
-      ),
-    ]);
-    final response = StaffResponse.fromJson(responses[0]);
-    final studios = StaffResponse.fromJson(responses[1])
-        .data
-        .where((staff) => staff.positions.any(
-            (position) => position.type.id == _animationProductionPositionId))
-        .toList();
-    final studioIds = studios.map((studio) => studio.staff.id).toSet();
-    response.data.removeWhere((staff) => studioIds.contains(staff.staff.id));
-    response.data.insertAll(0, studios);
-    return response;
+    return StaffResponse.fromV0Persons(jsonData as List<dynamic>);
   }
 
   static Future<CharactersResponse> getCharatersByBangumiID(int id) async {

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -28,6 +28,7 @@ class BangumiSearchPage {
 
 class BangumiApi {
   static final BangumiClient _client = BangumiClient.instance;
+  static const int _animationProductionPositionId = 67;
 
   static Future<List<List<BangumiItem>>> getCalendar() async {
     List<List<BangumiItem>> bangumiCalendar = [];
@@ -487,12 +488,29 @@ class BangumiApi {
   }
 
   static Future<StaffResponse> getBangumiStaffByID(int id) async {
-    final jsonData = await _client.get(
-      ApiEndpoints.formatUrl(
-          ApiEndpoints.bangumiAPINextDomain + ApiEndpoints.bangumiStaffByIDNext,
-          [id]),
+    final url = ApiEndpoints.formatUrl(
+      ApiEndpoints.bangumiAPINextDomain + ApiEndpoints.bangumiStaffByIDNext,
+      [id],
     );
-    return StaffResponse.fromJson(jsonData);
+    final responses = await Future.wait([
+      _client.get(url),
+      _client.get(
+        url,
+        queryParameters: const {
+          'position': _animationProductionPositionId,
+        },
+      ),
+    ]);
+    final response = StaffResponse.fromJson(responses[0]);
+    final studios = StaffResponse.fromJson(responses[1])
+        .data
+        .where((staff) => staff.positions.any(
+            (position) => position.type.id == _animationProductionPositionId))
+        .toList();
+    final studioIds = studios.map((studio) => studio.staff.id).toSet();
+    response.data.removeWhere((staff) => studioIds.contains(staff.staff.id));
+    response.data.insertAll(0, studios);
+    return response;
   }
 
   static Future<CharactersResponse> getCharatersByBangumiID(int id) async {

--- a/lib/request/config/api_endpoints.dart
+++ b/lib/request/config/api_endpoints.dart
@@ -61,6 +61,9 @@ class ApiEndpoints {
   /// 从条目ID获取角色信息
   static const String bangumiCharacterByID = '/v0/subjects/{0}/characters';
 
+  /// 从条目ID获取工作人员信息
+  static const String bangumiStaffByID = '/v0/subjects/{0}/persons';
+
   /// 从条目ID获取剧集ID
   static const String bangumiEpisodeByID = '/v0/episodes';
 
@@ -109,9 +112,6 @@ class ApiEndpoints {
   /// 番剧角色评论
   static const String bangumiCharacterCommentsByIDNext =
       '/p1/characters/{0}/comments';
-
-  /// 番剧工作人员信息
-  static const String bangumiStaffByIDNext = '/p1/subjects/{0}/staffs/persons';
 
   /// DanDanPlay API Domain
   static const String dandanAPIDomain = 'https://api.dandanplay.net';


### PR DESCRIPTION
## What's Changed
1. staff 列表请求从 `next.bgm.tv/p1/subjects/{id}/staffs/persons` 切换到 `api.bgm.tv/v0/subjects/{id}/persons`
   - v0 接口一次全量返回(含制作公司),去掉原来的 `position=67` 二次请求
   - v0 按 (人物 × 关系) 返回扁平数组,按人物 ID 合并,同一人多职位合并为一行
2. 重要职位本地排序前置:动画制作(工作室)→ 原作 → 总导演 → 导演 → 系列构成 → 脚本 → 人物设定 → 总作画监督 → 作画监督 → 美术监督 → 色彩设计 → 音乐 → 音响监督 → 摄影监督,其余职位保持接口原始顺序
   - 职位优先级表在 `lib/modules/staff/staff_response.dart` 的 `_staffRelationPriority`,可调整
   - Dart `List.sort` 不稳定,同优先级用原序号兜底,保证稳定排序

已知取舍:v0 `RelatedPerson` 没有 `nameCN`/`info` 字段,staff 列表的中文名副标题会为空。

|<img width="1331" height="1589" alt="image" src="https://github.com/user-attachments/assets/f7b22472-5b1f-433d-8b6a-2db310ed899e" />|<img width="1331" height="1589" alt="image" src="https://github.com/user-attachments/assets/10538d7e-a228-4df4-b9ec-53938d59aa87" />|
|---|---|

---

GPT 5.6 Sol high，DeepSeek V4 Flash

close #2051
