### PR TITLE
fix(video): 从历史记录进入播放页时，选集列表滚动到合适的位置

### DIFF
--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -154,12 +154,12 @@ class _VideoPageState extends State<VideoPage>
   }
 
   void _initOfflineMode(PlayerController playerController) {
-    _showTabBodyImmediately(locateEpisode: false);
     final identity = videoPageController.currentHistoryIdentity;
     videoPageController.historyOffset = identity == null
         ? 0
         : videoPageController.getHistoryOffsetFor(identity);
     visibleRoad = videoPageController.selectedEpisode.road;
+    _showTabBodyImmediately();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Future.delayed(_offlinePlayerInitDelay);
@@ -177,7 +177,6 @@ class _VideoPageState extends State<VideoPage>
 
   void _initOnlineMode(PlayerController playerController) {
     videoPageController.historyOffset = 0;
-    _showTabBodyImmediately();
 
     var progress = historyController.lastWatching(
         videoPageController.bangumiItem,
@@ -197,6 +196,7 @@ class _VideoPageState extends State<VideoPage>
       }
     }
     visibleRoad = videoPageController.selectedEpisode.road;
+    _showTabBodyImmediately();
 
     _logSubscription = videoPageController.logStream.listen((log) {
       if (mounted) {
@@ -306,10 +306,9 @@ class _VideoPageState extends State<VideoPage>
       if (!mounted || !scrollController.hasClients) {
         return;
       }
+      final int index = videoPageController.selectedEpisode.episode - 1;
       await observerController.jumpTo(
-        index: videoPageController.selectedEpisode.episode > 1
-            ? videoPageController.selectedEpisode.episode - 1
-            : videoPageController.selectedEpisode.episode,
+        index: index < 0 ? 0 : index,
         isFixedHeight: true,
       );
     });
@@ -339,11 +338,9 @@ class _VideoPageState extends State<VideoPage>
     }
   }
 
-  void _showTabBodyImmediately({bool locateEpisode = true}) {
+  void _showTabBodyImmediately() {
     _setTabBodyVisible(true, animated: false);
-    if (locateEpisode) {
-      menuJumpToCurrentEpisode();
-    }
+    menuJumpToCurrentEpisode();
   }
 
   void _hideTabBodyImmediately() {
@@ -660,17 +657,17 @@ class _VideoPageState extends State<VideoPage>
               : MediaQuery.sizeOf(context).width / 3),
       child: Container(
         color: Theme.of(context).canvasColor,
-        child: GridViewObserver(
-          controller: observerController,
-          child: (isDesktop() || isTablet())
-              ? tabBody
-              : Column(
+        child: (isDesktop() || isTablet())
+            ? tabBody
+            : GridViewObserver(
+                controller: observerController,
+                child: Column(
                   children: [
                     menuBar,
                     menuBody,
                   ],
                 ),
-        ),
+              ),
       ),
     );
   }

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -177,7 +177,7 @@ class _VideoPageState extends State<VideoPage>
 
   void _initOnlineMode(PlayerController playerController) {
     videoPageController.historyOffset = 0;
-    _showTabBodyImmediately(locateEpisode: false);
+    _showTabBodyImmediately();
 
     var progress = historyController.lastWatching(
         videoPageController.bangumiItem,
@@ -299,14 +299,19 @@ class _VideoPageState extends State<VideoPage>
   }
 
   void menuJumpToCurrentEpisode() {
-    Future.delayed(const Duration(milliseconds: 20), () async {
-      if (!mounted) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // GridViewObserver binds its sliver context in its own post-frame callback.
+      // Wait until the current frame's callbacks have all completed first.
+      await Future<void>.delayed(Duration.zero);
+      if (!mounted || !scrollController.hasClients) {
         return;
       }
       await observerController.jumpTo(
-          index: videoPageController.selectedEpisode.episode > 1
-              ? videoPageController.selectedEpisode.episode - 1
-              : videoPageController.selectedEpisode.episode);
+        index: videoPageController.selectedEpisode.episode > 1
+            ? videoPageController.selectedEpisode.episode - 1
+            : videoPageController.selectedEpisode.episode,
+        isFixedHeight: true,
+      );
     });
   }
 


### PR DESCRIPTION
<!--
提交 PR 前，请确认您已经阅读 [贡献指引](static/doc/CONTRIBUTING.md)。不符合的 PR 可能会被延迟处理或直接关闭。
请勿随意删除此模板的任何部分。
-->

## 描述

<!-- 这个 PR 都做了什么工作？解决了什么问题？或是开发了什么新功能？ -->

从历史记录进入播放页时，选集列表滚动到合适的位置。

以钢炼41集为例（钢炼有很多集，选集列表无法一次性展示所有集数），修改前：
<img width="1875" height="1281" alt="image" src="https://github.com/user-attachments/assets/8d111f03-6d13-4316-8c71-c1c431856370" />
可以看到左上角显示41集，但是右边选集列表没有跳转到合适的位置。

修改后：
<img width="1872" height="1251" alt="image" src="https://github.com/user-attachments/assets/18f98919-1372-42af-937a-3d237b423188" />

## 关联的 Issues

<!-- 这个 PR 和哪些 Issues 关联？例如 #123, #87, #314 -->

## PR 类型

<!-- 这个 PR 属于什么类型的改动？ -->

- [√] Bug 修复
- [ ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

<!-- 这个 PR 的工作是否用到了 AI 辅助？ -->

- [ ] 没有使用 AI 辅助
- [ ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [√] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: 

<!-- 请按照要求，填写完整的 AI 模型名称，如 “Claude Fable 5”，“Kimi-K3” -->

GPT-5.6-Luna-xhigh

## 提交前检查

- [√] 我已经填写了 PR 模板中的所有内容
- [√] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [√] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

<!-- 简要写下一些附注。注意如果是对 PR 工作的描述，应该写在开头的 “描述” 一栏中 -->