### PR TITLE
fix(info): 刷新收藏番剧的评分数据

### DIFF
--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -111,11 +111,22 @@ abstract class _InfoController with Store {
     }
   }
 
-  Future<void> refreshBangumiInfoByID(int id) async {
-    await _updateBangumiInfoByID(id, type: "update");
+  Future<void> refreshBangumiInfoByID(
+    int id, {
+    bool preserveInterestWhenMissing = false,
+  }) async {
+    await _updateBangumiInfoByID(
+      id,
+      type: "update",
+      preserveInterestWhenMissing: preserveInterestWhenMissing,
+    );
   }
 
-  Future<void> _updateBangumiInfoByID(int id, {required String type}) async {
+  Future<void> _updateBangumiInfoByID(
+    int id, {
+    required String type,
+    bool preserveInterestWhenMissing = false,
+  }) async {
     final value = await _bangumiInfoLoader(id);
     if (value == null || bangumiItem.id != id) {
       return;
@@ -135,7 +146,9 @@ abstract class _InfoController with Store {
       final incomingInterest = value.interest;
       final previousInterest = bangumiItem.interest;
       if (incomingInterest == null) {
-        bangumiItem.interest = null;
+        if (!preserveInterestWhenMissing) {
+          bangumiItem.interest = null;
+        }
       } else if (previousInterest == null || !previousInterest.hasUserProfile) {
         bangumiItem.interest = incomingInterest;
       } else {

--- a/lib/pages/info/info_controller.dart
+++ b/lib/pages/info/info_controller.dart
@@ -16,10 +16,15 @@ part 'info_controller.g.dart';
 
 class InfoController = _InfoController with _$InfoController;
 
+typedef BangumiInfoLoader = Future<BangumiItem?> Function(int id);
+
 abstract class _InfoController with Store {
-  _InfoController(this.collectController);
+  _InfoController(this.collectController, {BangumiInfoLoader? bangumiInfoLoader})
+      : _bangumiInfoLoader =
+            bangumiInfoLoader ?? BangumiApi.getBangumiInfoByID;
 
   final CollectController collectController;
+  final BangumiInfoLoader _bangumiInfoLoader;
   late BangumiItem bangumiItem;
 
   @observable
@@ -111,8 +116,8 @@ abstract class _InfoController with Store {
   }
 
   Future<void> _updateBangumiInfoByID(int id, {required String type}) async {
-    final value = await BangumiApi.getBangumiInfoByID(id);
-    if (value == null) {
+    final value = await _bangumiInfoLoader(id);
+    if (value == null || bangumiItem.id != id) {
       return;
     }
     if (type == "init") {

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 import 'package:kazumi/bean/dialog/adaptive_bottom_sheet.dart';
@@ -72,7 +73,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
   bool get _isShowingBangumiInfoSkeleton =>
       infoController.isLoading || _showBangumiInfoSkeleton;
 
-  bool _needsBangumiInfoRefresh(BangumiItem bangumiItem) {
+  bool _needsBangumiInfoSkeleton(BangumiItem bangumiItem) {
     final votesCount = bangumiItem.votesCount;
     final missingVoteDistribution =
         votesCount.isEmpty || bangumiItem.votes <= 0 || votesCount.length < 10;
@@ -215,15 +216,20 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     infoController.staffList.clear();
     infoController.clearRelations();
     infoController.pluginSearchResponseList.clear();
-    // Search results can miss rating distribution or summaries, so fill those
-    // fields without replacing image URLs that are already rendered.
-    if (_needsBangumiInfoRefresh(infoController.bangumiItem)) {
+    // Refresh only the detail page the user opened. Incomplete search results
+    // keep the loading skeleton, while complete cached entries stay visible
+    // until their current rating and vote count arrive.
+    if (_needsBangumiInfoSkeleton(infoController.bangumiItem)) {
       _showBangumiInfoSkeleton = true;
-      queryBangumiInfoByID(
-        infoController.bangumiItem.id,
-        type: 'attach',
-        enforceMinimumLoadingDuration: true,
+      unawaited(
+        queryBangumiInfoByID(
+          infoController.bangumiItem.id,
+          type: 'attach',
+          enforceMinimumLoadingDuration: true,
+        ),
       );
+    } else {
+      unawaited(_refreshBangumiInfoSilently(infoController.bangumiItem.id));
     }
     infoTabController = TabController(length: _infoTabs.length, vsync: this);
     _fabTabIndex = infoTabController.index;
@@ -325,6 +331,20 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
           _showBangumiInfoSkeleton = false;
         });
       }
+    }
+  }
+
+  Future<void> _refreshBangumiInfoSilently(int id) async {
+    try {
+      await infoController.refreshBangumiInfoByID(id);
+      if (mounted) {
+        setState(() {});
+      }
+    } catch (e) {
+      KazumiLogger().e(
+        'InfoPage: failed to refresh cached bangumi info',
+        error: e,
+      );
     }
   }
 

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:kazumi/bean/dialog/adaptive_bottom_sheet.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/pages/info/rating_review_dialog.dart';
+import 'package:kazumi/request/clients/bangumi_client.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:kazumi/bean/widget/collect_button.dart';
@@ -338,7 +339,8 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     try {
       await infoController.refreshBangumiInfoByID(
         id,
-        preserveInterestWhenMissing: true,
+        preserveInterestWhenMissing:
+            !BangumiClient.requestWillIncludeAuthorization(),
       );
       if (mounted) {
         setState(() {});

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -336,7 +336,10 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
 
   Future<void> _refreshBangumiInfoSilently(int id) async {
     try {
-      await infoController.refreshBangumiInfoByID(id);
+      await infoController.refreshBangumiInfoByID(
+        id,
+        preserveInterestWhenMissing: true,
+      );
       if (mounted) {
         setState(() {});
       }

--- a/lib/request/clients/bangumi_client.dart
+++ b/lib/request/clients/bangumi_client.dart
@@ -13,6 +13,13 @@ class BangumiClient {
 
   static final BangumiClient instance = BangumiClient._();
 
+  static bool requestWillIncludeAuthorization({bool requiresAuth = false}) {
+    final bangumiSyncEnable =
+        GStorage.getSetting(SettingsKeys.bangumiSyncEnable);
+    final token = GStorage.getSetting(SettingsKeys.bangumiAccessToken).trim();
+    return (requiresAuth || bangumiSyncEnable) && token.isNotEmpty;
+  }
+
   Future<dynamic> get(
     String url, {
     Map<String, dynamic>? queryParameters,
@@ -73,10 +80,8 @@ class BangumiClient {
     Object? data,
   }) {
     final headers = <String, dynamic>{...bangumiHTTPHeader};
-    final bangumiSyncEnable =
-        GStorage.getSetting(SettingsKeys.bangumiSyncEnable);
     final token = GStorage.getSetting(SettingsKeys.bangumiAccessToken).trim();
-    if ((requiresAuth || bangumiSyncEnable) && token.isNotEmpty) {
+    if (requestWillIncludeAuthorization(requiresAuth: requiresAuth)) {
       headers['Authorization'] = 'Bearer $token';
     }
     if (_shouldSignProtectedMirrorRequest(url, method)) {

--- a/test/info_controller_test.dart
+++ b/test/info_controller_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_change_module.dart';
+import 'package:kazumi/modules/collect/collect_module.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/pages/collect/collect_controller.dart';
+import 'package:kazumi/pages/info/info_controller.dart';
+import 'package:kazumi/repositories/collect_crud_repository.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+
+void main() {
+  group('InfoController rating refresh', () {
+    test(
+      'refreshes complete cached ratings and persists the collectible',
+      () async {
+        final cached = _bangumiItem(
+          ratingScore: 7.1,
+          votes: 120,
+          votesCount: List<int>.filled(10, 12),
+        );
+        final current = _bangumiItem(
+          ratingScore: 8.3,
+          votes: 1250,
+          votesCount: List<int>.generate(10, (index) => index + 20),
+        );
+        final crudRepository = _FakeCollectCrudRepository(cached);
+        final collectController = CollectController(
+          crudRepository,
+          _FakeCollectRepository(),
+        )..loadCollectibles();
+        final requestedIds = <int>[];
+        final controller = InfoController(
+          collectController,
+          bangumiInfoLoader: (id) async {
+            requestedIds.add(id);
+            return current;
+          },
+        )..bangumiItem = cached;
+
+        await controller.refreshBangumiInfoByID(cached.id);
+
+        expect(requestedIds, [cached.id]);
+        expect(controller.bangumiItem.ratingScore, 8.3);
+        expect(controller.bangumiItem.votes, 1250);
+        expect(
+          controller.bangumiItem.votesCount,
+          List<int>.generate(10, (index) => index + 20),
+        );
+        expect(crudRepository.updateCount, 1);
+        expect(
+          crudRepository.getCollectible(cached.id)!.bangumiItem.ratingScore,
+          8.3,
+        );
+        expect(collectController.collectibles.single.bangumiItem.votes, 1250);
+      },
+    );
+
+    test(
+      'keeps cached ratings when the detail request has no result',
+      () async {
+        final cached = _bangumiItem(
+          ratingScore: 7.1,
+          votes: 120,
+          votesCount: List<int>.filled(10, 12),
+        );
+        final crudRepository = _FakeCollectCrudRepository(cached);
+        final collectController = CollectController(
+          crudRepository,
+          _FakeCollectRepository(),
+        );
+        final controller = InfoController(
+          collectController,
+          bangumiInfoLoader: (_) async => null,
+        )..bangumiItem = cached;
+
+        await controller.refreshBangumiInfoByID(cached.id);
+
+        expect(controller.bangumiItem.ratingScore, 7.1);
+        expect(controller.bangumiItem.votes, 120);
+        expect(crudRepository.updateCount, 0);
+      },
+    );
+
+    test(
+      'ignores a response for a detail page that is no longer active',
+      () async {
+        final first = _bangumiItem(id: 1872, ratingScore: 7.1, votes: 120);
+        final second = _bangumiItem(id: 2000, ratingScore: 6.5, votes: 80);
+        final current = _bangumiItem(id: 1872, ratingScore: 8.3, votes: 1250);
+        final crudRepository = _FakeCollectCrudRepository(first);
+        final collectController = CollectController(
+          crudRepository,
+          _FakeCollectRepository(),
+        );
+        final controller = InfoController(
+          collectController,
+          bangumiInfoLoader: (_) async => current,
+        )..bangumiItem = first;
+
+        controller.bangumiItem = second;
+        await controller.refreshBangumiInfoByID(first.id);
+
+        expect(controller.bangumiItem.id, second.id);
+        expect(controller.bangumiItem.ratingScore, 6.5);
+        expect(crudRepository.updateCount, 0);
+      },
+    );
+  });
+}
+
+BangumiItem _bangumiItem({
+  int id = 1872,
+  double ratingScore = 7.0,
+  int votes = 100,
+  List<int>? votesCount,
+}) {
+  return BangumiItem(
+    id: id,
+    type: 2,
+    name: 'Test Anime',
+    nameCn: '测试动画',
+    summary: 'summary',
+    airDate: '2026-01-01',
+    airWeekday: 4,
+    rank: 100,
+    images: const <String, String>{},
+    tags: const [],
+    alias: const [],
+    ratingScore: ratingScore,
+    votes: votes,
+    votesCount: votesCount ?? List<int>.filled(10, 10),
+    info: '',
+  );
+}
+
+class _FakeCollectCrudRepository implements ICollectCrudRepository {
+  _FakeCollectCrudRepository(BangumiItem item) {
+    collectibles[item.id] = CollectedBangumi(item, DateTime(2026), 1);
+  }
+
+  final Map<int, CollectedBangumi> collectibles = {};
+  int updateCount = 0;
+
+  @override
+  Stream<void> get changes => const Stream<void>.empty();
+
+  @override
+  Future<void> addCollectChange(CollectedBangumiChange change) async {}
+
+  @override
+  Future<void> addCollectible(BangumiItem bangumiItem, int type) async {
+    collectibles[bangumiItem.id] = CollectedBangumi(
+      bangumiItem,
+      DateTime(2026),
+      type,
+    );
+  }
+
+  @override
+  Future<void> clearFavorites() async {}
+
+  @override
+  Future<void> deleteCollectible(int id) async {
+    collectibles.remove(id);
+  }
+
+  @override
+  List<CollectedBangumi> getAllCollectibles() => collectibles.values.toList();
+
+  @override
+  CollectedBangumi? getCollectible(int id) => collectibles[id];
+
+  @override
+  int getCollectType(int id) => collectibles[id]?.type ?? 0;
+
+  @override
+  List<BangumiItem> getFavorites() => const [];
+
+  @override
+  Future<void> updateCollectible(BangumiItem bangumiItem) async {
+    final collectible = collectibles[bangumiItem.id];
+    if (collectible == null) {
+      return;
+    }
+    updateCount++;
+    collectible.bangumiItem = bangumiItem;
+  }
+}
+
+class _FakeCollectRepository implements ICollectRepository {
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) => const {};
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => const {};
+
+  @override
+  bool getPrivateMode() => false;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}

--- a/test/info_controller_test.dart
+++ b/test/info_controller_test.dart
@@ -104,7 +104,7 @@ void main() {
     );
 
     test(
-      'preserves a local review when a silent response omits interest',
+      'preserves a local review when an anonymous response omits interest',
       () async {
         final cached = _bangumiItem(
           ratingScore: 7.1,
@@ -147,6 +147,45 @@ void main() {
         expect(
           crudRepository.getCollectible(cached.id)!.bangumiItem.interest?.rate,
           8,
+        );
+      },
+    );
+
+    test(
+      'clears a local review when an authenticated response omits interest',
+      () async {
+        final cached = _bangumiItem(
+          ratingScore: 7.1,
+          votes: 120,
+          interest: BangumiInterest(
+            id: 1,
+            rate: 8,
+            type: 1,
+            comment: '已在远端删除的评价',
+            tags: const ['推荐'],
+            epStatus: 0,
+            volStatus: 0,
+            updatedAt: 1,
+          ),
+        );
+        final current = _bangumiItem(ratingScore: 8.3, votes: 1250);
+        final crudRepository = _FakeCollectCrudRepository(cached);
+        final collectController = CollectController(
+          crudRepository,
+          _FakeCollectRepository(),
+        );
+        final controller = InfoController(
+          collectController,
+          bangumiInfoLoader: (_) async => current,
+        )..bangumiItem = cached;
+
+        await controller.refreshBangumiInfoByID(cached.id);
+
+        expect(controller.bangumiItem.ratingScore, 8.3);
+        expect(controller.bangumiItem.interest, isNull);
+        expect(
+          crudRepository.getCollectible(cached.id)!.bangumiItem.interest,
+          isNull,
         );
       },
     );

--- a/test/info_controller_test.dart
+++ b/test/info_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:kazumi/modules/bangumi/bangumi_interest.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/collect/collect_change_module.dart';
 import 'package:kazumi/modules/collect/collect_module.dart';
@@ -10,6 +12,26 @@ import 'package:kazumi/repositories/collect_repository.dart';
 
 void main() {
   group('InfoController rating refresh', () {
+    test('constructs through modular DI with the optional test loader omitted',
+        () {
+      final cached = _bangumiItem();
+      final collectController = CollectController(
+        _FakeCollectCrudRepository(cached),
+        _FakeCollectRepository(),
+      );
+      final module = createModule(
+        register: (context) {
+          context
+            ..addInstance<CollectController>(collectController)
+            ..add<InfoController>(InfoController.new);
+        },
+      );
+
+      final controller = bootstrapModule(module).injector.get<InfoController>();
+
+      expect(controller.collectController, same(collectController));
+    });
+
     test(
       'refreshes complete cached ratings and persists the collectible',
       () async {
@@ -82,6 +104,54 @@ void main() {
     );
 
     test(
+      'preserves a local review when a silent response omits interest',
+      () async {
+        final cached = _bangumiItem(
+          ratingScore: 7.1,
+          votes: 120,
+          votesCount: List<int>.filled(10, 12),
+          interest: BangumiInterest(
+            id: 1,
+            rate: 8,
+            type: 1,
+            comment: '我的评价',
+            tags: const ['推荐'],
+            epStatus: 0,
+            volStatus: 0,
+            updatedAt: 1,
+          ),
+        );
+        final current = _bangumiItem(
+          ratingScore: 8.3,
+          votes: 1250,
+          votesCount: List<int>.generate(10, (index) => index + 20),
+        );
+        final crudRepository = _FakeCollectCrudRepository(cached);
+        final collectController = CollectController(
+          crudRepository,
+          _FakeCollectRepository(),
+        );
+        final controller = InfoController(
+          collectController,
+          bangumiInfoLoader: (_) async => current,
+        )..bangumiItem = cached;
+
+        await controller.refreshBangumiInfoByID(
+          cached.id,
+          preserveInterestWhenMissing: true,
+        );
+
+        expect(controller.bangumiItem.ratingScore, 8.3);
+        expect(controller.bangumiItem.interest?.rate, 8);
+        expect(controller.bangumiItem.interest?.comment, '我的评价');
+        expect(
+          crudRepository.getCollectible(cached.id)!.bangumiItem.interest?.rate,
+          8,
+        );
+      },
+    );
+
+    test(
       'ignores a response for a detail page that is no longer active',
       () async {
         final first = _bangumiItem(id: 1872, ratingScore: 7.1, votes: 120);
@@ -113,6 +183,7 @@ BangumiItem _bangumiItem({
   double ratingScore = 7.0,
   int votes = 100,
   List<int>? votesCount,
+  BangumiInterest? interest,
 }) {
   return BangumiItem(
     id: id,
@@ -130,6 +201,7 @@ BangumiItem _bangumiItem({
     votes: votes,
     votesCount: votesCount ?? List<int>.filled(10, 10),
     info: '',
+    interest: interest,
   );
 }
 


### PR DESCRIPTION
## 修复内容

- 打开番剧详情页时，后台刷新当前条目的评分、评分人数和评分分布。
- 已有完整缓存继续立即展示，不因后台刷新切换到加载骨架。
- 刷新结果同步写回本地收藏，收藏页后续会显示最新数据。
- 仅请求用户当前打开的单个详情，不批量刷新整个收藏列表。
- 忽略已离开详情页的过期响应，避免旧请求覆盖新页面。
- 匿名详情响应缺少 `interest` 时保留本地评价；认证响应缺少时按远端状态清除。

## 根因

详情页此前只会在简介缺失、评分人数为 0 或评分分布不完整时补充请求。已经包含完整评分数据的收藏条目即使长期过期，也不会再次请求详情，因此评分和评分人数会一直停留在收藏时的快照。

## 验证

- [x] `flutter test test/info_controller_test.dart`（6 项）
- [x] `flutter test`（138 项）
- [x] `flutter analyze --no-fatal-infos --fatal-warnings`（通过，仅有 5 条既有 info）
- [x] `dart format --output=none --set-exit-if-changed test/info_controller_test.dart`
- [x] `git diff --check`

Closes #1872
