### PR TITLE
fix(danmaku): 启用新版搜索分词

### DIFF
--- a/lib/request/apis/danmaku_api.dart
+++ b/lib/request/apis/danmaku_api.dart
@@ -9,6 +9,13 @@ import 'package:kazumi/utils/string_similarity.dart';
 class DanmakuApi {
   static final DanmakuClient _client = DanmakuClient.instance;
 
+  static Map<String, String> buildAnimeSearchQuery(String title) {
+    return {
+      'keyword': title,
+      'v2': 'true',
+    };
+  }
+
   // 从BgmBangumiID获取DanDanBangumiID
   static Future<int> getDanDanBangumiIDByBgmBangumiID(int bgmBangumiID) async {
     var path = ApiEndpoints.formatUrl(
@@ -80,9 +87,7 @@ class DanmakuApi {
       String title) async {
     var path = ApiEndpoints.dandanAPISearch;
     var endPoint = ApiEndpoints.dandanAPIDomain + path;
-    Map<String, String> keywordMap = {
-      'keyword': title,
-    };
+    final keywordMap = buildAnimeSearchQuery(title);
 
     final jsonData = await _client.get(endPoint, queryParameters: keywordMap);
     DanmakuSearchResponse danmakuSearchResponse =

--- a/test/danmaku_api_test.dart
+++ b/test/danmaku_api_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/request/apis/danmaku_api.dart';
+
+void main() {
+  test('anime search opts into the v2 search engine', () {
+    expect(
+      DanmakuApi.buildAnimeSearchQuery('一拳超人 第三季'),
+      {
+        'keyword': '一拳超人 第三季',
+        'v2': 'true',
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 修改内容

- 在弹弹 Play 动画搜索请求中增加 `v2=true`
- 使用官方新版搜索引擎改善完整标题、简称和带季数标题的分词匹配
- 保留用户输入的原始关键词，不在客户端做截断或猜测
- 添加查询参数回归测试，防止后续遗漏新版搜索开关

## 问题原因

弹弹 Play 于 2026-07-13 为 `/api/v2/search/anime` 上线新版搜索引擎，并明确说明它具有更好的分词效果，但该接口目前仍需显式传入 `v2=true`。Kazumi 只发送了 `keyword`，因此仍在使用旧搜索逻辑，可能出现完整标题或简称无结果、缩短关键词后反而命中的情况。

官方变更说明：https://doc.dandanplay.com/open/changelog.html

Closes #2453

## 验证

- `flutter test --no-pub`（133 项测试通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`
- `dart format lib/request/apis/danmaku_api.dart test/danmaku_api_test.dart`
- `git diff --check`