### PR TITLE
fix(ui): 修复底栏“我的”图标状态

### DIFF
--- a/lib/pages/menu/menu.dart
+++ b/lib/pages/menu/menu.dart
@@ -7,6 +7,30 @@ import 'package:kazumi/navigation.dart';
 import 'package:kazumi/pages/menu/route_visibility.dart';
 import 'package:kazumi/pages/router.dart';
 
+@visibleForTesting
+const bottomMenuDestinations = <NavigationDestination>[
+  NavigationDestination(
+    selectedIcon: Icon(Icons.home),
+    icon: Icon(Icons.home_outlined),
+    label: '推荐',
+  ),
+  NavigationDestination(
+    selectedIcon: Icon(Icons.timeline),
+    icon: Icon(Icons.timeline_outlined),
+    label: '时间表',
+  ),
+  NavigationDestination(
+    selectedIcon: Icon(Icons.favorite),
+    icon: Icon(Icons.favorite_outlined),
+    label: '追番',
+  ),
+  NavigationDestination(
+    selectedIcon: Icon(Icons.settings),
+    icon: Icon(Icons.settings_outlined),
+    label: '我的',
+  ),
+];
+
 class ScaffoldMenu extends StatefulWidget {
   const ScaffoldMenu({super.key});
 
@@ -131,28 +155,7 @@ class _ScaffoldMenu extends State<ScaffoldMenu> with RouteAware {
     return Scaffold(
       body: _outlet(context),
       bottomNavigationBar: NavigationBar(
-        destinations: const <Widget>[
-          NavigationDestination(
-            selectedIcon: Icon(Icons.home),
-            icon: Icon(Icons.home_outlined),
-            label: '推荐',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.timeline),
-            icon: Icon(Icons.timeline_outlined),
-            label: '时间表',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.favorite),
-            icon: Icon(Icons.favorite_outlined),
-            label: '追番',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.settings),
-            icon: Icon(Icons.settings),
-            label: '我的',
-          ),
-        ],
+        destinations: bottomMenuDestinations,
         selectedIndex: selectedIndex,
         onDestinationSelected: _selectDestination,
       ),

--- a/test/menu_destination_test.dart
+++ b/test/menu_destination_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/pages/menu/menu.dart';
+
+void main() {
+  test('底栏图标在选中前后使用不同样式', () {
+    for (final destination in bottomMenuDestinations) {
+      final icon = destination.icon as Icon;
+      final selectedIcon = destination.selectedIcon as Icon;
+
+      expect(
+        icon.icon,
+        isNot(selectedIcon.icon),
+        reason: '${destination.label} 应使用不同的未选中与选中图标',
+      );
+    }
+
+    final settings = bottomMenuDestinations.last;
+    expect((settings.icon as Icon).icon, Icons.settings_outlined);
+    expect((settings.selectedIcon as Icon).icon, Icons.settings);
+  });
+}


### PR DESCRIPTION
## 描述

竖屏底部导航栏中，“我的”目的地原先在选中和未选中状态下都使用 `Icons.settings`，因此无法像其他目的地一样通过填充状态区分选中状态。

本 PR 将未选中图标改为 `Icons.settings_outlined`，选中时继续使用 `Icons.settings`，与横屏侧栏和其余底栏图标的表现保持一致。同时提取底栏目的地配置并添加回归测试，确保每个目的地的选中与未选中图标不同。

## 关联的 Issues

Closes #910

## PR 类型

- [x] Bug 修复
- [ ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [ ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [x] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: OpenAI GPT-5 Codex

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

验证结果：

- `flutter test --no-pub`（133 项测试通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无 warning/error；5 条仓库原有 info）
- `dart format --output=none --set-exit-if-changed test/menu_destination_test.dart`
- `git diff --check`
