### PR TITLE
fix(player): 修复逆序剧集的上下集导航

### DIFF
--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -270,36 +270,35 @@ class _PlayerItemState extends State<PlayerItem>
     if (videoPageController.loading) return;
     final selection = videoPageController.selectedEpisode;
     final currentRoad = selection.road;
-    final episodes = videoPageController.roadList[currentRoad].data;
-    int targetEpisode;
-    if (direction == 'next') {
-      targetEpisode = selection.episode + 1;
-    } else if (direction == 'prev') {
-      targetEpisode = selection.episode - 1;
-    } else {
+    final next = switch (direction) {
+      'next' => true,
+      'prev' => false,
+      _ => null,
+    };
+    if (next == null) {
       return;
     }
-
-    if (targetEpisode > episodes.length) {
-      KazumiDialog.showToast(message: '已经是最新一集');
-      return;
-    }
-    if (targetEpisode <= 0) {
-      KazumiDialog.showToast(message: '已经是第一集');
-      return;
-    }
-
-    final targetSelection = VideoEpisodeSelection(
-      episode: targetEpisode,
-      road: currentRoad,
+    final adjacentSelections = adjacentEpisodeSelections(
+      road: videoPageController.roadList[currentRoad],
+      current: selection,
     );
+    final targetSelection =
+        next ? adjacentSelections.next : adjacentSelections.previous;
+    if (targetSelection == null) {
+      KazumiDialog.showToast(message: next ? '已经是最新一集' : '已经是第一集');
+      return;
+    }
+
     // Resolution failures surface through the controller's failed state;
     // the toast here is progress feedback only.
     final targetRef = videoPageController.resolveEpisode(targetSelection);
     if (targetRef != null) {
       KazumiDialog.showToast(message: '正在加载${targetRef.displayTitle}');
     }
-    widget.changeEpisode(targetEpisode, currentRoad: currentRoad);
+    widget.changeEpisode(
+      targetSelection.episode,
+      currentRoad: targetSelection.road,
+    );
   }
 
   Future<void> handleShortcutRewind() async {
@@ -516,8 +515,12 @@ class _PlayerItemState extends State<PlayerItem>
 
       if (playerController.playback.duration <= Duration.zero) return;
 
-      final canSkipToPrevious = currentEpisode > 1;
-      final canSkipToNext = currentEpisode < currentRoadData.data.length;
+      final adjacentSelections = adjacentEpisodeSelections(
+        road: currentRoadData,
+        current: selection,
+      );
+      final canSkipToPrevious = adjacentSelections.previous != null;
+      final canSkipToNext = adjacentSelections.next != null;
       final bangumiTitle = videoPageController.bangumiItem.nameCn.isNotEmpty
           ? videoPageController.bangumiItem.nameCn
           : videoPageController.bangumiItem.name;
@@ -1023,23 +1026,28 @@ class _PlayerItemState extends State<PlayerItem>
           // Completion of a stale near-end resume is not a real watch;
           // replay from the beginning instead of advancing.
           unawaited(playerController.playback.restartFromBeginning());
-        } else if (playingSelection.episode < playingRoadData.data.length &&
-            autoPlayNext) {
-          final nextSelection = VideoEpisodeSelection(
-            episode: playingSelection.episode + 1,
-            road: playingSelection.road,
-          );
-          // Resolution failures surface through the controller's failed state
-          // instead of silently retrying here every second.
-          final nextRef = videoPageController.resolveEpisode(nextSelection);
-          if (nextRef != null) {
-            KazumiDialog.showToast(message: '正在加载${nextRef.displayTitle}');
+        } else if (autoPlayNext) {
+          final nextSelection = adjacentEpisodeSelections(
+            road: playingRoadData,
+            current: playingSelection,
+          ).next;
+          if (nextSelection != null) {
+            // Resolution failures surface through the controller's failed
+            // state instead of silently retrying here every second.
+            final nextRef = videoPageController.resolveEpisode(nextSelection);
+            if (nextRef != null) {
+              KazumiDialog.showToast(
+                message: '正在加载${nextRef.displayTitle}',
+              );
+            }
+            try {
+              playerTimer!.cancel();
+            } catch (_) {}
+            widget.changeEpisode(
+              nextSelection.episode,
+              currentRoad: nextSelection.road,
+            );
           }
-          try {
-            playerTimer!.cancel();
-          } catch (_) {}
-          widget.changeEpisode(playingSelection.episode + 1,
-              currentRoad: playingSelection.road);
         }
       }
       playerController.setSyncPlayCurrentPosition();

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -56,6 +56,62 @@ class VideoEpisodeSelection {
   }
 }
 
+typedef AdjacentEpisodeSelections = ({
+  VideoEpisodeSelection? previous,
+  VideoEpisodeSelection? next,
+});
+
+/// Finds the chronological previous and next episodes in a source-provided
+/// road.
+///
+/// Numbered identifiers reveal whether the source is ordered ascending or
+/// descending. Unnumbered or ambiguous lists keep their original order.
+AdjacentEpisodeSelections adjacentEpisodeSelections({
+  required Road road,
+  required VideoEpisodeSelection current,
+}) {
+  final episodeCount = road.data.length < road.identifier.length
+      ? road.data.length
+      : road.identifier.length;
+  if (current.episode <= 0 || current.episode > episodeCount) {
+    return (previous: null, next: null);
+  }
+
+  var ascendingPairs = 0;
+  var descendingPairs = 0;
+  int? previousNumber;
+  for (final identifier in road.identifier) {
+    final number = extractEpisodeNumber(identifier);
+    if (number <= 0) {
+      continue;
+    }
+    if (previousNumber != null) {
+      if (number > previousNumber) {
+        ascendingPairs++;
+      } else if (number < previousNumber) {
+        descendingPairs++;
+      }
+    }
+    previousNumber = number;
+  }
+
+  final forwardStep = descendingPairs > ascendingPairs ? -1 : 1;
+  VideoEpisodeSelection? selectionAt(int episode) {
+    if (episode <= 0 || episode > episodeCount) {
+      return null;
+    }
+    return VideoEpisodeSelection(
+      episode: episode,
+      road: current.road,
+    );
+  }
+
+  return (
+    previous: selectionAt(current.episode - forwardStep),
+    next: selectionAt(current.episode + forwardStep),
+  );
+}
+
 abstract class _VideoPageController with Store implements Disposable {
   _VideoPageController(
     this.historyController,

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -81,7 +81,7 @@ AdjacentEpisodeSelections adjacentEpisodeSelections({
   var descendingPairs = 0;
   int? previousNumber;
   for (final identifier in road.identifier) {
-    final number = extractEpisodeNumber(identifier);
+    final number = _episodeNumberForOrdering(identifier);
     if (number <= 0) {
       continue;
     }
@@ -95,7 +95,7 @@ AdjacentEpisodeSelections adjacentEpisodeSelections({
     previousNumber = number;
   }
 
-  final forwardStep = descendingPairs > ascendingPairs ? -1 : 1;
+  final forwardStep = descendingPairs > 0 && ascendingPairs == 0 ? -1 : 1;
   VideoEpisodeSelection? selectionAt(int episode) {
     if (episode <= 0 || episode > episodeCount) {
       return null;
@@ -110,6 +110,26 @@ AdjacentEpisodeSelections adjacentEpisodeSelections({
     previous: selectionAt(current.episode - forwardStep),
     next: selectionAt(current.episode + forwardStep),
   );
+}
+
+int _episodeNumberForOrdering(String identifier) {
+  final episodeMatch = RegExp(
+    r'(?:第\s*)?(\d+)\s*[话集]',
+    caseSensitive: false,
+  ).firstMatch(identifier);
+  if (episodeMatch != null) {
+    return int.tryParse(episodeMatch.group(1)!) ?? 0;
+  }
+
+  final abbreviatedMatch = RegExp(
+    r'\b(?:EP?|E)\s*0*(\d+)\b',
+    caseSensitive: false,
+  ).firstMatch(identifier);
+  if (abbreviatedMatch != null) {
+    return int.tryParse(abbreviatedMatch.group(1)!) ?? 0;
+  }
+
+  return extractEpisodeNumber(identifier);
 }
 
 abstract class _VideoPageController with Store implements Disposable {

--- a/test/episode_ref_test.dart
+++ b/test/episode_ref_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kazumi/modules/download/download_module.dart';
+import 'package:kazumi/modules/roads/road_module.dart';
 import 'package:kazumi/pages/player/controller/player_models.dart';
 import 'package:kazumi/pages/video/video_controller.dart';
 
@@ -55,6 +56,88 @@ void main() {
     });
   });
 
+  group('adjacentEpisodeSelections', () {
+    test('follows ascending episode numbers', () {
+      final road = _road(['第1话', '第2话', '第3话']);
+      const current = VideoEpisodeSelection(episode: 2, road: 0);
+      final adjacent = adjacentEpisodeSelections(
+        road: road,
+        current: current,
+      );
+
+      expect(
+        adjacent.next,
+        const VideoEpisodeSelection(episode: 3, road: 0),
+      );
+      expect(
+        adjacent.previous,
+        const VideoEpisodeSelection(episode: 1, road: 0),
+      );
+    });
+
+    test('reverses list traversal for descending episode numbers', () {
+      final road = _road(['第3话', '第2话', '第1话']);
+      const current = VideoEpisodeSelection(episode: 2, road: 1);
+      final adjacent = adjacentEpisodeSelections(
+        road: road,
+        current: current,
+      );
+
+      expect(
+        adjacent.next,
+        const VideoEpisodeSelection(episode: 1, road: 1),
+      );
+      expect(
+        adjacent.previous,
+        const VideoEpisodeSelection(episode: 3, road: 1),
+      );
+    });
+
+    test('ignores unnumbered entries when detecting descending order', () {
+      final road = _road(['先导片', '第12话', '第11话']);
+
+      expect(
+        adjacentEpisodeSelections(
+          road: road,
+          current: const VideoEpisodeSelection(episode: 3, road: 0),
+        ).next,
+        const VideoEpisodeSelection(episode: 2, road: 0),
+      );
+    });
+
+    test('keeps source order when episode numbers cannot be inferred', () {
+      final road = _road(['OVA 上篇', 'OVA 下篇']);
+
+      expect(
+        adjacentEpisodeSelections(
+          road: road,
+          current: const VideoEpisodeSelection(episode: 1, road: 0),
+        ).next,
+        const VideoEpisodeSelection(episode: 2, road: 0),
+      );
+    });
+
+    test('returns null at chronological boundaries', () {
+      final ascending = _road(['第1话', '第2话', '第3话']);
+      final descending = _road(['第3话', '第2话', '第1话']);
+
+      expect(
+        adjacentEpisodeSelections(
+          road: ascending,
+          current: const VideoEpisodeSelection(episode: 3, road: 0),
+        ).next,
+        isNull,
+      );
+      expect(
+        adjacentEpisodeSelections(
+          road: descending,
+          current: const VideoEpisodeSelection(episode: 1, road: 0),
+        ).next,
+        isNull,
+      );
+    });
+  });
+
   test('PlaybackInitParams carries danmaku episode independently', () {
     const params = PlaybackInitParams(
       videoUrl: 'file:///tmp/video.mp4',
@@ -94,6 +177,14 @@ void main() {
       expect(snapshot.originalRoadToDisplayRoad, {0: 0, 2: 1});
     });
   });
+}
+
+Road _road(List<String> identifiers) {
+  return Road(
+    name: '播放列表',
+    data: List.generate(identifiers.length, (index) => '/episode/$index'),
+    identifier: identifiers,
+  );
 }
 
 DownloadEpisode _episode(int episodeNumber, String name, int road) {

--- a/test/episode_ref_test.dart
+++ b/test/episode_ref_test.dart
@@ -93,6 +93,34 @@ void main() {
       );
     });
 
+    test('prefers marked episode numbers over leading quality values', () {
+      final road = _road([
+        '1080P 第1集',
+        '720P 第2集',
+        '480P 第3集',
+      ]);
+
+      expect(
+        adjacentEpisodeSelections(
+          road: road,
+          current: const VideoEpisodeSelection(episode: 2, road: 0),
+        ).next,
+        const VideoEpisodeSelection(episode: 3, road: 0),
+      );
+    });
+
+    test('keeps source order when numbered identifiers are not monotonic', () {
+      final road = _road(['第4话', '第3话', '第2话', '第5话']);
+
+      expect(
+        adjacentEpisodeSelections(
+          road: road,
+          current: const VideoEpisodeSelection(episode: 2, road: 0),
+        ).next,
+        const VideoEpisodeSelection(episode: 3, road: 0),
+      );
+    });
+
     test('ignores unnumbered entries when detecting descending order', () {
       final road = _road(['先导片', '第12话', '第11话']);
 


### PR DESCRIPTION
## 修改内容

- 根据剧集标题中的数字判断播放列表是正序还是逆序
- 优先识别“第 N 话/集”和 `EP/E` 格式，避免把分辨率、日期等前置数字误认为集数
- 仅在可识别编号严格单调递减时反转方向；混合或不明确的列表保持来源顺序
- “上一集 / 下一集”按时间顺序选择相邻剧集，不再固定使用列表索引加减一
- 系统媒体控制按钮的可用状态和播放完成后的自动连播使用同一算法
- 添加正序、逆序、前置质量数字、混合顺序、未编号条目和边界条件回归测试

## 问题原因

播放器原先假定所有来源都按第一集到最新一集的顺序返回数据，因此“下一集”固定使用 `episode + 1`。当来源按最新一集到第一集的逆序返回时，这个操作会跳到时间上的上一集；自动连播和系统媒体控制也存在相同问题。

现在会从明确的剧集编号判断线路是否严格逆序，再决定列表中的前进方向。该逻辑位于全平台共用播放器代码，可同时覆盖 Issue 报告的 Android 和 macOS 等平台。

Closes #2454

## 验证

- `flutter test --no-pub`（139 项测试通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`
- `dart format lib/pages/player/player_item.dart lib/pages/video/video_controller.dart test/episode_ref_test.dart`
- `git diff --check`