### PR TITLE
fix(android): 修复播控中心通知图标

### DIFF
--- a/android/app/src/main/res/drawable/ic_media_notification.xml
+++ b/android/app/src/main/res/drawable/ic_media_notification.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M19,3H5C3.9,3 3,3.9 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.9 20.1,3 19,3ZM19,19H5V5H19V19ZM10,8V16L15,12L10,8Z" />
+</vector>

--- a/lib/services/player/audio_controller.dart
+++ b/lib/services/player/audio_controller.dart
@@ -51,6 +51,7 @@ class AudioController {
       config: const AudioServiceConfig(
         androidNotificationChannelId: 'io.github.Predidit.Kazumi.channel.audio',
         androidNotificationChannelName: 'Kazumi Playback',
+        androidNotificationIcon: 'drawable/ic_media_notification',
         androidNotificationOngoing: true,
       ),
     );

--- a/test/android_media_notification_icon_test.dart
+++ b/test/android_media_notification_icon_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const iconName = 'ic_media_notification';
+  const iconReference = 'drawable/$iconName';
+
+  test('audio service uses a dedicated drawable as its Android small icon',
+      () async {
+    final source =
+        await File('lib/services/player/audio_controller.dart').readAsString();
+
+    expect(
+      source,
+      contains("androidNotificationIcon: '$iconReference'"),
+    );
+  });
+
+  test('Android media notification icon is a white monochrome vector',
+      () async {
+    final icon = File('android/app/src/main/res/drawable/$iconName.xml');
+
+    expect(await icon.exists(), isTrue);
+    final source = await icon.readAsString();
+    expect(source, contains('<vector'));
+    expect(source, isNot(contains('<adaptive-icon')));
+
+    final fillColors = RegExp(r'android:fillColor="([^"]+)"')
+        .allMatches(source)
+        .map((match) => match.group(1))
+        .toList();
+    expect(fillColors, isNotEmpty);
+    expect(fillColors, everyElement('#FFFFFFFF'));
+  });
+}


### PR DESCRIPTION
## 描述

- 为 Android 媒体通知新增专用的白色单色矢量 small icon
- 在 `AudioServiceConfig` 中显式配置 `drawable/ic_media_notification`
- 添加配置与资源回归测试，防止重新退回 launcher 图标或引入彩色/自适应 small icon

当前配置没有指定 `androidNotificationIcon`。audio_service 0.18.18 默认使用 `mipmap/ic_launcher`，并将其传给 Android 的 `setSmallIcon()`。项目 launcher 图标是彩色自适应图标，不符合 Android 通知 small icon 需要透明背景、白色单色前景的要求，因此在 AOSP 15 播控中心显示成缺少细节的圆形方块。

## 关联的 Issues

Closes #1920

## PR 类型

- [x] Bug 修复
- [ ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [x] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: OpenAI GPT-5

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

验证结果：

- 回归测试在修复前稳定失败：配置缺少专用 small icon，drawable 资源不存在
- `flutter test test/android_media_notification_icon_test.dart`（2 项通过）
- `flutter test --no-pub`（134 项通过）
- `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无 error/warning，保留 5 条既有 info）
- `dart format --output=none --set-exit-if-changed test/android_media_notification_icon_test.dart`
- `git diff --check`

本机未配置 Android SDK，Android resource 的实际编译由 PR 的 Android release CI 验证。