### PR TITLE
fix(ui): 修复长标题下追番按钮不可达

### DIFF
--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -25,10 +25,9 @@ class BangumiInfoCardV extends StatefulWidget {
 }
 
 class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
-  static const double _compactInfoMaxHeight = 230;
-  static const double _compactInfoMaxWidth = 160;
-  static const double _compactDateMinHeight = 150;
-  static const double _compactScoreMinHeight = 190;
+  static const double _fullInfoMinCharacters = 10;
+  static const double _fullInfoLineBudget = 8;
+  static const double _fullInfoActionHeight = 40;
   int touchedIndex = -1;
 
   Widget get voteBarChart {
@@ -151,6 +150,7 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
           widget.bangumiItem.airDate == ''
               ? '2000-11-11' // Skeleton Loader 占位符
               : widget.bangumiItem.airDate,
+          key: const ValueKey('bangumi-info-date'),
           style: TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
@@ -192,46 +192,45 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
     );
   }
 
-  Widget _buildCompactInfo(double maxHeight) {
+  Widget _buildCompactInfo() {
     final date = widget.bangumiItem.airDate == ''
         ? '2000-11-11'
         : widget.bangumiItem.airDate;
     final score = widget.showRating
         ? '${widget.bangumiItem.ratingScore} 分'
         : '*** 分';
-    final dateStyle = TextStyle(
-      fontSize: 20,
+    final compactStyle = TextStyle(
+      fontSize: 16,
       fontWeight: FontWeight.bold,
       color: Theme.of(context).colorScheme.primary,
     );
-    final scoreStyle = dateStyle.copyWith(fontSize: 16);
-    final showDate = maxHeight >= _compactDateMinHeight;
-    final showScore =
-        showDate && !widget.isLoading && maxHeight >= _compactScoreMinHeight;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        CollectButton(
-          bangumiItem: widget.bangumiItem,
-          color: Theme.of(context).colorScheme.primary,
+        Row(
+          children: [
+            CollectButton(
+              bangumiItem: widget.bangumiItem,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            Expanded(
+              child: Text(
+                score,
+                key: const ValueKey('bangumi-info-score'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: compactStyle,
+              ),
+            ),
+          ],
         ),
-        if (showDate) SizedBox(height: 4),
-        if (showDate)
-          Text(
-            date,
-            key: const ValueKey('bangumi-info-date'),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: dateStyle,
-          ),
-        if (showScore)
-          Text(
-            score,
-            key: const ValueKey('bangumi-info-score'),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: scoreStyle,
-          ),
+        Text(
+          date,
+          key: const ValueKey('bangumi-info-date'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: compactStyle,
+        ),
       ],
     );
   }
@@ -283,15 +282,17 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                 Flexible(
                   child: LayoutBuilder(
                     builder: (context, constraints) {
-                      final useCompactLayout =
-                          constraints.maxHeight < _compactInfoMaxHeight ||
-                              constraints.maxWidth < _compactInfoMaxWidth;
+                      final scaledInfoValue =
+                          MediaQuery.textScalerOf(context).scale(20);
+                      final useCompactLayout = constraints.maxWidth <
+                              scaledInfoValue * _fullInfoMinCharacters ||
+                          constraints.maxHeight <
+                              scaledInfoValue * _fullInfoLineBudget +
+                                  _fullInfoActionHeight;
                       return Skeletonizer(
                         enabled: widget.isLoading,
                         child: useCompactLayout
-                            ? _buildCompactInfo(
-                                constraints.maxHeight,
-                              )
+                            ? _buildCompactInfo()
                             : Column(
                                 mainAxisAlignment:
                                     MainAxisAlignment.spaceBetween,

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -116,8 +116,92 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
     );
   }
 
+  Widget _buildInfoDetails({required bool wrapRating}) {
+    final ratingWidgets = <Widget>[
+      Text(
+        widget.showRating ? '${widget.bangumiItem.ratingScore}' : '***',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+      RatingBarIndicator(
+        itemCount: 5,
+        rating: widget.showRating
+            ? widget.bangumiItem.ratingScore.toDouble() / 2
+            : 0,
+        itemBuilder: (context, index) => Icon(
+          Icons.star_rounded,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+        itemSize: 20.0,
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('放送开始:'),
+        Text(
+          widget.bangumiItem.airDate == ''
+              ? '2000-11-11' // Skeleton Loader 占位符
+              : widget.bangumiItem.airDate,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+        ),
+        SizedBox(height: 8),
+        Text(
+          widget.showRating ? '${widget.bangumiItem.votes} 人评分:' : '*** 人评分:',
+        ),
+        if (widget.isLoading)
+          // Skeleton Loader 占位符
+          Text(
+            '10.0 ********',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        if (!widget.isLoading && wrapRating)
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: ratingWidgets,
+          ),
+        if (!widget.isLoading && !wrapRating)
+          Row(
+            children: [
+              ratingWidgets.first,
+              const SizedBox(width: 8),
+              ratingWidgets.last,
+            ],
+          ),
+        SizedBox(height: 8),
+        Text('Bangumi Ranked:'),
+        Text(
+          widget.showRating ? '#${widget.bangumiItem.rank}' : '***',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final useCompactLayout = MediaQuery.sizeOf(context).width <
+            LayoutBreakpoint.compact['width']! ||
+        MediaQuery.textScalerOf(context).scale(1) > 1;
+
     return Container(
       height: 300,
       constraints: BoxConstraints(maxWidth: 950),
@@ -163,98 +247,35 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                 Flexible(
                   child: Skeletonizer(
                     enabled: widget.isLoading,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '放送开始:',
-                            ),
-                            Text(
-                              widget.bangumiItem.airDate == ''
-                                  ? '2000-11-11' // Skeleton Loader 占位符
-                                  : widget.bangumiItem.airDate,
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
+                    child: useCompactLayout
+                        ? Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              CollectButton(
+                                bangumiItem: widget.bangumiItem,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
-                            ),
-                            SizedBox(height: 8),
-                            Text(
-                              widget.showRating
-                                  ? '${widget.bangumiItem.votes} 人评分:'
-                                  : '*** 人评分:',
-                            ),
-                            if (widget.isLoading)
-                              // Skeleton Loader 占位符
-                              Text(
-                                '10.0 ********',
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.primary,
+                              Expanded(
+                                child: SingleChildScrollView(
+                                  child: _buildInfoDetails(wrapRating: true),
                                 ),
                               ),
-                            if (!widget.isLoading)
-                              Row(
-                                children: [
-                                  Text(
-                                    widget.showRating
-                                        ? '${widget.bangumiItem.ratingScore}'
-                                        : '***',
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.bold,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  RatingBarIndicator(
-                                    itemCount: 5,
-                                    rating: widget.showRating
-                                        ? widget.bangumiItem.ratingScore
-                                                .toDouble() /
-                                            2
-                                        : 0,
-                                    itemBuilder: (context, index) => Icon(
-                                      Icons.star_rounded,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                                    itemSize: 20.0,
-                                  ),
-                                ],
+                            ],
+                          )
+                        : Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              _buildInfoDetails(wrapRating: false),
+                              SizedBox(
+                                width: 120,
+                                height: 40,
+                                child: CollectButton.extend(
+                                  bangumiItem: widget.bangumiItem,
+                                ),
                               ),
-                            SizedBox(height: 8),
-                            Text(
-                              'Bangumi Ranked:',
-                            ),
-                            Text(
-                              widget.showRating
-                                  ? '#${widget.bangumiItem.rank}'
-                                  : '***',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            ),
-                          ],
-                        ),
-                        SizedBox(
-                          width: 120,
-                          height: 40,
-                          child: CollectButton.extend(
-                            bangumiItem: widget.bangumiItem,
+                            ],
                           ),
-                        ),
-                      ],
-                    ),
                   ),
                 ),
                 if (widget.showRating &&

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -116,7 +116,7 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
     );
   }
 
-  Widget _buildInfoDetails({required bool wrapRating}) {
+  Widget _buildInfoDetails() {
     final ratingWidgets = <Widget>[
       Text(
         widget.showRating ? '${widget.bangumiItem.ratingScore}' : '***',
@@ -167,20 +167,12 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
               color: Theme.of(context).colorScheme.primary,
             ),
           ),
-        if (!widget.isLoading && wrapRating)
+        if (!widget.isLoading)
           Wrap(
             spacing: 8,
             runSpacing: 4,
             crossAxisAlignment: WrapCrossAlignment.center,
             children: ratingWidgets,
-          ),
-        if (!widget.isLoading && !wrapRating)
-          Row(
-            children: [
-              ratingWidgets.first,
-              const SizedBox(width: 8),
-              ratingWidgets.last,
-            ],
           ),
         SizedBox(height: 8),
         Text('Bangumi Ranked:'),
@@ -198,10 +190,6 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
 
   @override
   Widget build(BuildContext context) {
-    final useCompactLayout = MediaQuery.sizeOf(context).width <
-            LayoutBreakpoint.compact['width']! ||
-        MediaQuery.textScalerOf(context).scale(1) > 1;
-
     return Container(
       height: 300,
       constraints: BoxConstraints(maxWidth: 950),
@@ -247,35 +235,36 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                 Flexible(
                   child: Skeletonizer(
                     enabled: widget.isLoading,
-                    child: useCompactLayout
-                        ? Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              CollectButton(
-                                bangumiItem: widget.bangumiItem,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                              Expanded(
-                                child: SingleChildScrollView(
-                                  child: _buildInfoDetails(wrapRating: true),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: LayoutBuilder(
+                            builder: (context, constraints) {
+                              return FittedBox(
+                                fit: BoxFit.scaleDown,
+                                alignment: Alignment.topLeft,
+                                child: SizedBox(
+                                  width: constraints.maxWidth,
+                                  child: _buildInfoDetails(),
                                 ),
-                              ),
-                            ],
-                          )
-                        : Column(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              _buildInfoDetails(wrapRating: false),
-                              SizedBox(
-                                width: 120,
-                                height: 40,
-                                child: CollectButton.extend(
-                                  bangumiItem: widget.bangumiItem,
-                                ),
-                              ),
-                            ],
+                              );
+                            },
                           ),
+                        ),
+                        SizedBox(
+                          width: 120,
+                          height: 40,
+                          child: MediaQuery.withClampedTextScaling(
+                            maxScaleFactor: 1,
+                            child: CollectButton.extend(
+                              bangumiItem: widget.bangumiItem,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 if (widget.showRating &&

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -25,9 +25,10 @@ class BangumiInfoCardV extends StatefulWidget {
 }
 
 class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
-  static const double _extendedActionHeight = 40;
-  // Reserve the Material tap target and inter-widget layout beyond text paint.
-  static const double _materialControlMargin = 32;
+  static const double _compactInfoMaxHeight = 230;
+  static const double _compactInfoMaxWidth = 160;
+  static const double _compactDateMinHeight = 150;
+  static const double _compactScoreMinHeight = 190;
   int touchedIndex = -1;
 
   Widget get voteBarChart {
@@ -191,55 +192,7 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
     );
   }
 
-  double _textHeight(String text, TextStyle style, double maxWidth) {
-    final painter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      textScaler: MediaQuery.textScalerOf(context),
-      textDirection: Directionality.of(context),
-    )..layout(maxWidth: maxWidth);
-    return painter.height;
-  }
-
-  double _requiredInfoHeight(double maxWidth) {
-    final defaultStyle = DefaultTextStyle.of(context).style;
-    final valueStyle = TextStyle(
-      fontSize: 20,
-      fontWeight: FontWeight.bold,
-      color: Theme.of(context).colorScheme.primary,
-    );
-    final scoreStyle = valueStyle.copyWith(fontSize: 16);
-    final date = widget.bangumiItem.airDate == ''
-        ? '2000-11-11'
-        : widget.bangumiItem.airDate;
-    final ratingLabel =
-        widget.showRating ? '${widget.bangumiItem.votes} 人评分:' : '*** 人评分:';
-    final rank = widget.showRating ? '#${widget.bangumiItem.rank}' : '***';
-    final score = widget.showRating ? '${widget.bangumiItem.ratingScore}' : '***';
-
-    final scorePainter = TextPainter(
-      text: TextSpan(text: score, style: scoreStyle),
-      textScaler: MediaQuery.textScalerOf(context),
-      textDirection: Directionality.of(context),
-    )..layout();
-    final ratingHeight = scorePainter.width + 8 + 100 <= maxWidth
-        ? scorePainter.height.clamp(20, double.infinity)
-        : scorePainter.height + 4 + 20;
-
-    return _textHeight('放送开始:', defaultStyle, maxWidth) +
-        _textHeight(date, valueStyle, maxWidth) +
-        8 +
-        _textHeight(ratingLabel, defaultStyle, maxWidth) +
-        (widget.isLoading
-            ? _textHeight('10.0 ********', valueStyle, maxWidth)
-            : ratingHeight) +
-        8 +
-        _textHeight('Bangumi Ranked:', defaultStyle, maxWidth) +
-        _textHeight(rank, valueStyle, maxWidth) +
-        _extendedActionHeight +
-        _materialControlMargin;
-  }
-
-  Widget _buildCompactInfo(double maxWidth, double maxHeight) {
+  Widget _buildCompactInfo(double maxHeight) {
     final date = widget.bangumiItem.airDate == ''
         ? '2000-11-11'
         : widget.bangumiItem.airDate;
@@ -252,12 +205,9 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
       color: Theme.of(context).colorScheme.primary,
     );
     final scoreStyle = dateStyle.copyWith(fontSize: 16);
-    final showScore = !widget.isLoading &&
-        48 +
-                4 +
-                _textHeight(date, dateStyle, maxWidth) +
-                _textHeight(score, scoreStyle, maxWidth) <=
-            maxHeight;
+    final showDate = maxHeight >= _compactDateMinHeight;
+    final showScore =
+        showDate && !widget.isLoading && maxHeight >= _compactScoreMinHeight;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -265,14 +215,15 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
           bangumiItem: widget.bangumiItem,
           color: Theme.of(context).colorScheme.primary,
         ),
-        SizedBox(height: 4),
-        Text(
-          date,
-          key: const ValueKey('bangumi-info-date'),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: dateStyle,
-        ),
+        if (showDate) SizedBox(height: 4),
+        if (showDate)
+          Text(
+            date,
+            key: const ValueKey('bangumi-info-date'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: dateStyle,
+          ),
         if (showScore)
           Text(
             score,
@@ -333,13 +284,12 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                   child: LayoutBuilder(
                     builder: (context, constraints) {
                       final useCompactLayout =
-                          _requiredInfoHeight(constraints.maxWidth) >
-                              constraints.maxHeight;
+                          constraints.maxHeight < _compactInfoMaxHeight ||
+                              constraints.maxWidth < _compactInfoMaxWidth;
                       return Skeletonizer(
                         enabled: widget.isLoading,
                         child: useCompactLayout
                             ? _buildCompactInfo(
-                                constraints.maxWidth,
                                 constraints.maxHeight,
                               )
                             : Column(

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -25,6 +25,9 @@ class BangumiInfoCardV extends StatefulWidget {
 }
 
 class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
+  static const double _extendedActionHeight = 40;
+  // Reserve the Material tap target and inter-widget layout beyond text paint.
+  static const double _materialControlMargin = 32;
   int touchedIndex = -1;
 
   Widget get voteBarChart {
@@ -188,6 +191,100 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
     );
   }
 
+  double _textHeight(String text, TextStyle style, double maxWidth) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textScaler: MediaQuery.textScalerOf(context),
+      textDirection: Directionality.of(context),
+    )..layout(maxWidth: maxWidth);
+    return painter.height;
+  }
+
+  double _requiredInfoHeight(double maxWidth) {
+    final defaultStyle = DefaultTextStyle.of(context).style;
+    final valueStyle = TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+      color: Theme.of(context).colorScheme.primary,
+    );
+    final scoreStyle = valueStyle.copyWith(fontSize: 16);
+    final date = widget.bangumiItem.airDate == ''
+        ? '2000-11-11'
+        : widget.bangumiItem.airDate;
+    final ratingLabel =
+        widget.showRating ? '${widget.bangumiItem.votes} 人评分:' : '*** 人评分:';
+    final rank = widget.showRating ? '#${widget.bangumiItem.rank}' : '***';
+    final score = widget.showRating ? '${widget.bangumiItem.ratingScore}' : '***';
+
+    final scorePainter = TextPainter(
+      text: TextSpan(text: score, style: scoreStyle),
+      textScaler: MediaQuery.textScalerOf(context),
+      textDirection: Directionality.of(context),
+    )..layout();
+    final ratingHeight = scorePainter.width + 8 + 100 <= maxWidth
+        ? scorePainter.height.clamp(20, double.infinity)
+        : scorePainter.height + 4 + 20;
+
+    return _textHeight('放送开始:', defaultStyle, maxWidth) +
+        _textHeight(date, valueStyle, maxWidth) +
+        8 +
+        _textHeight(ratingLabel, defaultStyle, maxWidth) +
+        (widget.isLoading
+            ? _textHeight('10.0 ********', valueStyle, maxWidth)
+            : ratingHeight) +
+        8 +
+        _textHeight('Bangumi Ranked:', defaultStyle, maxWidth) +
+        _textHeight(rank, valueStyle, maxWidth) +
+        _extendedActionHeight +
+        _materialControlMargin;
+  }
+
+  Widget _buildCompactInfo(double maxWidth, double maxHeight) {
+    final date = widget.bangumiItem.airDate == ''
+        ? '2000-11-11'
+        : widget.bangumiItem.airDate;
+    final score = widget.showRating
+        ? '${widget.bangumiItem.ratingScore} 分'
+        : '*** 分';
+    final dateStyle = TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+      color: Theme.of(context).colorScheme.primary,
+    );
+    final scoreStyle = dateStyle.copyWith(fontSize: 16);
+    final showScore = !widget.isLoading &&
+        48 +
+                4 +
+                _textHeight(date, dateStyle, maxWidth) +
+                _textHeight(score, scoreStyle, maxWidth) <=
+            maxHeight;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CollectButton(
+          bangumiItem: widget.bangumiItem,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+        SizedBox(height: 4),
+        Text(
+          date,
+          key: const ValueKey('bangumi-info-date'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: dateStyle,
+        ),
+        if (showScore)
+          Text(
+            score,
+            key: const ValueKey('bangumi-info-score'),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: scoreStyle,
+          ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -233,38 +330,35 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                 ),
                 SizedBox(width: 16),
                 Flexible(
-                  child: Skeletonizer(
-                    enabled: widget.isLoading,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: LayoutBuilder(
-                            builder: (context, constraints) {
-                              return FittedBox(
-                                fit: BoxFit.scaleDown,
-                                alignment: Alignment.topLeft,
-                                child: SizedBox(
-                                  width: constraints.maxWidth,
-                                  child: _buildInfoDetails(),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                        SizedBox(
-                          width: 120,
-                          height: 40,
-                          child: MediaQuery.withClampedTextScaling(
-                            maxScaleFactor: 1,
-                            child: CollectButton.extend(
-                              bangumiItem: widget.bangumiItem,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final useCompactLayout =
+                          _requiredInfoHeight(constraints.maxWidth) >
+                              constraints.maxHeight;
+                      return Skeletonizer(
+                        enabled: widget.isLoading,
+                        child: useCompactLayout
+                            ? _buildCompactInfo(
+                                constraints.maxWidth,
+                                constraints.maxHeight,
+                              )
+                            : Column(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  _buildInfoDetails(),
+                                  SizedBox(
+                                    width: 120,
+                                    height: 40,
+                                    child: CollectButton.extend(
+                                      bangumiItem: widget.bangumiItem,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                      );
+                    },
                   ),
                 ),
                 if (widget.showRating &&

--- a/test/bangumi_info_card_test.dart
+++ b/test/bangumi_info_card_test.dart
@@ -13,7 +13,7 @@ import 'package:kazumi/repositories/collect_repository.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  for (final scale in <double>[1, 1.5, 2]) {
+  for (final scale in <double>[1, 1.3, 1.5, 1.7, 2]) {
     testWidgets(
       'keeps the collect button visible and tappable at ${scale}x text',
       (tester) async {
@@ -31,6 +31,16 @@ void main() {
         expect(cardRect.contains(buttonRect.topLeft), isTrue);
         expect(buttonRect.right, lessThanOrEqualTo(cardRect.right));
         expect(buttonRect.bottom, lessThanOrEqualTo(cardRect.bottom));
+        for (final key in const [
+          ValueKey('bangumi-info-date'),
+          ValueKey('bangumi-info-score'),
+        ]) {
+          final infoFinder = find.byKey(key);
+          expect(infoFinder, findsOneWidget);
+          final infoRect = tester.getRect(infoFinder);
+          expect(infoRect.top, greaterThanOrEqualTo(cardRect.top));
+          expect(infoRect.bottom, lessThanOrEqualTo(cardRect.bottom));
+        }
 
         await tester.tap(buttonFinder);
         await tester.pumpAndSettle();

--- a/test/bangumi_info_card_test.dart
+++ b/test/bangumi_info_card_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/card/bangumi_info_card.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_change_module.dart';
+import 'package:kazumi/modules/collect/collect_module.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/pages/collect/collect_controller.dart';
+import 'package:kazumi/repositories/collect_crud_repository.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final scale in <double>[1, 1.5, 2]) {
+    testWidgets(
+      'keeps the collect button visible and tappable at ${scale}x text',
+      (tester) async {
+        _bootstrapCollectController();
+        await tester.pumpWidget(_testApp(textScale: scale));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        final cardRect = tester.getRect(find.byType(BangumiInfoCardV));
+        final buttonFinder =
+            find.widgetWithIcon(IconButton, Icons.favorite_border);
+        expect(buttonFinder, findsOneWidget);
+        final buttonRect = tester.getRect(buttonFinder);
+        expect(cardRect.contains(buttonRect.topLeft), isTrue);
+        expect(cardRect.contains(buttonRect.bottomRight), isTrue);
+
+        await tester.tap(buttonFinder);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MenuItemButton), findsNWidgets(6));
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets('keeps the extended collect button on wide normal text',
+      (tester) async {
+    _bootstrapCollectController();
+    await tester.pumpWidget(_testApp(textScale: 1, width: 1200));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(FilledButton, '未追'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+void _bootstrapCollectController() {
+  final collectController = CollectController(
+    _FakeCollectCrudRepository(),
+    _FakeCollectRepository(),
+  );
+  bootstrapModule(
+    createModule(
+      register: (context) =>
+          context.addInstance<CollectController>(collectController),
+    ),
+  );
+}
+
+Widget _testApp({required double textScale, double width = 360}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(
+        size: Size(width, 800),
+        textScaler: TextScaler.linear(textScale),
+      ),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: width,
+            child: BangumiInfoCardV(
+              bangumiItem: _longTitleBangumi(),
+              isLoading: false,
+              showRating: true,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+BangumiItem _longTitleBangumi() {
+  return BangumiItem(
+    id: 942,
+    type: 2,
+    name: 'A Very Long Anime Title That Must Wrap Across Multiple Lines',
+    nameCn: '这是一个非常非常长而且必须占据两行显示空间的番剧标题名称',
+    summary: 'summary',
+    airDate: '2026-08-17',
+    airWeekday: 1,
+    rank: 942,
+    images: const <String, String>{},
+    tags: const [],
+    alias: const [],
+    ratingScore: 8.2,
+    votes: 1000,
+    votesCount: List<int>.filled(10, 100),
+    info: '',
+  );
+}
+
+class _FakeCollectCrudRepository implements ICollectCrudRepository {
+  @override
+  Stream<void> get changes => const Stream<void>.empty();
+
+  @override
+  Future<void> addCollectChange(CollectedBangumiChange change) async {}
+
+  @override
+  Future<void> addCollectible(BangumiItem bangumiItem, int type) async {}
+
+  @override
+  Future<void> clearFavorites() async {}
+
+  @override
+  Future<void> deleteCollectible(int id) async {}
+
+  @override
+  List<CollectedBangumi> getAllCollectibles() => const [];
+
+  @override
+  CollectedBangumi? getCollectible(int id) => null;
+
+  @override
+  int getCollectType(int id) => 0;
+
+  @override
+  List<BangumiItem> getFavorites() => const [];
+
+  @override
+  Future<void> updateCollectible(BangumiItem bangumiItem) async {}
+}
+
+class _FakeCollectRepository implements ICollectRepository {
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) => const {};
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => const {};
+
+  @override
+  bool getPrivateMode() => false;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}

--- a/test/bangumi_info_card_test.dart
+++ b/test/bangumi_info_card_test.dart
@@ -24,12 +24,12 @@ void main() {
         expect(tester.takeException(), isNull);
 
         final cardRect = tester.getRect(find.byType(BangumiInfoCardV));
-        final buttonFinder =
-            find.widgetWithIcon(IconButton, Icons.favorite_border);
+        final buttonFinder = find.widgetWithText(FilledButton, '未追');
         expect(buttonFinder, findsOneWidget);
         final buttonRect = tester.getRect(buttonFinder);
         expect(cardRect.contains(buttonRect.topLeft), isTrue);
-        expect(cardRect.contains(buttonRect.bottomRight), isTrue);
+        expect(buttonRect.right, lessThanOrEqualTo(cardRect.right));
+        expect(buttonRect.bottom, lessThanOrEqualTo(cardRect.bottom));
 
         await tester.tap(buttonFinder);
         await tester.pumpAndSettle();
@@ -42,11 +42,77 @@ void main() {
 
   testWidgets('keeps the extended collect button on wide normal text',
       (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
     _bootstrapCollectController();
     await tester.pumpWidget(_testApp(textScale: 1, width: 1200));
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(FilledButton, '未追'), findsOneWidget);
+    expect(find.text('  评分透视:'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('does not consume the outer header drag', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    _bootstrapCollectController();
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(360, 800),
+            textScaler: TextScaler.linear(2),
+          ),
+          child: Scaffold(
+            body: NestedScrollView(
+              controller: scrollController,
+              headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                SliverAppBar(
+                  expandedHeight: 340,
+                  flexibleSpace: FlexibleSpaceBar(
+                    background: Padding(
+                      padding: const EdgeInsets.only(top: kToolbarHeight),
+                      child: BangumiInfoCardV(
+                        bangumiItem: _longTitleBangumi(),
+                        isLoading: false,
+                        showRating: true,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+              body: ListView(
+                children: const [SizedBox(height: 1200)],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byType(BangumiInfoCardV),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Scrollable &&
+              (widget.axisDirection == AxisDirection.up ||
+                  widget.axisDirection == AxisDirection.down),
+        ),
+      ),
+      findsNothing,
+    );
+    await tester.dragFrom(const Offset(270, 240), const Offset(0, -160));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0));
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/bangumi_info_card_test.dart
+++ b/test/bangumi_info_card_test.dart
@@ -24,7 +24,8 @@ void main() {
         expect(tester.takeException(), isNull);
 
         final cardRect = tester.getRect(find.byType(BangumiInfoCardV));
-        final buttonFinder = find.widgetWithText(FilledButton, '未追');
+        final buttonFinder =
+            find.widgetWithIcon(IconButton, Icons.favorite_border);
         expect(buttonFinder, findsOneWidget);
         final buttonRect = tester.getRect(buttonFinder);
         expect(cardRect.contains(buttonRect.topLeft), isTrue);
@@ -51,6 +52,32 @@ void main() {
 
     expect(find.widgetWithText(FilledButton, '未追'), findsOneWidget);
     expect(find.text('  评分透视:'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('preserves large text and menu scaling in the compact layout',
+      (tester) async {
+    _bootstrapCollectController();
+    await tester.pumpWidget(_testApp(textScale: 1));
+    await tester.pumpAndSettle();
+    final normalDateHeight =
+        tester.getSize(find.byKey(const ValueKey('bangumi-info-date'))).height;
+
+    await tester.pumpWidget(_testApp(textScale: 2));
+    await tester.pumpAndSettle();
+    final largeDateHeight =
+        tester.getSize(find.byKey(const ValueKey('bangumi-info-date'))).height;
+    expect(largeDateHeight, greaterThan(normalDateHeight));
+
+    await tester.tap(
+      find.widgetWithIcon(IconButton, Icons.favorite_border),
+    );
+    await tester.pumpAndSettle();
+    final menuContext = tester.element(find.text(' 在看'));
+    expect(
+      MediaQuery.textScalerOf(menuContext).scale(16),
+      closeTo(32, 0.01),
+    );
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## 修复内容

- 根据右侧信息区的真实宽高与当前 20px 字体实际缩放值选择完整或紧凑布局，不执行额外文本测量。
- 空间充足时保持原扩展追番按钮和完整信息。
- 空间不足时使用“图标按钮 + 评分”同一行、日期下一行，三个关键元素都保持系统字体缩放并留在卡片内。
- 追番菜单继承完整系统字体缩放。
- 不引入内部纵向滚动，拖动信息卡区域仍会正常折叠外层 AppBar。
- 桌面宽屏且正常字体比例保持原布局，并继续显示评分透视图。

## 根因

番剧信息卡高度固定为 300，长标题占据两行后，右侧元数据和底部追番按钮仍由固定结构的 `Column` 排布。窄屏或字体放大时，内容高度超过剩余空间，追番按钮被挤出可点击区域，同时评分行也可能横向溢出。

## 验证

- [x] 当前 main 在 360dp、长标题、1.0/1.5/2.0 字体缩放下均可稳定复现溢出
- [x] `flutter test test/bangumi_info_card_test.dart`（8 项）
- [x] `flutter test`（140 项）
- [x] `flutter analyze --no-fatal-infos --fatal-warnings`（通过，仅有 5 条既有 info）
- [x] 1.0/1.3/1.5/1.7/2.0 均验证日期、评分、追番入口在卡片边界内且入口可点击
- [x] 信息卡中没有额外 `TextPainter` / 手工 `.layout()`
- [x] 2.0 下关键日期文字实际高度大于 1.0
- [x] 追番菜单在 2.0 下继承完整字体缩放
- [x] 宽屏测试使用真实 1200×800 view，并覆盖扩展按钮和评分透视图
- [x] 外层 `NestedScrollView` 拖动测试通过
- [x] `dart format --output=none --set-exit-if-changed test/bangumi_info_card_test.dart`
- [x] `git diff --check`

Closes #942
