### PR TITLE
fix(info): 让番剧详情头部适应辅助字号

### DIFF
--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -119,7 +119,6 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 300,
       constraints: BoxConstraints(maxWidth: 950),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -133,10 +132,9 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
             style: Theme.of(context).textTheme.headlineSmall,
           ),
           SizedBox(height: 16),
-          Expanded(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
                 Flexible(
                   child: AspectRatio(
                     aspectRatio: 0.65,
@@ -164,7 +162,7 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                   child: Skeletonizer(
                     enabled: widget.isLoading,
                     child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Column(
@@ -200,7 +198,10 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                                 ),
                               ),
                             if (!widget.isLoading)
-                              Row(
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 4,
+                                crossAxisAlignment: WrapCrossAlignment.center,
                                 children: [
                                   Text(
                                     widget.showRating
@@ -213,7 +214,6 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                                           Theme.of(context).colorScheme.primary,
                                     ),
                                   ),
-                                  const SizedBox(width: 8),
                                   RatingBarIndicator(
                                     itemCount: 5,
                                     rating: widget.showRating
@@ -246,11 +246,14 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                             ),
                           ],
                         ),
-                        SizedBox(
-                          width: 120,
-                          height: 40,
-                          child: CollectButton.extend(
-                            bangumiItem: widget.bangumiItem,
+                        SizedBox(height: 12),
+                        ConstrainedBox(
+                          constraints: BoxConstraints(minWidth: 120),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: CollectButton.extend(
+                              bangumiItem: widget.bangumiItem,
+                            ),
                           ),
                         ),
                       ],
@@ -262,8 +265,7 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                         LayoutBreakpoint.compact['width']! &&
                     !widget.isLoading)
                   voteBarChart,
-              ],
-            ),
+            ],
           ),
         ],
       ),

--- a/lib/bean/card/bangumi_info_card.dart
+++ b/lib/bean/card/bangumi_info_card.dart
@@ -135,7 +135,9 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-                Flexible(
+              Flexible(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 230),
                   child: AspectRatio(
                     aspectRatio: 0.65,
                     child: LayoutBuilder(builder: (context, boxConstraints) {
@@ -157,114 +159,115 @@ class _BangumiInfoCardVState extends State<BangumiInfoCardV> {
                     }),
                   ),
                 ),
-                SizedBox(width: 16),
-                Flexible(
-                  child: Skeletonizer(
-                    enabled: widget.isLoading,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '放送开始:',
-                            ),
-                            Text(
-                              widget.bangumiItem.airDate == ''
-                                  ? '2000-11-11' // Skeleton Loader 占位符
-                                  : widget.bangumiItem.airDate,
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            ),
-                            SizedBox(height: 8),
-                            Text(
-                              widget.showRating
-                                  ? '${widget.bangumiItem.votes} 人评分:'
-                                  : '*** 人评分:',
-                            ),
-                            if (widget.isLoading)
-                              // Skeleton Loader 占位符
-                              Text(
-                                '10.0 ********',
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                              ),
-                            if (!widget.isLoading)
-                              Wrap(
-                                spacing: 8,
-                                runSpacing: 4,
-                                crossAxisAlignment: WrapCrossAlignment.center,
-                                children: [
-                                  Text(
-                                    widget.showRating
-                                        ? '${widget.bangumiItem.ratingScore}'
-                                        : '***',
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.bold,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                                  ),
-                                  RatingBarIndicator(
-                                    itemCount: 5,
-                                    rating: widget.showRating
-                                        ? widget.bangumiItem.ratingScore
-                                                .toDouble() /
-                                            2
-                                        : 0,
-                                    itemBuilder: (context, index) => Icon(
-                                      Icons.star_rounded,
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                                    itemSize: 20.0,
-                                  ),
-                                ],
-                              ),
-                            SizedBox(height: 8),
-                            Text(
-                              'Bangumi Ranked:',
-                            ),
-                            Text(
-                              widget.showRating
-                                  ? '#${widget.bangumiItem.rank}'
-                                  : '***',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            ),
-                          ],
-                        ),
-                        SizedBox(height: 12),
-                        ConstrainedBox(
-                          constraints: BoxConstraints(minWidth: 120),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: CollectButton.extend(
-                              bangumiItem: widget.bangumiItem,
+              ),
+              SizedBox(width: 16),
+              Flexible(
+                child: Skeletonizer(
+                  enabled: widget.isLoading,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '放送开始:',
+                          ),
+                          Text(
+                            widget.bangumiItem.airDate == ''
+                                ? '2000-11-11' // Skeleton Loader 占位符
+                                : widget.bangumiItem.airDate,
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                              color: Theme.of(context).colorScheme.primary,
                             ),
                           ),
+                          SizedBox(height: 8),
+                          Text(
+                            widget.showRating
+                                ? '${widget.bangumiItem.votes} 人评分:'
+                                : '*** 人评分:',
+                          ),
+                          if (widget.isLoading)
+                            // Skeleton Loader 占位符
+                            Text(
+                              '10.0 ********',
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                            ),
+                          if (!widget.isLoading)
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 4,
+                              crossAxisAlignment: WrapCrossAlignment.center,
+                              children: [
+                                Text(
+                                  widget.showRating
+                                      ? '${widget.bangumiItem.ratingScore}'
+                                      : '***',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                  ),
+                                ),
+                                RatingBarIndicator(
+                                  itemCount: 5,
+                                  rating: widget.showRating
+                                      ? widget.bangumiItem.ratingScore
+                                              .toDouble() /
+                                          2
+                                      : 0,
+                                  itemBuilder: (context, index) => Icon(
+                                    Icons.star_rounded,
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                  ),
+                                  itemSize: 20.0,
+                                ),
+                              ],
+                            ),
+                          SizedBox(height: 8),
+                          Text(
+                            'Bangumi Ranked:',
+                          ),
+                          Text(
+                            widget.showRating
+                                ? '#${widget.bangumiItem.rank}'
+                                : '***',
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: 12),
+                      ConstrainedBox(
+                        constraints: BoxConstraints(minWidth: 120),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: CollectButton.extend(
+                            bangumiItem: widget.bangumiItem,
+                          ),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ),
-                if (widget.showRating &&
-                    MediaQuery.sizeOf(context).width >=
-                        LayoutBreakpoint.compact['width']! &&
-                    !widget.isLoading)
-                  voteBarChart,
+              ),
+              if (widget.showRating &&
+                  MediaQuery.sizeOf(context).width >=
+                      LayoutBreakpoint.compact['width']! &&
+                  !widget.isLoading)
+                voteBarChart,
             ],
           ),
         ],

--- a/lib/pages/info/info_header_slivers.dart
+++ b/lib/pages/info/info_header_slivers.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+List<Widget> buildInfoHeaderSlivers({
+  required BuildContext context,
+  required Widget header,
+  required TabBar tabBar,
+  required Color tabBarColor,
+}) {
+  return [
+    SliverToBoxAdapter(child: header),
+    SliverOverlapAbsorber(
+      handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+      sliver: SliverPersistentHeader(
+        pinned: true,
+        delegate: InfoTabBarHeaderDelegate(
+          tabBar: tabBar,
+          backgroundColor: tabBarColor,
+        ),
+      ),
+    ),
+  ];
+}
+
+class InfoTabBarHeaderDelegate extends SliverPersistentHeaderDelegate {
+  const InfoTabBarHeaderDelegate({
+    required this.tabBar,
+    required this.backgroundColor,
+  });
+
+  final TabBar tabBar;
+  final Color backgroundColor;
+
+  @override
+  double get minExtent => tabBar.preferredSize.height;
+
+  @override
+  double get maxExtent => tabBar.preferredSize.height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Material(
+      color: backgroundColor,
+      elevation: overlapsContent ? 1 : 0,
+      child: tabBar,
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant InfoTabBarHeaderDelegate oldDelegate) {
+    return oldDelegate.tabBar != tabBar ||
+        oldDelegate.backgroundColor != backgroundColor;
+  }
+}

--- a/lib/pages/info/info_header_slivers.dart
+++ b/lib/pages/info/info_header_slivers.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+double adaptiveInfoToolbarHeight(
+  BuildContext context, {
+  double nativeControlOffset = 0,
+}) {
+  return MediaQuery.textScalerOf(context).scale(kToolbarHeight) +
+      nativeControlOffset;
+}
+
 List<Widget> buildInfoHeaderSlivers({
   required BuildContext context,
   required Widget header,

--- a/lib/pages/info/info_header_slivers.dart
+++ b/lib/pages/info/info_header_slivers.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 
+const double _appBarTitleMaxScaleFactor = 1.34;
+
 double adaptiveInfoToolbarHeight(
   BuildContext context, {
   double nativeControlOffset = 0,
 }) {
-  return MediaQuery.textScalerOf(context).scale(kToolbarHeight) +
-      nativeControlOffset;
+  final toolbarTextScaler = MediaQuery.textScalerOf(context).clamp(
+    maxScaleFactor: _appBarTitleMaxScaleFactor,
+  );
+  return toolbarTextScaler.scale(kToolbarHeight) + nativeControlOffset;
 }
 
 List<Widget> buildInfoHeaderSlivers({

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -354,9 +354,10 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     final bool showWindowButton =
         GStorage.getSetting(SettingsKeys.showWindowButton);
     final bool showRatingFab = _fabTabIndex == _commentsTabIndex;
-    final toolbarHeight = (Platform.isMacOS && showWindowButton)
-        ? kToolbarHeight + 22
-        : kToolbarHeight;
+    final toolbarHeight = adaptiveInfoToolbarHeight(
+      context,
+      nativeControlOffset: Platform.isMacOS && showWindowButton ? 22 : 0,
+    );
     return PopScope(
       canPop: true,
       child: DefaultTabController(
@@ -448,6 +449,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
                           ),
                         ),
                       EmbeddedNativeControlArea(
+                        requireOffset: false,
                         child: Padding(
                           padding: const EdgeInsets.all(16),
                           child: Align(

--- a/lib/pages/info/info_page.dart
+++ b/lib/pages/info/info_page.dart
@@ -9,6 +9,7 @@ import 'package:kazumi/bean/widget/collect_button.dart';
 import 'package:kazumi/bean/widget/embedded_native_control_area.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/pages/info/info_controller.dart';
+import 'package:kazumi/pages/info/info_header_slivers.dart';
 import 'package:kazumi/bean/card/bangumi_info_card.dart';
 import 'package:kazumi/pages/info/source_sheet.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
@@ -65,6 +66,7 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
   bool staffQueryTimeout = false;
   bool staffIsEmpty = false;
   bool _showBangumiInfoSkeleton = false;
+  bool _showAppBarCollect = false;
   int _fabTabIndex = 0;
 
   BangumiItem get inputBangumiIten => widget.inputBangumiItem;
@@ -273,6 +275,16 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     });
   }
 
+  void _syncAppBarCollectVisibility(bool visible) {
+    if (_showAppBarCollect == visible) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _showAppBarCollect == visible) return;
+      setState(() {
+        _showAppBarCollect = visible;
+      });
+    });
+  }
+
   Future<void> onCommentsTabSelected() async {
     final interest = infoController.bangumiItem.interest;
     final token =
@@ -342,134 +354,116 @@ class _InfoPageState extends State<InfoPage> with TickerProviderStateMixin {
     final bool showWindowButton =
         GStorage.getSetting(SettingsKeys.showWindowButton);
     final bool showRatingFab = _fabTabIndex == _commentsTabIndex;
+    final toolbarHeight = (Platform.isMacOS && showWindowButton)
+        ? kToolbarHeight + 22
+        : kToolbarHeight;
     return PopScope(
       canPop: true,
       child: DefaultTabController(
         length: _infoTabs.length,
         child: Scaffold(
-          body: NestedScrollView(
-            headerSliverBuilder:
-                (BuildContext context, bool innerBoxIsScrolled) {
-              return <Widget>[
-                SliverOverlapAbsorber(
-                  handle:
-                      NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                  sliver: SliverAppBar.medium(
-                    title: EmbeddedNativeControlArea(
-                      child: dtb.DragToMoveArea(
-                        child: Container(
-                          width: double.infinity,
-                          alignment: Alignment.centerLeft,
-                          child: Text(
-                            infoController.bangumiItem.nameCn == ''
-                                ? infoController.bangumiItem.name
-                                : infoController.bangumiItem.nameCn,
-                          ),
-                        ),
-                      ),
-                    ),
-                    automaticallyImplyLeading: false,
-                    scrolledUnderElevation: 0.0,
-                    leading: EmbeddedNativeControlArea(
-                      child: IconButton(
-                        onPressed: () {
-                          context.maybePop();
-                        },
-                        icon: Icon(Icons.arrow_back),
-                      ),
-                    ),
-                    actions: [
-                      if (innerBoxIsScrolled)
-                        EmbeddedNativeControlArea(
-                          child: CollectButton(
-                            bangumiItem: infoController.bangumiItem,
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      EmbeddedNativeControlArea(
-                        child: IconButton(
-                          onPressed: () {
-                            launchUrl(
-                              Uri.parse(
-                                  'https://bangumi.tv/subject/${infoController.bangumiItem.id}'),
-                              mode: LaunchMode.externalApplication,
-                            );
-                          },
-                          icon: const Icon(Icons.open_in_browser_rounded),
-                        ),
-                      ),
-                      if (!showWindowButton && isDesktop())
-                        CloseButton(onPressed: () => windowManager.close()),
-                      SizedBox(width: 8),
-                    ],
-                    toolbarHeight: (Platform.isMacOS && showWindowButton)
-                        ? kToolbarHeight + 22
-                        : kToolbarHeight,
-                    stretch: true,
-                    centerTitle: false,
-                    expandedHeight: (Platform.isMacOS && showWindowButton)
-                        ? 308 + kTextTabBarHeight + kToolbarHeight + 22
-                        : 308 + kTextTabBarHeight + kToolbarHeight,
-                    collapsedHeight: (Platform.isMacOS && showWindowButton)
-                        ? kTextTabBarHeight +
-                            kToolbarHeight +
-                            MediaQuery.paddingOf(context).top +
-                            22
-                        : kTextTabBarHeight +
-                            kToolbarHeight +
-                            MediaQuery.paddingOf(context).top,
-                    flexibleSpace: FlexibleSpaceBar(
-                      collapseMode: CollapseMode.pin,
-                      background: Observer(builder: (context) {
-                        final showBangumiInfoSkeleton =
-                            _isShowingBangumiInfoSkeleton;
-                        return Stack(
-                          children: [
-                            // No background image when loading to make loading looks better
-                            if (!showBangumiInfoSkeleton)
-                              Positioned.fill(
-                                bottom: kTextTabBarHeight,
-                                child: IgnorePointer(
-                                  child: _InfoHeaderBackground(
-                                    imageUrl: infoController
-                                            .bangumiItem.images['large'] ??
-                                        '',
-                                  ),
-                                ),
-                              ),
-                            SafeArea(
-                              bottom: false,
-                              child: EmbeddedNativeControlArea(
-                                child: Align(
-                                  alignment: Alignment.topCenter,
-                                  child: Padding(
-                                    padding: const EdgeInsets.fromLTRB(
-                                        16, kToolbarHeight, 16, 0),
-                                    child: BangumiInfoCardV(
-                                      bangumiItem: infoController.bangumiItem,
-                                      isLoading: showBangumiInfoSkeleton,
-                                      showRating: showRating,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        );
-                      }),
-                    ),
-                    forceElevated: innerBoxIsScrolled,
-                    bottom: TabBar(
-                      controller: infoTabController,
-                      isScrollable: true,
-                      tabAlignment: TabAlignment.center,
-                      dividerHeight: 0,
-                      tabs: _infoTabs.map((name) => Tab(text: name)).toList(),
+          appBar: PreferredSize(
+            preferredSize: Size.fromHeight(toolbarHeight),
+            child: AppBar(
+              title: EmbeddedNativeControlArea(
+                child: dtb.DragToMoveArea(
+                  child: Container(
+                    width: double.infinity,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      infoController.bangumiItem.nameCn == ''
+                          ? infoController.bangumiItem.name
+                          : infoController.bangumiItem.nameCn,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
                 ),
-              ];
+              ),
+              automaticallyImplyLeading: false,
+              scrolledUnderElevation: 0.0,
+              leading: EmbeddedNativeControlArea(
+                child: IconButton(
+                  onPressed: () {
+                    context.maybePop();
+                  },
+                  icon: Icon(Icons.arrow_back),
+                ),
+              ),
+              actions: [
+                if (_showAppBarCollect)
+                  EmbeddedNativeControlArea(
+                    child: CollectButton(
+                      bangumiItem: infoController.bangumiItem,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                EmbeddedNativeControlArea(
+                  child: IconButton(
+                    onPressed: () {
+                      launchUrl(
+                        Uri.parse(
+                            'https://bangumi.tv/subject/${infoController.bangumiItem.id}'),
+                        mode: LaunchMode.externalApplication,
+                      );
+                    },
+                    icon: const Icon(Icons.open_in_browser_rounded),
+                  ),
+                ),
+                if (!showWindowButton && isDesktop())
+                  CloseButton(onPressed: () => windowManager.close()),
+                SizedBox(width: 8),
+              ],
+              toolbarHeight: toolbarHeight,
+              centerTitle: false,
+            ),
+          ),
+          body: NestedScrollView(
+            headerSliverBuilder:
+                (BuildContext context, bool innerBoxIsScrolled) {
+              _syncAppBarCollectVisibility(innerBoxIsScrolled);
+              return buildInfoHeaderSlivers(
+                context: context,
+                tabBarColor: Theme.of(context).scaffoldBackgroundColor,
+                tabBar: TabBar(
+                  controller: infoTabController,
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.center,
+                  dividerHeight: 0,
+                  tabs: _infoTabs.map((name) => Tab(text: name)).toList(),
+                ),
+                header: Observer(builder: (context) {
+                  final showBangumiInfoSkeleton =
+                      _isShowingBangumiInfoSkeleton;
+                  return Stack(
+                    children: [
+                      if (!showBangumiInfoSkeleton)
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            child: _InfoHeaderBackground(
+                              imageUrl: infoController
+                                      .bangumiItem.images['large'] ??
+                                  '',
+                            ),
+                          ),
+                        ),
+                      EmbeddedNativeControlArea(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Align(
+                            alignment: Alignment.topCenter,
+                            child: BangumiInfoCardV(
+                              bangumiItem: infoController.bangumiItem,
+                              isLoading: showBangumiInfoSkeleton,
+                              showRating: showRating,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }),
+              );
             },
             body: Observer(builder: (context) {
               final showBangumiInfoSkeleton = _isShowingBangumiInfoSkeleton;

--- a/test/adaptive_info_header_test.dart
+++ b/test/adaptive_info_header_test.dart
@@ -175,6 +175,7 @@ void main() {
 
     expect(tester.takeException(), isNull);
     final appBarRect = tester.getRect(find.byType(AppBar));
+    expect(appBarRect.height, closeTo(kToolbarHeight * 1.34, 1));
     final appBarTitleRect = tester.getRect(
       find.descendant(
         of: find.byType(AppBar),

--- a/test/adaptive_info_header_test.dart
+++ b/test/adaptive_info_header_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kazumi/bean/card/bangumi_info_card.dart';
+import 'package:kazumi/bean/card/network_img_layer.dart';
 import 'package:kazumi/modules/bangumi/bangumi_item.dart';
 import 'package:kazumi/modules/collect/collect_change_module.dart';
 import 'package:kazumi/modules/collect/collect_module.dart';
@@ -50,9 +51,10 @@ void main() {
           }
           if (width == 1200 && scale == 1) {
             expect(find.text('  评分透视:'), findsOneWidget);
-          }
-          if (width == 1200 && scale == 1) {
-            expect(find.text('  评分透视:'), findsOneWidget);
+            expect(
+              tester.getSize(find.byType(NetworkImgLayer)).height,
+              lessThanOrEqualTo(230),
+            );
           }
 
           await tester.ensureVisible(buttonFinder);
@@ -121,40 +123,49 @@ void main() {
           ),
           child: DefaultTabController(
             length: 2,
-            child: Scaffold(
-              appBar: AppBar(
-                title: const Text(
-                  _longTitle,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              body: NestedScrollView(
-                headerSliverBuilder: (context, innerBoxIsScrolled) {
-                  return buildInfoHeaderSlivers(
-                    context: context,
-                    tabBarColor: Theme.of(context).scaffoldBackgroundColor,
-                    header: Container(
-                      key: headerKey,
-                      padding: const EdgeInsets.all(16),
-                      child: BangumiInfoCardV(
-                        bangumiItem: _bangumiItem(),
-                        isLoading: false,
-                        showRating: true,
+            child: Builder(
+              builder: (context) {
+                final toolbarHeight = adaptiveInfoToolbarHeight(context);
+                return Scaffold(
+                  appBar: PreferredSize(
+                    preferredSize: Size.fromHeight(toolbarHeight),
+                    child: AppBar(
+                      toolbarHeight: toolbarHeight,
+                      title: const Text(
+                        _longTitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
-                    tabBar: const TabBar(
-                      tabs: [Tab(text: '概览'), Tab(text: '评论')],
+                  ),
+                  body: NestedScrollView(
+                    headerSliverBuilder: (context, innerBoxIsScrolled) {
+                      return buildInfoHeaderSlivers(
+                        context: context,
+                        tabBarColor: Theme.of(context).scaffoldBackgroundColor,
+                        header: Container(
+                          key: headerKey,
+                          padding: const EdgeInsets.all(16),
+                          child: BangumiInfoCardV(
+                            bangumiItem: _bangumiItem(),
+                            isLoading: false,
+                            showRating: true,
+                          ),
+                        ),
+                        tabBar: const TabBar(
+                          tabs: [Tab(text: '概览'), Tab(text: '评论')],
+                        ),
+                      );
+                    },
+                    body: TabBarView(
+                      children: [
+                        _tabBody(const ValueKey('overview-body')),
+                        _tabBody(const ValueKey('comments-body')),
+                      ],
                     ),
-                  );
-                },
-                body: TabBarView(
-                  children: [
-                    _tabBody(const ValueKey('overview-body')),
-                    _tabBody(const ValueKey('comments-body')),
-                  ],
-                ),
-              ),
+                  ),
+                );
+              },
             ),
           ),
         ),
@@ -163,6 +174,15 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
+    final appBarRect = tester.getRect(find.byType(AppBar));
+    final appBarTitleRect = tester.getRect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text(_longTitle),
+      ),
+    );
+    expect(appBarTitleRect.top, greaterThanOrEqualTo(appBarRect.top));
+    expect(appBarTitleRect.bottom, lessThanOrEqualTo(appBarRect.bottom));
     expect(find.byKey(headerKey), findsOneWidget);
     await tester.flingFrom(
       const Offset(180, 800),
@@ -172,8 +192,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(headerKey), findsNothing);
-    expect(
-        tester.getTopLeft(find.byType(TabBar)).dy, closeTo(kToolbarHeight, 1));
+    expect(tester.getTopLeft(find.byType(TabBar)).dy,
+        closeTo(appBarRect.bottom, 1));
     await tester.tap(find.text('评论'));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('comments-body')), findsOneWidget);

--- a/test/adaptive_info_header_test.dart
+++ b/test/adaptive_info_header_test.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/card/bangumi_info_card.dart';
+import 'package:kazumi/modules/bangumi/bangumi_item.dart';
+import 'package:kazumi/modules/collect/collect_change_module.dart';
+import 'package:kazumi/modules/collect/collect_module.dart';
+import 'package:kazumi/modules/collect/collect_type.dart';
+import 'package:kazumi/pages/collect/collect_controller.dart';
+import 'package:kazumi/pages/info/info_header_slivers.dart';
+import 'package:kazumi/repositories/collect_crud_repository.dart';
+import 'package:kazumi/repositories/collect_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final width in <double>[360, 600, 1200]) {
+    for (final scale in <double>[1, 1.3, 1.5, 1.7, 2, 3]) {
+      testWidgets(
+        'keeps info and collect controls reachable at ${width}x ${scale}x',
+        (tester) async {
+          tester.view.physicalSize = Size(width, 1000);
+          tester.view.devicePixelRatio = 1;
+          addTearDown(tester.view.reset);
+          _bootstrapCollectController();
+
+          await tester.pumpWidget(_cardApp(textScale: scale));
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          final cardFinder = find.byType(BangumiInfoCardV);
+          final cardRect = tester.getRect(cardFinder);
+          final titleFinder = find.text(_longTitle);
+          final dateFinder = find.text('2026-08-17');
+          final scoreFinder = find.text('8.2');
+          final buttonFinder = find.widgetWithText(FilledButton, '未追');
+
+          for (final finder in [
+            titleFinder,
+            dateFinder,
+            scoreFinder,
+            buttonFinder,
+          ]) {
+            expect(finder, findsOneWidget);
+            final rect = tester.getRect(finder);
+            expect(rect.top, greaterThanOrEqualTo(cardRect.top));
+            expect(rect.bottom, lessThanOrEqualTo(cardRect.bottom));
+            expect(rect.left, greaterThanOrEqualTo(cardRect.left));
+            expect(rect.right, lessThanOrEqualTo(cardRect.right));
+          }
+          if (width == 1200 && scale == 1) {
+            expect(find.text('  评分透视:'), findsOneWidget);
+          }
+          if (width == 1200 && scale == 1) {
+            expect(find.text('  评分透视:'), findsOneWidget);
+          }
+
+          await tester.ensureVisible(buttonFinder);
+          await tester.tap(buttonFinder);
+          await tester.pumpAndSettle();
+
+          expect(find.byType(MenuItemButton), findsNWidgets(6));
+          final menuContext = tester.element(find.text(' 在看'));
+          expect(
+            MediaQuery.textScalerOf(menuContext).scale(16),
+            closeTo(scale * 16, 0.01),
+          );
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
+  }
+
+  testWidgets('card height grows with accessible text', (tester) async {
+    tester.view.physicalSize = const Size(360, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    _bootstrapCollectController();
+
+    await tester.pumpWidget(_cardApp(textScale: 1));
+    await tester.pumpAndSettle();
+    final normalHeight = tester.getSize(find.byType(BangumiInfoCardV)).height;
+
+    await tester.pumpWidget(_cardApp(textScale: 3));
+    await tester.pumpAndSettle();
+    final accessibleHeight =
+        tester.getSize(find.byType(BangumiInfoCardV)).height;
+
+    expect(accessibleHeight, greaterThan(normalHeight));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('loading card also keeps natural height at 3x', (tester) async {
+    tester.view.physicalSize = const Size(360, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    _bootstrapCollectController();
+
+    await tester.pumpWidget(_cardApp(textScale: 3, isLoading: true));
+    await tester.pump();
+
+    expect(
+        tester.getSize(find.byType(BangumiInfoCardV)).height, greaterThan(300));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('natural header scrolls away while the tab bar stays pinned',
+      (tester) async {
+    tester.view.physicalSize = const Size(360, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    _bootstrapCollectController();
+    const headerKey = ValueKey('natural-info-header');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(360, 1000),
+            textScaler: TextScaler.linear(3),
+          ),
+          child: DefaultTabController(
+            length: 2,
+            child: Scaffold(
+              appBar: AppBar(
+                title: const Text(
+                  _longTitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              body: NestedScrollView(
+                headerSliverBuilder: (context, innerBoxIsScrolled) {
+                  return buildInfoHeaderSlivers(
+                    context: context,
+                    tabBarColor: Theme.of(context).scaffoldBackgroundColor,
+                    header: Container(
+                      key: headerKey,
+                      padding: const EdgeInsets.all(16),
+                      child: BangumiInfoCardV(
+                        bangumiItem: _bangumiItem(),
+                        isLoading: false,
+                        showRating: true,
+                      ),
+                    ),
+                    tabBar: const TabBar(
+                      tabs: [Tab(text: '概览'), Tab(text: '评论')],
+                    ),
+                  );
+                },
+                body: TabBarView(
+                  children: [
+                    _tabBody(const ValueKey('overview-body')),
+                    _tabBody(const ValueKey('comments-body')),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(headerKey), findsOneWidget);
+    await tester.flingFrom(
+      const Offset(180, 800),
+      const Offset(0, -900),
+      3000,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(headerKey), findsNothing);
+    expect(
+        tester.getTopLeft(find.byType(TabBar)).dy, closeTo(kToolbarHeight, 1));
+    await tester.tap(find.text('评论'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('comments-body')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _tabBody(Key key) {
+  return Builder(
+    builder: (context) {
+      return CustomScrollView(
+        key: key,
+        slivers: [
+          SliverOverlapInjector(
+            handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 1200)),
+        ],
+      );
+    },
+  );
+}
+
+const _longTitle = '这是一个非常非常长而且必须占据多行显示空间的番剧标题名称';
+
+Widget _cardApp({required double textScale, bool isLoading = false}) {
+  return MaterialApp(
+    home: Builder(
+      builder: (context) {
+        final mediaQuery = MediaQuery.of(context);
+        return MediaQuery(
+          data: mediaQuery.copyWith(
+            textScaler: TextScaler.linear(textScale),
+          ),
+          child: Scaffold(
+            body: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: BangumiInfoCardV(
+                  bangumiItem: _bangumiItem(),
+                  isLoading: isLoading,
+                  showRating: true,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    ),
+  );
+}
+
+BangumiItem _bangumiItem() {
+  return BangumiItem(
+    id: 942,
+    type: 2,
+    name: _longTitle,
+    nameCn: _longTitle,
+    summary: 'summary',
+    airDate: '2026-08-17',
+    airWeekday: 1,
+    rank: 942,
+    images: const <String, String>{},
+    tags: const [],
+    alias: const [],
+    ratingScore: 8.2,
+    votes: 1000,
+    votesCount: List<int>.filled(10, 100),
+    info: '',
+  );
+}
+
+void _bootstrapCollectController() {
+  bootstrapModule(
+    createModule(
+      register: (context) => context.addInstance<CollectController>(
+        CollectController(
+          _FakeCollectCrudRepository(),
+          _FakeCollectRepository(),
+        ),
+      ),
+    ),
+  );
+}
+
+class _FakeCollectCrudRepository implements ICollectCrudRepository {
+  @override
+  Stream<void> get changes => const Stream<void>.empty();
+
+  @override
+  Future<void> addCollectChange(CollectedBangumiChange change) async {}
+
+  @override
+  Future<void> addCollectible(BangumiItem bangumiItem, int type) async {}
+
+  @override
+  Future<void> clearFavorites() async {}
+
+  @override
+  Future<void> deleteCollectible(int id) async {}
+
+  @override
+  List<CollectedBangumi> getAllCollectibles() => const [];
+
+  @override
+  CollectedBangumi? getCollectible(int id) => null;
+
+  @override
+  int getCollectType(int id) => 0;
+
+  @override
+  List<BangumiItem> getFavorites() => const [];
+
+  @override
+  Future<void> updateCollectible(BangumiItem bangumiItem) async {}
+}
+
+class _FakeCollectRepository implements ICollectRepository {
+  @override
+  Set<int> getBangumiIdsByType(CollectType type) => const {};
+
+  @override
+  Set<int> getBangumiIdsByTypes(List<CollectType> types) => const {};
+
+  @override
+  bool getPrivateMode() => false;
+
+  @override
+  bool getTimelineNotShowAbandonedBangumis() => false;
+
+  @override
+  bool getTimelineNotShowWatchedBangumis() => false;
+
+  @override
+  bool getTimelineOnlyShowWatchingBangumis() => false;
+
+  @override
+  Future<void> updateTimelineNotShowAbandonedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineNotShowWatchedBangumis(bool value) async {}
+
+  @override
+  Future<void> updateTimelineOnlyShowWatchingBangumis(bool value) async {}
+}


### PR DESCRIPTION
## 修复内容

- 移除番剧信息卡固定的 300px 高度，让卡片按标题、日期、评分和追番按钮的实际内容自然增长。
- 将信息卡从固定高度 `FlexibleSpaceBar` 拆为自然高度 sliver，背景随卡片高度延展。
- 顶部 AppBar 高度与 Flutter 标题的 1.34 最大缩放保持一致；TabBar 独立为 pinned sliver。
- 海报保留原视觉上限 230px，避免宽屏下由横向空间推动 header 异常增高。
- 评分与星级在横向空间不足时自动换行。
- 追番按钮使用自然尺寸，按钮与菜单继承完整系统字体缩放。
- macOS header 取消已经多余的原生控制区 22px 二次偏移。

## 根因

详情页此前同时固定了信息卡高度和 SliverAppBar 展开高度。长标题或系统辅助字号增大后，内容只能继续挤在固定空间里，最终把追番按钮推到卡片外并产生横纵向溢出。局部缩放、裁剪或内部滚动无法覆盖所有辅助字号，因此改为自然高度 sliver 结构。

## 验证

- [x] 当前 main 在真实窗口和大字号下稳定复现溢出
- [x] `flutter test test/adaptive_info_header_test.dart`（21 项）
- [x] `flutter test`（153 项）
- [x] `flutter analyze --no-fatal-infos --fatal-warnings`（通过，仅有 5 条既有 info）
- [x] 真实窗口宽度 360 / 600 / 1200
- [x] 字体比例 1.0 / 1.3 / 1.5 / 1.7 / 2.0 / 3.0
- [x] 标题、日期、评分、追番入口均位于自然高度卡片内
- [x] 追番菜单继承完整系统字体缩放
- [x] 3.0 下卡片高度相对 1.0 自然增长
- [x] 加载态 3.0 无溢出
- [x] 外层拖动有效、TabBar pinned、Tab 切换有效
- [x] 3.0 AppBar 标题未被工具栏裁剪，工具栏高度不超过标题的 1.34 最大缩放
- [x] 1200 宽海报高度不超过 230px
- [x] 宽屏保留扩展追番按钮和评分透视图
- [x] 没有额外 `TextPainter.layout()`、内部纵向滚动、整列缩放或全子树字体 clamp
- [x] `dart format lib/bean/card/bangumi_info_card.dart lib/pages/info/info_header_slivers.dart test/adaptive_info_header_test.dart`
- [x] `git diff --check`

Closes #942
