### PR TITLE
fix(macos): restore inactive window activation

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -2,7 +2,24 @@ import Cocoa
 import FlutterMacOS
 import window_manager
 
+// FlutterView accepts the first mouse event even when its window is inactive.
+// This view lets AppKit activate the window without forwarding that event.
+private final class InactiveMouseBlockerView: NSView {
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    guard window?.isKeyWindow == false, bounds.contains(point) else {
+      return nil
+    }
+    return self
+  }
+
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    return false
+  }
+}
+
 class MainFlutterWindow: NSWindow {
+  private let inactiveMouseBlocker = InactiveMouseBlockerView()
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     self.backgroundColor = NSColor.clear
@@ -10,6 +27,23 @@ class MainFlutterWindow: NSWindow {
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
+
+    if let contentView = self.contentView,
+      let contentContainer = contentView.superview
+    {
+      inactiveMouseBlocker.translatesAutoresizingMaskIntoConstraints = false
+      contentContainer.addSubview(
+        inactiveMouseBlocker,
+        positioned: .above,
+        relativeTo: contentView
+      )
+      NSLayoutConstraint.activate([
+        inactiveMouseBlocker.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+        inactiveMouseBlocker.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        inactiveMouseBlocker.topAnchor.constraint(equalTo: contentView.topAnchor),
+        inactiveMouseBlocker.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      ])
+    }
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
@@ -19,18 +53,5 @@ class MainFlutterWindow: NSWindow {
   override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
     super.order(place, relativeTo: otherWin)
     hiddenWindowAtLaunch()
-  }
-
-  override func sendEvent(_ event: NSEvent) {
-    if !isKeyWindow,
-       event.type == .leftMouseDown || event.type == .rightMouseDown || event.type == .otherMouseDown,
-       let contentView = self.contentView,
-       let hit = contentView.superview?.hitTest(event.locationInWindow),
-       hit == contentView || hit.isDescendant(of: contentView) {
-      NSApp.activate(ignoringOtherApps: true)
-      self.makeKeyAndOrderFront(nil)
-      return
-    }
-    super.sendEvent(event)
   }
 }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -6,10 +6,10 @@ import window_manager
 // This view lets AppKit activate the window without forwarding that event.
 private final class InactiveMouseBlockerView: NSView {
   override func hitTest(_ point: NSPoint) -> NSView? {
-    guard window?.isKeyWindow == false, bounds.contains(point) else {
+    guard window?.isKeyWindow == false else {
       return nil
     }
-    return self
+    return super.hitTest(point)
   }
 
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
@@ -28,14 +28,12 @@ class MainFlutterWindow: NSWindow {
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
 
-    if let contentView = self.contentView,
-      let contentContainer = contentView.superview
-    {
+    if let contentView = self.contentView {
       inactiveMouseBlocker.translatesAutoresizingMaskIntoConstraints = false
-      contentContainer.addSubview(
+      contentView.addSubview(
         inactiveMouseBlocker,
         positioned: .above,
-        relativeTo: contentView
+        relativeTo: nil
       )
       NSLayoutConstraint.activate([
         inactiveMouseBlocker.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),


### PR DESCRIPTION
## Summary

- replace manual event interception with an AppKit first-mouse blocker
- let inactive windows become key without forwarding the activation click to Flutter
- keep normal mouse handling unchanged once the window is active

## Background

FlutterView intentionally accepts the first mouse event in an inactive window. The previous workaround swallowed that event and called NSApp.activate manually, but activation requests are not guaranteed to complete. On recent macOS versions, Kazumi could therefore remain inactive and ignore subsequent mouse and keyboard input until it was selected from the Dock.

The blocker only participates in hit testing while the window is not key and returns false from acceptsFirstMouse. This lets AppKit perform its native activation flow while preserving the expected no-click-through behavior.

Closes #2457

## Testing

- flutter test (132 tests passed)
- flutter analyze --no-fatal-infos --fatal-warnings
- flutter build macos --release
- manual macOS 26.5.2 verification of inactive first-mouse and active Flutter click paths