### PR TITLE
fix(linux): 防止重复启动导致本地数据丢失

### DIFF
--- a/lib/services/storage/storage.dart
+++ b/lib/services/storage/storage.dart
@@ -165,7 +165,16 @@ class GStorage {
   static Future<Box<T>> _openBoxSafe<T>(String boxName) async {
     try {
       return await Hive.openBox<T>(boxName);
-    } catch (e) {
+    } on FileSystemException catch (e) {
+      // A second process or a filesystem permission issue can prevent Hive
+      // from acquiring its lock. Preserve the box instead of treating an
+      // access failure as corruption and deleting user data.
+      KazumiLogger().e(
+        'GStorage: Failed to access box "$boxName"; data preserved',
+        error: e,
+      );
+      rethrow;
+    } on HiveError catch (e) {
       KazumiLogger().e(
           'GStorage: Box "$boxName" corrupted, attempting recovery',
           error: e);

--- a/lib/services/storage/storage.dart
+++ b/lib/services/storage/storage.dart
@@ -165,16 +165,7 @@ class GStorage {
   static Future<Box<T>> _openBoxSafe<T>(String boxName) async {
     try {
       return await Hive.openBox<T>(boxName);
-    } on FileSystemException catch (e) {
-      // A second process or a filesystem permission issue can prevent Hive
-      // from acquiring its lock. Preserve the box instead of treating an
-      // access failure as corruption and deleting user data.
-      KazumiLogger().e(
-        'GStorage: Failed to access box "$boxName"; data preserved',
-        error: e,
-      );
-      rethrow;
-    } on HiveError catch (e) {
+    } catch (e) {
       KazumiLogger().e(
           'GStorage: Box "$boxName" corrupted, attempting recovery',
           error: e);

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -131,6 +131,17 @@ static void intent_method_call_handler(FlMethodChannel*,
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
+  // A repeated launch is forwarded to this unique application instance.
+  GList* windows =
+      gtk_application_get_windows(GTK_APPLICATION(application));
+  if (windows != nullptr) {
+    GtkWindow* window = GTK_WINDOW(windows->data);
+    gtk_widget_show(GTK_WIDGET(window));
+    gtk_window_present(window);
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
@@ -234,6 +245,6 @@ static void my_application_init(MyApplication* self) {}
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     "flags", static_cast<GApplicationFlags>(0),
                                      nullptr));
 }


### PR DESCRIPTION
## 修改内容

- 将 Linux runner 注册为唯一 `GApplication`
- 重复启动时唤起已有窗口，不再创建新的 Flutter engine
- 窗口隐藏到托盘或最小化后，再次启动也会重新显示已有窗口

## 问题原因

Linux runner 原先显式使用 `G_APPLICATION_NON_UNIQUE`，因此每次从启动器打开应用都会创建新的窗口和 Flutter engine。多个实例随后会同时打开同一组 Hive box，而现有损坏恢复逻辑会在锁冲突后重建 box，导致本地设置和其他数据被清空。

现在 runner 使用 `GApplication` 的单实例协商机制。重复启动会把激活请求转发给已运行的主实例，并复用最近聚焦的窗口，从源头避免多个 Flutter/Hive 实例访问同一份数据。

Closes #2462
Closes #2027

Related: #2015（解决从 GNOME Background Apps 重复启动新实例的路径；MPRIS 激活行为不在本 PR 范围内）

## 验证

- `flutter test`（132 项测试通过）
- `flutter analyze --no-fatal-infos --fatal-warnings`
- `git diff --check`
- Linux amd64 release build
- Linux arm64 release build