### PR TITLE
fix(sync): 防止不完整 WebDAV 备份清空收藏

### DIFF
--- a/lib/pages/collect/collect_controller.dart
+++ b/lib/pages/collect/collect_controller.dart
@@ -250,6 +250,13 @@ abstract class _CollectController with Store {
         KazumiDialog.showToast(message: 'WebDav同步完成');
       }
     } on IncompleteWebDavCollectiblesBackupException {
+      if (GStorage.collectibles.isEmpty) {
+        KazumiDialog.showToast(
+          message: '远端收藏备份不完整，当前设备没有本地收藏，无法安全修复',
+          duration: const Duration(seconds: 5),
+        );
+        return false;
+      }
       return _offerWebDavCollectiblesRepair(
         showSuccessToast: showSuccessToast,
       );
@@ -264,14 +271,16 @@ abstract class _CollectController with Store {
   Future<bool> _offerWebDavCollectiblesRepair({
     required bool showSuccessToast,
   }) async {
+    final localCollectiblesCount = GStorage.collectibles.length;
     final shouldRepair = await KazumiDialog.show<bool>(
       clickMaskDismiss: false,
       builder: (context) => AlertDialog(
         title: const Text('WebDav 收藏备份不完整'),
-        content: const Text(
+        content: Text(
           '远端变更记录存在，但完整收藏快照缺失。'
           '为避免清空本地数据，本次同步已停止。\n\n'
-          '如果当前设备的收藏是完整的，可以用它重建远端备份。'
+          '当前设备有 $localCollectiblesCount 条本地收藏。'
+          '如果这些收藏是完整的，可以用它们重建远端备份。'
           '这会覆盖其他设备尚未同步的收藏变更。',
         ),
         actions: [
@@ -289,9 +298,16 @@ abstract class _CollectController with Store {
     if (shouldRepair != true) {
       return false;
     }
-    return uploadCollectiblesToWebDav(
-      showSuccessToast: showSuccessToast,
-    );
+    try {
+      await WebDav().repairCollectiblesFromLocal();
+      if (showSuccessToast) {
+        KazumiDialog.showToast(message: 'WebDav 收藏备份已使用本地数据修复');
+      }
+      return true;
+    } catch (e) {
+      KazumiDialog.showToast(message: 'WebDav 收藏备份修复失败 $e');
+      return false;
+    }
   }
 
   /// Only upload local collectibles and change logs to WebDAV, without downloading and merging.

--- a/lib/pages/collect/collect_controller.dart
+++ b/lib/pages/collect/collect_controller.dart
@@ -249,12 +249,49 @@ abstract class _CollectController with Store {
       if (showSuccessToast) {
         KazumiDialog.showToast(message: 'WebDav同步完成');
       }
+    } on IncompleteWebDavCollectiblesBackupException {
+      return _offerWebDavCollectiblesRepair(
+        showSuccessToast: showSuccessToast,
+      );
     } catch (e) {
       KazumiDialog.showToast(message: 'WebDav同步失败 $e');
       return false;
     }
     loadCollectibles();
     return true;
+  }
+
+  Future<bool> _offerWebDavCollectiblesRepair({
+    required bool showSuccessToast,
+  }) async {
+    final shouldRepair = await KazumiDialog.show<bool>(
+      clickMaskDismiss: false,
+      builder: (context) => AlertDialog(
+        title: const Text('WebDav 收藏备份不完整'),
+        content: const Text(
+          '远端变更记录存在，但完整收藏快照缺失。'
+          '为避免清空本地数据，本次同步已停止。\n\n'
+          '如果当前设备的收藏是完整的，可以用它重建远端备份。'
+          '这会覆盖其他设备尚未同步的收藏变更。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('使用本地收藏修复'),
+          ),
+        ],
+      ),
+    );
+    if (shouldRepair != true) {
+      return false;
+    }
+    return uploadCollectiblesToWebDav(
+      showSuccessToast: showSuccessToast,
+    );
   }
 
   /// Only upload local collectibles and change logs to WebDAV, without downloading and merging.

--- a/lib/pages/collect/collect_controller.dart
+++ b/lib/pages/collect/collect_controller.dart
@@ -299,7 +299,15 @@ abstract class _CollectController with Store {
       return false;
     }
     try {
-      await WebDav().repairCollectiblesFromLocal();
+      final result = await WebDav().repairCollectiblesFromLocal();
+      if (result == WebDavCollectiblesRepairResult.remoteStateChanged) {
+        await WebDav().syncCollectibles();
+        loadCollectibles();
+        if (showSuccessToast) {
+          KazumiDialog.showToast(message: '远端收藏备份已恢复，已重新同步');
+        }
+        return true;
+      }
       if (showSuccessToast) {
         KazumiDialog.showToast(message: 'WebDav 收藏备份已使用本地数据修复');
       }

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -11,11 +11,21 @@ import 'package:kazumi/services/sync/webdav_remote_file_commit.dart';
 import 'package:kazumi/utils/async_serial_queue.dart';
 import 'package:kazumi/utils/async_single_flight.dart';
 
+class IncompleteWebDavCollectiblesBackupException implements Exception {
+  const IncompleteWebDavCollectiblesBackupException();
+
+  @override
+  String toString() => '远端收藏备份不完整，本地收藏未修改';
+}
+
 class WebDav {
   static const String _syncRootPath = '/kazumiSync';
   static const String _historyRootPath = '$_syncRootPath/history';
   static const String _historyChangesPath = '$_historyRootPath/changes';
   static const String _historySnapshotPath = '$_historyRootPath/snapshot.json';
+  static const int _collectiblesRemoteStateReadAttempts = 3;
+  static const Duration _collectiblesRemoteStateRetryDelay =
+      Duration(milliseconds: 250);
 
   late String webDavURL;
   late String webDavUsername;
@@ -129,7 +139,7 @@ class WebDav {
     List<CollectedBangumi> remoteCollectibles = [];
     List<CollectedBangumiChange> remoteChanges = [];
 
-    final files = await client.readDir(_syncRootPath);
+    final files = await _readCollectiblesRemoteFiles();
     final collectiblesExists =
         files.any((file) => file.name == 'collectibles.tmp');
     final changesExists =
@@ -138,7 +148,7 @@ class WebDav {
       KazumiLogger().w(
         'WebDav: collectibles snapshot missing while change log exists',
       );
-      throw StateError('WebDav: incomplete collectibles backup');
+      throw const IncompleteWebDavCollectiblesBackupException();
     }
     if (!collectiblesExists && !changesExists) {
       await _updateBox('collectibles');
@@ -184,6 +194,26 @@ class WebDav {
     if (GStorage.collectChanges.isNotEmpty) {
       await _updateBox('collectchanges');
     }
+  }
+
+  Future<List<webdav.File>> _readCollectiblesRemoteFiles() async {
+    late List<webdav.File> files;
+    for (var attempt = 0;
+        attempt < _collectiblesRemoteStateReadAttempts;
+        attempt++) {
+      files = await client.readDir(_syncRootPath);
+      final collectiblesExists =
+          files.any((file) => file.name == 'collectibles.tmp');
+      final changesExists =
+          files.any((file) => file.name == 'collectchanges.tmp');
+      if (!changesExists || collectiblesExists) {
+        return files;
+      }
+      if (attempt < _collectiblesRemoteStateReadAttempts - 1) {
+        await Future<void>.delayed(_collectiblesRemoteStateRetryDelay);
+      }
+    }
+    return files;
   }
 
   Future<void> _syncHistory() async {

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -18,6 +18,13 @@ class IncompleteWebDavCollectiblesBackupException implements Exception {
   String toString() => '远端收藏备份不完整，本地收藏未修改';
 }
 
+class EmptyLocalCollectiblesRepairException implements Exception {
+  const EmptyLocalCollectiblesRepairException();
+
+  @override
+  String toString() => '当前设备没有可用于修复的本地收藏';
+}
+
 class WebDav {
   static const String _syncRootPath = '/kazumiSync';
   static const String _historyRootPath = '$_syncRootPath/history';
@@ -118,6 +125,25 @@ class WebDav {
       });
     } catch (e) {
       KazumiLogger().e('WebDav: update collectibles failed', error: e);
+      rethrow;
+    }
+  }
+
+  Future<void> repairCollectiblesFromLocal() async {
+    try {
+      await _runWebDavExclusive(() async {
+        if (GStorage.collectibles.isEmpty) {
+          throw const EmptyLocalCollectiblesRepairException();
+        }
+        // Repair establishes one consistent local baseline. Always replace the
+        // orphaned remote log, including when the local log is intentionally
+        // empty, before publishing the snapshot. If publishing is interrupted,
+        // the missing-snapshot guard remains active until repair is retried.
+        await _updateBox('collectchanges');
+        await _updateBox('collectibles');
+      });
+    } catch (e) {
+      KazumiLogger().e('WebDav: repair collectibles failed', error: e);
       rethrow;
     }
   }

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -25,6 +25,11 @@ class EmptyLocalCollectiblesRepairException implements Exception {
   String toString() => '当前设备没有可用于修复的本地收藏';
 }
 
+enum WebDavCollectiblesRepairResult {
+  repaired,
+  remoteStateChanged,
+}
+
 class WebDav {
   static const String _syncRootPath = '/kazumiSync';
   static const String _historyRootPath = '$_syncRootPath/history';
@@ -129,9 +134,19 @@ class WebDav {
     }
   }
 
-  Future<void> repairCollectiblesFromLocal() async {
+  Future<WebDavCollectiblesRepairResult> repairCollectiblesFromLocal() async {
     try {
-      await _runWebDavExclusive(() async {
+      return await _runWebDavExclusive(() async {
+        // The confirmation dialog can stay open indefinitely. Check the
+        // remote state again under the operation queue before overwriting it.
+        final files = await _readCollectiblesRemoteFiles();
+        final collectiblesExists =
+            files.any((file) => file.name == 'collectibles.tmp');
+        final changesExists =
+            files.any((file) => file.name == 'collectchanges.tmp');
+        if (collectiblesExists || !changesExists) {
+          return WebDavCollectiblesRepairResult.remoteStateChanged;
+        }
         if (GStorage.collectibles.isEmpty) {
           throw const EmptyLocalCollectiblesRepairException();
         }
@@ -141,6 +156,7 @@ class WebDav {
         // the missing-snapshot guard remains active until repair is retried.
         await _updateBox('collectchanges');
         await _updateBox('collectibles');
+        return WebDavCollectiblesRepairResult.repaired;
       });
     } catch (e) {
       KazumiLogger().e('WebDav: repair collectibles failed', error: e);

--- a/lib/services/sync/webdav.dart
+++ b/lib/services/sync/webdav.dart
@@ -134,6 +134,12 @@ class WebDav {
         files.any((file) => file.name == 'collectibles.tmp');
     final changesExists =
         files.any((file) => file.name == 'collectchanges.tmp');
+    if (changesExists && !collectiblesExists) {
+      KazumiLogger().w(
+        'WebDav: collectibles snapshot missing while change log exists',
+      );
+      throw StateError('WebDav: incomplete collectibles backup');
+    }
     if (!collectiblesExists && !changesExists) {
       await _updateBox('collectibles');
       if (GStorage.collectChanges.isNotEmpty) {

--- a/test/webdav_collectibles_sync_test.dart
+++ b/test/webdav_collectibles_sync_test.dart
@@ -91,7 +91,8 @@ void main() {
     await box.putAll(values);
     await box.flush();
     await box.close();
-    return File('${hiveDirectory.path}/$name.hive').readAsBytes();
+    return File('${hiveDirectory.path}/${name.toLowerCase()}.hive')
+        .readAsBytes();
   }
 
   Future<void> putLocalCollectible({bool withAddChange = false}) async {

--- a/test/webdav_collectibles_sync_test.dart
+++ b/test/webdav_collectibles_sync_test.dart
@@ -1,0 +1,301 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:kazumi/hive_registrar.g.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/bangumi/bangumi_tag.dart';
+import 'package:kazumi/modules/collect/collect_change_module.dart';
+import 'package:kazumi/modules/collect/collect_module.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/services/storage/storage.dart';
+import 'package:kazumi/services/sync/webdav.dart';
+import 'package:webdav_client/webdav_client.dart' as webdav;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory supportDirectory;
+  late Directory hiveDirectory;
+  late Directory webDavTempDirectory;
+  late Box<CollectedBangumi> collectiblesBox;
+  late Box<CollectedBangumiChange> changesBox;
+  late _FakeWebDavClient fakeClient;
+  late WebDav webDavSync;
+  var remoteBoxId = 0;
+
+  setUpAll(() async {
+    supportDirectory =
+        await Directory.systemTemp.createTemp('kazumi_webdav_collectibles_');
+    hiveDirectory = Directory('${supportDirectory.path}/hive');
+    webDavTempDirectory = Directory('${supportDirectory.path}/webdavTemp');
+    await hiveDirectory.create(recursive: true);
+    await webDavTempDirectory.create(recursive: true);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+      if (call.method == 'getApplicationSupportDirectory') {
+        return supportDirectory.path;
+      }
+      return null;
+    });
+
+    Hive.init(hiveDirectory.path);
+    Hive.registerAdapters();
+    collectiblesBox = await Hive.openBox<CollectedBangumi>('collectibles');
+    changesBox = await Hive.openBox<CollectedBangumiChange>('collectchanges');
+    GStorage.collectibles = collectiblesBox;
+    GStorage.collectChanges = changesBox;
+
+    fakeClient = _FakeWebDavClient();
+    webDavSync = WebDav()
+      ..client = fakeClient
+      ..webDavLocalTempDirectory = webDavTempDirectory;
+  });
+
+  setUp(() async {
+    await collectiblesBox.clear();
+    await changesBox.clear();
+    fakeClient.reset();
+    if (await webDavTempDirectory.exists()) {
+      await webDavTempDirectory.delete(recursive: true);
+    }
+    await webDavTempDirectory.create(recursive: true);
+  });
+
+  tearDown(() async {
+    for (final name in const [
+      'tempCollectiblesBox',
+      'tempCollectChangesBox',
+    ]) {
+      if (Hive.isBoxOpen(name)) {
+        await Hive.box(name).close();
+      }
+    }
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    await Hive.close();
+    if (await supportDirectory.exists()) {
+      await supportDirectory.delete(recursive: true);
+    }
+  });
+
+  Future<List<int>> buildRemoteBox<T>(Map<int, T> values) async {
+    final name = 'remoteBox${remoteBoxId++}';
+    final box = await Hive.openBox<T>(name);
+    await box.putAll(values);
+    await box.flush();
+    await box.close();
+    return File('${hiveDirectory.path}/$name.hive').readAsBytes();
+  }
+
+  Future<void> putLocalCollectible({bool withAddChange = false}) async {
+    await collectiblesBox.put(1, _collect(1));
+    if (withAddChange) {
+      await changesBox.put(100, _change(100, 1, 1));
+    }
+    await collectiblesBox.flush();
+    await changesBox.flush();
+  }
+
+  test('remote empty initializes from local without deleting collectibles',
+      () async {
+    await putLocalCollectible();
+
+    await webDavSync.syncCollectibles();
+
+    expect(collectiblesBox.keys, [1]);
+    expect(fakeClient.files, contains('/kazumiSync/collectibles.tmp'));
+  });
+
+  test('corrupt remote snapshot fails without changing local collectibles',
+      () async {
+    await putLocalCollectible();
+    fakeClient.files['/kazumiSync/collectibles.tmp'] = [1, 2, 3, 4];
+
+    await expectLater(webDavSync.syncCollectibles(), throwsA(anything));
+
+    expect(collectiblesBox.keys, [1]);
+    expect(fakeClient.uploadCount, 0);
+  });
+
+  test('snapshot-only remote keeps locally logged additions', () async {
+    await putLocalCollectible(withAddChange: true);
+    fakeClient.files['/kazumiSync/collectibles.tmp'] =
+        await buildRemoteBox<CollectedBangumi>({2: _collect(2)});
+
+    await webDavSync.syncCollectibles();
+
+    expect(collectiblesBox.keys.toSet(), {1, 2});
+  });
+
+  test('changes without snapshot fail closed and preserve local collectibles',
+      () async {
+    await putLocalCollectible();
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      101: _change(101, 1, 3),
+    });
+
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(collectiblesBox.keys, [1]);
+    expect(fakeClient.uploadCount, 0);
+  });
+
+  test('download interruption fails without changing local collectibles',
+      () async {
+    await putLocalCollectible();
+    fakeClient.files['/kazumiSync/collectibles.tmp'] =
+        await buildRemoteBox<CollectedBangumi>({2: _collect(2)});
+    fakeClient.failDownloads.add('/kazumiSync/collectibles.tmp');
+
+    await expectLater(webDavSync.syncCollectibles(), throwsA(anything));
+
+    expect(collectiblesBox.keys, [1]);
+    expect(fakeClient.uploadCount, 0);
+  });
+
+  test('complete remote snapshot still applies a legitimate remote deletion',
+      () async {
+    await putLocalCollectible(withAddChange: true);
+    fakeClient.files['/kazumiSync/collectibles.tmp'] =
+        await buildRemoteBox<CollectedBangumi>({});
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      100: _change(100, 1, 1),
+      101: _change(101, 1, 3),
+    });
+
+    await webDavSync.syncCollectibles();
+
+    expect(collectiblesBox.values, isEmpty);
+  });
+}
+
+class _FakeWebDavClient extends webdav.Client {
+  _FakeWebDavClient()
+      : super(
+          uri: 'https://example.invalid',
+          c: webdav.WdDio(),
+          auth: const webdav.Auth(user: '', pwd: ''),
+        );
+
+  final Map<String, List<int>> files = {};
+  final Set<String> failDownloads = {};
+  int uploadCount = 0;
+
+  void reset() {
+    files.clear();
+    failDownloads.clear();
+    uploadCount = 0;
+  }
+
+  @override
+  Future<List<webdav.File>> readDir(String path, [dynamic cancelToken]) async {
+    final prefix = path == '/' ? '/' : '$path/';
+    return files.keys
+        .where((filePath) => filePath.startsWith(prefix))
+        .map((filePath) => filePath.substring(prefix.length))
+        .where((name) => name.isNotEmpty && !name.contains('/'))
+        .map((name) => webdav.File(name: name, isDir: false))
+        .toList();
+  }
+
+  @override
+  Future<void> read2File(
+    String path,
+    String savePath, {
+    void Function(int count, int total)? onProgress,
+    dynamic cancelToken,
+  }) async {
+    if (failDownloads.contains(path)) {
+      throw const FileSystemException('injected download interruption');
+    }
+    final bytes = files[path];
+    if (bytes == null) {
+      throw FileSystemException('missing fake remote file', path);
+    }
+    final file = File(savePath);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes, flush: true);
+  }
+
+  @override
+  Future<void> writeFromFile(
+    String localFilePath,
+    String path, {
+    void Function(int count, int total)? onProgress,
+    dynamic cancelToken,
+  }) async {
+    uploadCount++;
+    files[path] = await File(localFilePath).readAsBytes();
+  }
+
+  @override
+  Future<void> remove(String path, [dynamic cancelToken]) async {
+    files.remove(path);
+  }
+
+  @override
+  Future<void> rename(
+    String oldPath,
+    String newPath,
+    bool overwrite, [
+    dynamic cancelToken,
+  ]) async {
+    final bytes = files.remove(oldPath);
+    if (bytes == null) {
+      throw FileSystemException('missing fake remote file', oldPath);
+    }
+    files[newPath] = bytes;
+  }
+}
+
+CollectedBangumi _collect(int id) {
+  return CollectedBangumi(
+    BangumiItem(
+      id: id,
+      type: 2,
+      name: 'subject $id',
+      nameCn: '条目 $id',
+      summary: '',
+      airDate: '2026-01-01',
+      airWeekday: 4,
+      rank: 0,
+      images: const {
+        'large': '',
+        'common': '',
+        'medium': '',
+        'small': '',
+        'grid': '',
+      },
+      tags: const <BangumiTag>[],
+      alias: const [],
+      ratingScore: 0,
+      votes: 0,
+      votesCount: const [],
+      info: '',
+    ),
+    DateTime.utc(2026, 1, id),
+    CollectType.watching.value,
+  );
+}
+
+CollectedBangumiChange _change(int id, int bangumiId, int action) {
+  return CollectedBangumiChange(
+    id,
+    bangumiId,
+    action,
+    CollectType.watching.value,
+    id,
+  );
+}

--- a/test/webdav_collectibles_sync_test.dart
+++ b/test/webdav_collectibles_sync_test.dart
@@ -145,11 +145,48 @@ void main() {
 
     await expectLater(
       webDavSync.syncCollectibles(),
-      throwsA(isA<StateError>()),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
     );
 
     expect(collectiblesBox.keys, [1]);
     expect(fakeClient.uploadCount, 0);
+  });
+
+  test('transient missing snapshot is retried before failing closed', () async {
+    await putLocalCollectible(withAddChange: true);
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      99: _change(99, 2, 1),
+    });
+    fakeClient.filesOnSecondSyncRootRead['/kazumiSync/collectibles.tmp'] =
+        await buildRemoteBox<CollectedBangumi>({2: _collect(2)});
+
+    await webDavSync.syncCollectibles();
+
+    expect(collectiblesBox.keys.toSet(), {1, 2});
+    expect(fakeClient.syncRootReadCount, 2);
+  });
+
+  test('persistent orphan can be repaired explicitly from local backup',
+      () async {
+    await putLocalCollectible(withAddChange: true);
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      101: _change(101, 1, 3),
+    });
+
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
+    );
+    expect(collectiblesBox.keys, [1]);
+
+    await webDavSync.updateCollectibles();
+
+    expect(fakeClient.files, contains('/kazumiSync/collectibles.tmp'));
+    expect(fakeClient.files, contains('/kazumiSync/collectchanges.tmp'));
+    await webDavSync.syncCollectibles();
+    expect(collectiblesBox.keys, [1]);
   });
 
   test('download interruption fails without changing local collectibles',
@@ -191,17 +228,28 @@ class _FakeWebDavClient extends webdav.Client {
         );
 
   final Map<String, List<int>> files = {};
+  final Map<String, List<int>> filesOnSecondSyncRootRead = {};
   final Set<String> failDownloads = {};
   int uploadCount = 0;
+  int syncRootReadCount = 0;
 
   void reset() {
     files.clear();
+    filesOnSecondSyncRootRead.clear();
     failDownloads.clear();
     uploadCount = 0;
+    syncRootReadCount = 0;
   }
 
   @override
   Future<List<webdav.File>> readDir(String path, [dynamic cancelToken]) async {
+    if (path == '/kazumiSync') {
+      syncRootReadCount++;
+      if (syncRootReadCount == 2) {
+        files.addAll(filesOnSecondSyncRootRead);
+        filesOnSecondSyncRootRead.clear();
+      }
+    }
     final prefix = path == '/' ? '/' : '$path/';
     return files.keys
         .where((filePath) => filePath.startsWith(prefix))

--- a/test/webdav_collectibles_sync_test.dart
+++ b/test/webdav_collectibles_sync_test.dart
@@ -181,11 +181,88 @@ void main() {
     );
     expect(collectiblesBox.keys, [1]);
 
-    await webDavSync.updateCollectibles();
+    await webDavSync.repairCollectiblesFromLocal();
 
     expect(fakeClient.files, contains('/kazumiSync/collectibles.tmp'));
     expect(fakeClient.files, contains('/kazumiSync/collectchanges.tmp'));
     await webDavSync.syncCollectibles();
+    expect(collectiblesBox.keys, [1]);
+  });
+
+  test('repair is blocked when the local collectible baseline is empty',
+      () async {
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      101: _change(101, 1, 3),
+    });
+
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
+    );
+    await expectLater(
+      webDavSync.repairCollectiblesFromLocal(),
+      throwsA(isA<EmptyLocalCollectiblesRepairException>()),
+    );
+
+    expect(fakeClient.files, isNot(contains('/kazumiSync/collectibles.tmp')));
+    expect(fakeClient.uploadCount, 0);
+  });
+
+  test('repair overwrites an orphaned change log even when local log is empty',
+      () async {
+    await putLocalCollectible();
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      101: _change(101, 1, 3),
+      102: _change(102, 2, 1),
+    });
+
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
+    );
+    await webDavSync.repairCollectiblesFromLocal();
+
+    expect(fakeClient.uploadedPaths, [
+      '/kazumiSync/collectchanges.tmp.cache',
+      '/kazumiSync/collectibles.tmp.cache',
+    ]);
+
+    final repairedChangesFile =
+        File('${webDavTempDirectory.path}/repaired-collectchanges.tmp');
+    await fakeClient.read2File(
+      '/kazumiSync/collectchanges.tmp',
+      repairedChangesFile.path,
+    );
+    expect(
+      await GStorage.getCollectChangesFromFile(repairedChangesFile.path),
+      isEmpty,
+    );
+
+    await webDavSync.syncCollectibles();
+    expect(collectiblesBox.keys, [1]);
+    expect(collectiblesBox.containsKey(2), isFalse);
+  });
+
+  test('interrupted repair keeps the missing-snapshot guard active', () async {
+    await putLocalCollectible();
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      101: _change(101, 1, 3),
+    });
+    fakeClient.failUploads.add('/kazumiSync/collectibles.tmp.cache');
+
+    await expectLater(
+      webDavSync.repairCollectiblesFromLocal(),
+      throwsA(anything),
+    );
+    expect(collectiblesBox.keys, [1]);
+    expect(fakeClient.files, isNot(contains('/kazumiSync/collectibles.tmp')));
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
+    );
     expect(collectiblesBox.keys, [1]);
   });
 
@@ -230,6 +307,8 @@ class _FakeWebDavClient extends webdav.Client {
   final Map<String, List<int>> files = {};
   final Map<String, List<int>> filesOnSecondSyncRootRead = {};
   final Set<String> failDownloads = {};
+  final Set<String> failUploads = {};
+  final List<String> uploadedPaths = [];
   int uploadCount = 0;
   int syncRootReadCount = 0;
 
@@ -237,6 +316,8 @@ class _FakeWebDavClient extends webdav.Client {
     files.clear();
     filesOnSecondSyncRootRead.clear();
     failDownloads.clear();
+    failUploads.clear();
+    uploadedPaths.clear();
     uploadCount = 0;
     syncRootReadCount = 0;
   }
@@ -285,7 +366,11 @@ class _FakeWebDavClient extends webdav.Client {
     void Function(int count, int total)? onProgress,
     dynamic cancelToken,
   }) async {
+    if (failUploads.contains(path)) {
+      throw const FileSystemException('injected upload interruption');
+    }
     uploadCount++;
+    uploadedPaths.add(path);
     files[path] = await File(localFilePath).readAsBytes();
   }
 

--- a/test/webdav_collectibles_sync_test.dart
+++ b/test/webdav_collectibles_sync_test.dart
@@ -181,7 +181,10 @@ void main() {
     );
     expect(collectiblesBox.keys, [1]);
 
-    await webDavSync.repairCollectiblesFromLocal();
+    expect(
+      await webDavSync.repairCollectiblesFromLocal(),
+      WebDavCollectiblesRepairResult.repaired,
+    );
 
     expect(fakeClient.files, contains('/kazumiSync/collectibles.tmp'));
     expect(fakeClient.files, contains('/kazumiSync/collectchanges.tmp'));
@@ -222,7 +225,10 @@ void main() {
       webDavSync.syncCollectibles(),
       throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
     );
-    await webDavSync.repairCollectiblesFromLocal();
+    expect(
+      await webDavSync.repairCollectiblesFromLocal(),
+      WebDavCollectiblesRepairResult.repaired,
+    );
 
     expect(fakeClient.uploadedPaths, [
       '/kazumiSync/collectchanges.tmp.cache',
@@ -243,6 +249,32 @@ void main() {
     await webDavSync.syncCollectibles();
     expect(collectiblesBox.keys, [1]);
     expect(collectiblesBox.containsKey(2), isFalse);
+  });
+
+  test('repair rechecks a snapshot that appeared during confirmation',
+      () async {
+    await putLocalCollectible(withAddChange: true);
+    fakeClient.files['/kazumiSync/collectchanges.tmp'] =
+        await buildRemoteBox<CollectedBangumiChange>({
+      99: _change(99, 2, 1),
+    });
+
+    await expectLater(
+      webDavSync.syncCollectibles(),
+      throwsA(isA<IncompleteWebDavCollectiblesBackupException>()),
+    );
+    fakeClient.files['/kazumiSync/collectibles.tmp'] =
+        await buildRemoteBox<CollectedBangumi>({2: _collect(2)});
+    final uploadCountBeforeRepair = fakeClient.uploadCount;
+
+    expect(
+      await webDavSync.repairCollectiblesFromLocal(),
+      WebDavCollectiblesRepairResult.remoteStateChanged,
+    );
+    expect(fakeClient.uploadCount, uploadCountBeforeRepair);
+
+    await webDavSync.syncCollectibles();
+    expect(collectiblesBox.keys.toSet(), {1, 2});
   });
 
   test('interrupted repair keeps the missing-snapshot guard active', () async {


### PR DESCRIPTION
## 描述

WebDAV 收藏同步以 `collectibles.tmp` 作为完整快照，以 `collectchanges.tmp` 记录变更。原实现允许在远端只有变更日志、缺少收藏快照时继续同步，并把缺失快照解析为空列表。合并结果随后可能清空本地收藏，再将空结果回写远端，其他设备同步后也会丢失收藏。

本 PR 增加四层保护与恢复：

1. 远端出现“变更日志存在、完整快照暂时缺失”时，有界重读三次，避开其他设备替换快照时的短暂窗口。
2. 状态持续不完整时，使用受控同步异常停止合并，保证本地收藏不被修改。
3. 应用显示明确的恢复对话框。仅当当前设备存在本地收藏时才允许恢复，并显示将采用的本地收藏数量和覆盖其他设备未同步变更的风险。
4. 用户确认后、实际写入前再次读取远端。如果其他设备已经补齐快照，则零上传并转为正常同步，避免覆盖刚恢复的远端收藏。

专用恢复流程无论本地变更日志是否为空，都会先覆盖远端孤立变更日志，再发布本地收藏快照，建立一致的本地权威基线。若发布快照中断，远端仍处于缺少快照的受保护状态，下次同步不会把它解释为空收藏。

完整快照和变更日志同时存在时，合法的远端删除仍按原协议生效；远端全空时仍会使用本地数据初始化备份。

新增基于临时 Hive 和 fake WebDAV 的隔离测试，覆盖：

- 远端全空、损坏快照、只有快照、只有变更日志
- 发布期间快照短暂缺失后恢复
- 持续孤立变更日志经用户明确选择后使用本地备份修复
- 本地收藏为空时拒绝修复
- 本地变更日志为空时仍覆盖远端孤立日志
- 修复后再次同步不复活孤立日志条目，也不丢失本地收藏
- 修复发布中断时继续保持缺失快照保护
- 确认对话框期间另一设备补齐快照时放弃覆盖并正常合并
- 下载中断
- 完整远端状态下的合法全量删除

## 关联的 Issues

Closes #2077

## PR 类型

- [x] Bug 修复
- [ ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [ ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [x] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: OpenAI GPT-5 Codex

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

修复前，缺失快照测试稳定失败：同步成功返回而不是 fail-closed。修复后的验证结果：

- `flutter test --no-pub`（144 项测试通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无 warning/error；5 条仓库原有 info）
- `dart format --output=none --set-exit-if-changed lib/services/sync/webdav.dart lib/pages/collect/collect_controller.dart test/webdav_collectibles_sync_test.dart`
- `git diff --check`

测试仅使用临时目录和 fake WebDAV，不连接真实服务，也不读取真实用户数据。
