### PR TITLE
fix(linux): 避免详情页文本布局导致崩溃

### DIFF
--- a/lib/bean/widget/expandable_selectable_text.dart
+++ b/lib/bean/widget/expandable_selectable_text.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+/// Selectable text that only offers expansion when its collapsed rendering
+/// actually exceeds [maxLines].
+///
+/// Overflow is read from the paragraph that Flutter already laid out for
+/// display. This avoids a second, manual [TextPainter] layout pass.
+class ExpandableSelectableText extends StatefulWidget {
+  const ExpandableSelectableText({
+    super.key,
+    required this.text,
+    this.maxLines = 7,
+    this.expandLabel = '加载更多',
+    this.collapseLabel = '加载更少',
+  }) : assert(maxLines > 0);
+
+  final String text;
+  final int maxLines;
+  final String expandLabel;
+  final String collapseLabel;
+
+  @override
+  State<ExpandableSelectableText> createState() =>
+      _ExpandableSelectableTextState();
+}
+
+class _ExpandableSelectableTextState extends State<ExpandableSelectableText> {
+  final GlobalKey _textKey = GlobalKey();
+  bool _expanded = false;
+  bool _canExpand = false;
+  bool _overflowCheckScheduled = false;
+
+  @override
+  void didUpdateWidget(ExpandableSelectableText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text ||
+        oldWidget.maxLines != widget.maxLines) {
+      _expanded = false;
+      _canExpand = false;
+    }
+  }
+
+  void _scheduleOverflowCheck() {
+    if (_expanded || _overflowCheckScheduled) return;
+    _overflowCheckScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _overflowCheckScheduled = false;
+      if (!mounted || _expanded) return;
+
+      final renderObject = _textKey.currentContext?.findRenderObject();
+      final paragraph = _findParagraph(renderObject);
+      if (paragraph == null) return;
+
+      final canExpand = paragraph.didExceedMaxLines;
+      if (canExpand != _canExpand) {
+        setState(() {
+          _canExpand = canExpand;
+        });
+      }
+    });
+  }
+
+  RenderParagraph? _findParagraph(RenderObject? renderObject) {
+    if (renderObject is RenderParagraph) return renderObject;
+    RenderParagraph? paragraph;
+    renderObject?.visitChildren((child) {
+      paragraph ??= _findParagraph(child);
+    });
+    return paragraph;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, _) {
+        _scheduleOverflowCheck();
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SelectionArea(
+              child: Text(
+                widget.text,
+                key: _textKey,
+                maxLines: _expanded ? null : widget.maxLines,
+                overflow: _expanded ? TextOverflow.visible : TextOverflow.clip,
+                textAlign: TextAlign.start,
+              ),
+            ),
+            if (_canExpand)
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _expanded = !_expanded;
+                    });
+                  },
+                  child: Text(
+                    _expanded ? widget.collapseLabel : widget.expandLabel,
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/info/info_tabview.dart
+++ b/lib/pages/info/info_tabview.dart
@@ -1,6 +1,6 @@
-import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:kazumi/bean/widget/expandable_selectable_text.dart';
 import 'package:kazumi/bean/widget/error_widget.dart';
 import 'package:kazumi/bean/card/comments_card.dart';
 import 'package:kazumi/bean/card/character_card.dart';
@@ -72,7 +72,6 @@ class InfoTabView extends StatefulWidget {
 class _InfoTabViewState extends State<InfoTabView>
     with SingleTickerProviderStateMixin {
   final maxWidth = 950.0;
-  bool fullIntro = false;
   bool fullTag = false;
 
   @override
@@ -109,53 +108,7 @@ class _InfoTabViewState extends State<InfoTabView>
             children: [
               Text('简介', style: TextStyle(fontSize: 18)),
               const SizedBox(height: 8),
-              // https://stackoverflow.com/questions/54091055/flutter-how-to-get-the-number-of-text-lines
-              // only show expand button when line > 7
-              LayoutBuilder(builder: (context, constraints) {
-                final span = TextSpan(text: widget.bangumiItem.summary);
-                final tp =
-                    TextPainter(text: span, textDirection: TextDirection.ltr);
-                tp.layout(maxWidth: constraints.maxWidth);
-                final numLines = tp.computeLineMetrics().length;
-                if (numLines > 7) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      SizedBox(
-                        // make intro expandable
-                        height: fullIntro ? null : 120,
-                        width: MediaQuery.sizeOf(context).width > maxWidth
-                            ? maxWidth
-                            : MediaQuery.sizeOf(context).width - 32,
-                        child: SelectableText(
-                          widget.bangumiItem.summary,
-                          textAlign: TextAlign.start,
-                          scrollBehavior: const ScrollBehavior().copyWith(
-                            scrollbars: false,
-                          ),
-                          scrollPhysics: NeverScrollableScrollPhysics(),
-                          selectionHeightStyle: ui.BoxHeightStyle.max,
-                        ),
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          setState(() {
-                            fullIntro = !fullIntro;
-                          });
-                        },
-                        child: Text(fullIntro ? '加载更少' : '加载更多'),
-                      ),
-                    ],
-                  );
-                } else {
-                  return SelectableText(
-                    widget.bangumiItem.summary,
-                    textAlign: TextAlign.start,
-                    scrollPhysics: NeverScrollableScrollPhysics(),
-                    selectionHeightStyle: ui.BoxHeightStyle.max,
-                  );
-                }
-              }),
+              ExpandableSelectableText(text: widget.bangumiItem.summary),
               const SizedBox(height: 16),
               Text('标签', style: TextStyle(fontSize: 18)),
               const SizedBox(height: 8),

--- a/test/expandable_selectable_text_test.dart
+++ b/test/expandable_selectable_text_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/widget/expandable_selectable_text.dart';
+
+void main() {
+  Widget buildSubject(String text, {double width = 320}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: width,
+            child: ExpandableSelectableText(text: text),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('short text stays selectable without expansion controls', (
+    tester,
+  ) async {
+    const summary = '简短简介';
+
+    await tester.pumpWidget(buildSubject(summary));
+    await tester.pump();
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(find.text('加载更多'), findsNothing);
+    expect(find.text('加载更少'), findsNothing);
+    expect(tester.widget<Text>(find.text(summary)).maxLines, 7);
+  });
+
+  testWidgets('long text can expand and collapse after its display layout', (
+    tester,
+  ) async {
+    final summary = List.filled(16, '这是一段需要折叠的番剧简介。').join();
+
+    await tester.pumpWidget(buildSubject(summary, width: 220));
+    await tester.pump();
+
+    expect(find.text('加载更多'), findsOneWidget);
+    expect(tester.widget<Text>(find.text(summary)).maxLines, 7);
+
+    await tester.tap(find.text('加载更多'));
+    await tester.pump();
+
+    expect(find.text('加载更少'), findsOneWidget);
+    expect(tester.widget<Text>(find.text(summary)).maxLines, isNull);
+
+    await tester.tap(find.text('加载更少'));
+    await tester.pump();
+
+    expect(find.text('加载更多'), findsOneWidget);
+    expect(tester.widget<Text>(find.text(summary)).maxLines, 7);
+  });
+
+  testWidgets('expansion control follows the actual available width', (
+    tester,
+  ) async {
+    final summary = List.filled(8, '番剧简介内容。').join();
+
+    await tester.pumpWidget(buildSubject(summary, width: 100));
+    await tester.pump();
+    expect(find.text('加载更多'), findsOneWidget);
+
+    await tester.pumpWidget(buildSubject(summary, width: 700));
+    await tester.pump();
+    expect(find.text('加载更多'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 描述

- 移除详情页为判断简介行数而额外执行的 `TextPainter.layout()`
- 直接读取实际显示段落的 `didExceedMaxLines`，只在内容确实超过 7 行时显示展开按钮
- 保留文本选择、展开/收起及窗口宽度变化后的状态更新
- 添加短简介、长简介展开/收起和宽度变化的 widget 回归测试

#558 与 #673 的崩溃都发生在 Linux 番剧详情页。#673 中的源码调试结果将触发点定位到简介区域额外执行的 `TextPainter.layout()`；移除该测量块后不再崩溃。

本 PR 不再为判断行数创建第二次同步文本布局，而是在 Flutter 完成实际显示布局后读取 `RenderParagraph.didExceedMaxLines`。这样可以规避特定 Linux 图形设备/驱动上的文本布局竞态，同时保留原有交互。

## 关联的 Issues

Closes #558
Closes #673

## PR 类型

- [x] Bug 修复
- [ ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [x] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: OpenAI GPT-5

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

验证结果：

- `flutter test test/expandable_selectable_text_test.dart`（3 项通过）
- `flutter test --no-pub`（135 项通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无 error/warning，保留 5 条既有 info）
- `dart format --output=none --set-exit-if-changed lib/bean/widget/expandable_selectable_text.dart test/expandable_selectable_text_test.dart`
- `git diff --check`

该崩溃依赖特定 Linux 图形设备与驱动，本地无法直接复现；修复依据为 #673 中报告者定位出的稳定触发路径。