### PR TITLE
feat(plugin): support custom rule repositories

### DIFF
--- a/lib/pages/plugin_editor/plugin_catalog_view.dart
+++ b/lib/pages/plugin_editor/plugin_catalog_view.dart
@@ -163,15 +163,20 @@ class PluginCatalogViewState extends State<PluginCatalogView> {
 
   Widget _buildLoadError() {
     final enableGitProxy = GStorage.getSetting(SettingsKeys.enableGitProxy);
+    final customRepository = GStorage.getSetting(
+      SettingsKeys.ruleRepositoryUrl,
+    ).isNotEmpty;
     return Center(
       child: GeneralErrorWidget(
-        errMsg:
-            '${widget.errorMessage}\n${enableGitProxy ? '规则仓库镜像已启用' : '规则仓库镜像已禁用'}',
+        errMsg: customRepository
+            ? '${widget.errorMessage}\n当前使用自定义规则仓库'
+            : '${widget.errorMessage}\n${enableGitProxy ? '规则仓库镜像已启用' : '规则仓库镜像已禁用'}',
         actions: [
-          GeneralErrorButton(
-            onPressed: () => unawaited(_toggleGitProxyAndRefresh()),
-            text: enableGitProxy ? '禁用规则镜像' : '启用规则镜像',
-          ),
+          if (!customRepository)
+            GeneralErrorButton(
+              onPressed: () => unawaited(_toggleGitProxyAndRefresh()),
+              text: enableGitProxy ? '禁用规则镜像' : '启用规则镜像',
+            ),
           GeneralErrorButton(onPressed: refresh, text: '刷新'),
         ],
       ),

--- a/lib/pages/plugin_editor/plugin_catalog_view.dart
+++ b/lib/pages/plugin_editor/plugin_catalog_view.dart
@@ -7,6 +7,7 @@ import 'package:kazumi/bean/widget/error_widget.dart';
 import 'package:kazumi/modules/plugin/plugin_http_module.dart';
 import 'package:kazumi/pages/plugin_editor/plugin_update_actions.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
+import 'package:kazumi/request/config/rules_repository_config.dart';
 import 'package:kazumi/services/storage/storage.dart';
 
 enum PluginCatalogSort { lastUpdate, name }
@@ -49,41 +50,42 @@ class PluginCatalogViewState extends State<PluginCatalogView> {
     }
   }
 
-  Future<void> _loadPluginCatalog({bool forceRefresh = false}) async {
+  Future<bool> _loadPluginCatalog({bool forceRefresh = false}) async {
     try {
       if (forceRefresh) {
         await _controller.refreshPluginCatalog();
       } else {
         await _controller.ensurePluginCatalog();
       }
-      if (!mounted) return;
+      if (!mounted) return true;
       setState(() {
         _loading = false;
         _loadFailed = false;
       });
+      return true;
     } catch (_) {
-      if (!mounted) return;
+      if (!mounted) return false;
       setState(() {
         _loading = false;
         _loadFailed = true;
       });
+      return false;
     }
   }
 
-  void refresh() {
-    if (_loading) return;
+  Future<bool> refresh() {
     setState(() {
       _loading = true;
       _loadFailed = false;
     });
-    unawaited(_loadPluginCatalog(forceRefresh: true));
+    return _loadPluginCatalog(forceRefresh: true);
   }
 
   Future<void> _toggleGitProxyAndRefresh() async {
     final enableGitProxy = GStorage.getSetting(SettingsKeys.enableGitProxy);
     await GStorage.putSetting(SettingsKeys.enableGitProxy, !enableGitProxy);
     if (!mounted) return;
-    refresh();
+    await refresh();
   }
 
   List<PluginHTTPItem> _sortedItems() {
@@ -163,9 +165,9 @@ class PluginCatalogViewState extends State<PluginCatalogView> {
 
   Widget _buildLoadError() {
     final enableGitProxy = GStorage.getSetting(SettingsKeys.enableGitProxy);
-    final customRepository = GStorage.getSetting(
-      SettingsKeys.ruleRepositoryUrl,
-    ).isNotEmpty;
+    final customRepository = RulesRepositoryConfig.isCustomRepository(
+      GStorage.getSetting(SettingsKeys.ruleRepositoryUrl),
+    );
     return Center(
       child: GeneralErrorWidget(
         errMsg: customRepository
@@ -177,7 +179,10 @@ class PluginCatalogViewState extends State<PluginCatalogView> {
               onPressed: () => unawaited(_toggleGitProxyAndRefresh()),
               text: enableGitProxy ? '禁用规则镜像' : '启用规则镜像',
             ),
-          GeneralErrorButton(onPressed: refresh, text: '刷新'),
+          GeneralErrorButton(
+            onPressed: () => unawaited(refresh()),
+            text: '刷新',
+          ),
         ],
       ),
     );
@@ -207,7 +212,7 @@ class PluginCatalogViewState extends State<PluginCatalogView> {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             IconButton(
-              onPressed: refresh,
+              onPressed: () => unawaited(refresh()),
               tooltip: '刷新规则列表',
               icon: const Icon(Icons.refresh_rounded),
             ),

--- a/lib/pages/plugin_editor/plugin_shop_page.dart
+++ b/lib/pages/plugin_editor/plugin_shop_page.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:kazumi/bean/appbar/sys_app_bar.dart';
+import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/pages/plugin_editor/plugin_catalog_view.dart';
 import 'package:kazumi/plugins/plugins_controller.dart';
+import 'package:kazumi/request/config/api_endpoints.dart';
+import 'package:kazumi/request/config/rules_repository_config.dart';
+import 'package:kazumi/services/storage/storage.dart';
 
 class PluginShopPage extends StatefulWidget {
   const PluginShopPage({
@@ -25,12 +29,81 @@ class _PluginShopPageState extends State<PluginShopPage> {
     });
   }
 
+  Future<void> _configureRepository() async {
+    final currentUrl = GStorage.getSetting(SettingsKeys.ruleRepositoryUrl);
+    final textController = TextEditingController(text: currentUrl);
+    final result = await KazumiDialog.show<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('设置规则仓库'),
+        content: SizedBox(
+          width: 520,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('仅添加你信任的仓库。第三方规则会访问其声明的网站和接口。'),
+              const SizedBox(height: 16),
+              TextField(
+                controller: textController,
+                autofocus: true,
+                keyboardType: TextInputType.url,
+                decoration: InputDecoration(
+                  labelText: '仓库地址',
+                  hintText: ApiEndpoints.pluginShop,
+                  helperText: '填写包含 index.json 的目录，或直接粘贴 index.json URL',
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(''),
+            child: const Text('恢复官方仓库'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(textController.text),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    textController.dispose();
+    if (result == null) return;
+
+    try {
+      final normalized = RulesRepositoryConfig.normalizeForStorage(result);
+      await GStorage.putSetting(SettingsKeys.ruleRepositoryUrl, normalized);
+      catalogKey.currentState?.refresh();
+      if (!mounted) return;
+      KazumiDialog.showToast(
+        context: context,
+        message: normalized.isEmpty ? '已恢复官方规则仓库' : '已切换规则仓库',
+      );
+    } on FormatException catch (error) {
+      if (!mounted) return;
+      KazumiDialog.showToast(context: context, message: error.message);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: SysAppBar(
         title: const Text('规则仓库'),
         actions: [
+          IconButton(
+            onPressed: _configureRepository,
+            tooltip: '设置规则仓库',
+            icon: const Icon(Icons.storage_rounded),
+          ),
           IconButton(
               onPressed: _toggleSort,
               tooltip: sortByName ? '按名称排序' : '按更新时间排序',

--- a/lib/pages/plugin_editor/plugin_shop_page.dart
+++ b/lib/pages/plugin_editor/plugin_shop_page.dart
@@ -31,61 +31,25 @@ class _PluginShopPageState extends State<PluginShopPage> {
 
   Future<void> _configureRepository() async {
     final currentUrl = GStorage.getSetting(SettingsKeys.ruleRepositoryUrl);
-    final textController = TextEditingController(text: currentUrl);
     final result = await KazumiDialog.show<String>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('设置规则仓库'),
-        content: SizedBox(
-          width: 520,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text('仅添加你信任的仓库。第三方规则会访问其声明的网站和接口。'),
-              const SizedBox(height: 16),
-              TextField(
-                controller: textController,
-                autofocus: true,
-                keyboardType: TextInputType.url,
-                decoration: InputDecoration(
-                  labelText: '仓库地址',
-                  hintText: ApiEndpoints.pluginShop,
-                  helperText: '填写包含 index.json 的目录，或直接粘贴 index.json URL',
-                  border: const OutlineInputBorder(),
-                ),
-              ),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(''),
-            child: const Text('恢复官方仓库'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('取消'),
-          ),
-          FilledButton(
-            onPressed: () =>
-                Navigator.of(dialogContext).pop(textController.text),
-            child: const Text('保存'),
-          ),
-        ],
+      builder: (_) => _RepositoryDialog(
+        initialUrl: currentUrl,
       ),
     );
-    textController.dispose();
     if (result == null) return;
 
     try {
       final normalized = RulesRepositoryConfig.normalizeForStorage(result);
       await GStorage.putSetting(SettingsKeys.ruleRepositoryUrl, normalized);
-      catalogKey.currentState?.refresh();
+      widget.controller.invalidatePluginCatalog();
+      final refreshed = await catalogKey.currentState?.refresh() ?? false;
       if (!mounted) return;
       KazumiDialog.showToast(
         context: context,
-        message: normalized.isEmpty ? '已恢复官方规则仓库' : '已切换规则仓库',
+        message: refreshed
+            ? (normalized.isEmpty ? '已恢复官方规则仓库' : '已切换规则仓库')
+            : '仓库地址已保存，但目录加载失败',
       );
     } on FormatException catch (error) {
       if (!mounted) return;
@@ -121,6 +85,74 @@ class _PluginShopPageState extends State<PluginShopPage> {
             sortByName ? PluginCatalogSort.name : PluginCatalogSort.lastUpdate,
         errorMessage: '啊咧（⊙.⊙） 无法访问规则仓库',
       ),
+    );
+  }
+}
+
+class _RepositoryDialog extends StatefulWidget {
+  const _RepositoryDialog({required this.initialUrl});
+
+  final String initialUrl;
+
+  @override
+  State<_RepositoryDialog> createState() => _RepositoryDialogState();
+}
+
+class _RepositoryDialogState extends State<_RepositoryDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialUrl);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('设置规则仓库'),
+      content: SizedBox(
+        width: 520,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('仅添加你信任的仓库。第三方规则会访问其声明的网站和接口。'),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              keyboardType: TextInputType.url,
+              decoration: const InputDecoration(
+                labelText: '仓库地址',
+                hintText: ApiEndpoints.pluginShop,
+                helperText: '填写包含 index.json 的目录，或直接粘贴 index.json URL',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(''),
+          child: const Text('恢复官方仓库'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(_controller.text),
+          child: const Text('保存'),
+        ),
+      ],
     );
   }
 }

--- a/lib/plugins/plugins_controller.dart
+++ b/lib/plugins/plugins_controller.dart
@@ -10,7 +10,6 @@ import 'package:kazumi/request/apis/plugin_catalog_api.dart';
 import 'package:kazumi/modules/plugin/plugin_http_module.dart';
 import 'package:kazumi/services/logging/logger.dart';
 import 'package:kazumi/utils/async_serial_queue.dart';
-import 'package:kazumi/utils/async_single_flight.dart';
 import 'package:kazumi/utils/version.dart';
 
 part 'plugins_controller.g.dart';
@@ -77,8 +76,7 @@ abstract class _PluginsController with Store {
   final PluginLoader _pluginLoader;
   final PluginJsonWriter? _pluginJsonWriter;
   final PluginErrorReporter _errorReporter;
-  final AsyncSingleFlight<List<PluginHTTPItem>> _catalogRefreshSingleFlight =
-      AsyncSingleFlight<List<PluginHTTPItem>>();
+  Future<List<PluginHTTPItem>>? _pluginCatalogRefresh;
   final AsyncSerialQueue _mutations = AsyncSerialQueue();
   Map<String, PluginHTTPItem> _pluginCatalogByName = const {};
   DateTime? _pluginCatalogRefreshedAt;
@@ -216,6 +214,7 @@ abstract class _PluginsController with Store {
 
   void invalidatePluginCatalog() {
     _pluginCatalogGeneration++;
+    _pluginCatalogRefresh = null;
     _pluginCatalogRefreshedAt = null;
     _pluginCatalogByName = const {};
     pluginHTTPList.clear();
@@ -314,31 +313,52 @@ abstract class _PluginsController with Store {
   }
 
   Future<List<PluginHTTPItem>> refreshPluginCatalog() {
-    return _catalogRefreshSingleFlight.run(() async {
-      while (true) {
-        final generation = _pluginCatalogGeneration;
-        try {
-          final catalog = await _catalogLoader();
-          if (generation != _pluginCatalogGeneration) continue;
-          _pluginCatalogByName = {
-            for (final item in catalog) _catalogKey(item.name): item,
-          };
-          pluginHTTPList
-            ..clear()
-            ..addAll(catalog);
-          _pluginCatalogRefreshedAt = DateTime.now();
-          return List<PluginHTTPItem>.unmodifiable(catalog);
-        } catch (error, stackTrace) {
-          if (generation != _pluginCatalogGeneration) continue;
-          _errorReporter(
-            'Plugin: failed to refresh rule catalog',
-            error,
-            stackTrace,
-          );
-          rethrow;
-        }
+    final active = _pluginCatalogRefresh;
+    if (active != null) return active;
+
+    final refresh = _loadPluginCatalogGeneration(_pluginCatalogGeneration);
+    _pluginCatalogRefresh = refresh;
+    refresh.then<void>(
+      (_) => _clearPluginCatalogRefresh(refresh),
+      onError: (Object _, StackTrace __) => _clearPluginCatalogRefresh(refresh),
+    );
+    return refresh;
+  }
+
+  Future<List<PluginHTTPItem>> _loadPluginCatalogGeneration(
+    int generation,
+  ) async {
+    late final List<PluginHTTPItem> catalog;
+    try {
+      catalog = await _catalogLoader();
+    } catch (error, stackTrace) {
+      if (generation != _pluginCatalogGeneration) {
+        return refreshPluginCatalog();
       }
-    });
+      _errorReporter(
+        'Plugin: failed to refresh rule catalog',
+        error,
+        stackTrace,
+      );
+      rethrow;
+    }
+    if (generation != _pluginCatalogGeneration) {
+      return refreshPluginCatalog();
+    }
+    _pluginCatalogByName = {
+      for (final item in catalog) _catalogKey(item.name): item,
+    };
+    pluginHTTPList
+      ..clear()
+      ..addAll(catalog);
+    _pluginCatalogRefreshedAt = DateTime.now();
+    return List<PluginHTTPItem>.unmodifiable(catalog);
+  }
+
+  void _clearPluginCatalogRefresh(Future<List<PluginHTTPItem>> refresh) {
+    if (identical(_pluginCatalogRefresh, refresh)) {
+      _pluginCatalogRefresh = null;
+    }
   }
 
   Future<List<PluginHTTPItem>> ensurePluginCatalog() {

--- a/lib/plugins/plugins_controller.dart
+++ b/lib/plugins/plugins_controller.dart
@@ -82,6 +82,7 @@ abstract class _PluginsController with Store {
   final AsyncSerialQueue _mutations = AsyncSerialQueue();
   Map<String, PluginHTTPItem> _pluginCatalogByName = const {};
   DateTime? _pluginCatalogRefreshedAt;
+  int _pluginCatalogGeneration = 0;
   int _optimisticReorderRevision = 0;
 
   // Reuse a recent catalog across startup, the rule list, and the rule shop.
@@ -213,6 +214,13 @@ abstract class _PluginsController with Store {
         DateTime.now().difference(refreshedAt) < _pluginCatalogMaxAge;
   }
 
+  void invalidatePluginCatalog() {
+    _pluginCatalogGeneration++;
+    _pluginCatalogRefreshedAt = null;
+    _pluginCatalogByName = const {};
+    pluginHTTPList.clear();
+  }
+
   void _replacePlugin(Plugin plugin) {
     bool flag = false;
     for (int i = 0; i < pluginList.length; ++i) {
@@ -307,23 +315,28 @@ abstract class _PluginsController with Store {
 
   Future<List<PluginHTTPItem>> refreshPluginCatalog() {
     return _catalogRefreshSingleFlight.run(() async {
-      try {
-        final catalog = await _catalogLoader();
-        _pluginCatalogByName = {
-          for (final item in catalog) _catalogKey(item.name): item,
-        };
-        pluginHTTPList
-          ..clear()
-          ..addAll(catalog);
-        _pluginCatalogRefreshedAt = DateTime.now();
-        return List<PluginHTTPItem>.unmodifiable(catalog);
-      } catch (error, stackTrace) {
-        _errorReporter(
-          'Plugin: failed to refresh rule catalog',
-          error,
-          stackTrace,
-        );
-        rethrow;
+      while (true) {
+        final generation = _pluginCatalogGeneration;
+        try {
+          final catalog = await _catalogLoader();
+          if (generation != _pluginCatalogGeneration) continue;
+          _pluginCatalogByName = {
+            for (final item in catalog) _catalogKey(item.name): item,
+          };
+          pluginHTTPList
+            ..clear()
+            ..addAll(catalog);
+          _pluginCatalogRefreshedAt = DateTime.now();
+          return List<PluginHTTPItem>.unmodifiable(catalog);
+        } catch (error, stackTrace) {
+          if (generation != _pluginCatalogGeneration) continue;
+          _errorReporter(
+            'Plugin: failed to refresh rule catalog',
+            error,
+            stackTrace,
+          );
+          rethrow;
+        }
       }
     });
   }

--- a/lib/request/apis/plugin_catalog_api.dart
+++ b/lib/request/apis/plugin_catalog_api.dart
@@ -1,15 +1,22 @@
 import 'dart:convert';
 import 'package:kazumi/services/logging/logger.dart';
-import 'package:kazumi/request/config/api_endpoints.dart';
+import 'package:kazumi/request/config/rules_repository_config.dart';
 import 'package:kazumi/request/clients/rules_repo_client.dart';
 import 'package:kazumi/plugins/plugins.dart';
 import 'package:kazumi/modules/plugin/plugin_http_module.dart';
+import 'package:kazumi/services/storage/storage.dart';
 
 class PluginCatalogApi {
   static final RulesRepoClient _client = RulesRepoClient.instance;
 
-  static Future<List<PluginHTTPItem>> getPluginList() async {
-    final raw = await _client.getText('${ApiEndpoints.pluginShop}index.json');
+  static Future<List<PluginHTTPItem>> getPluginList({
+    String? repositoryUrl,
+  }) async {
+    final configuredUrl = repositoryUrl ??
+        GStorage.getSetting<String>(SettingsKeys.ruleRepositoryUrl);
+    final raw = await _client.getText(
+      RulesRepositoryConfig.catalogUri(configuredUrl).toString(),
+    );
     final result = parsePluginList(raw);
     if (result.skippedItems > 0) {
       KazumiLogger().w(
@@ -53,8 +60,12 @@ class PluginCatalogApi {
     }
   }
 
-  static Future<Plugin> getPlugin(String name) async {
-    final raw = await _client.getText('${ApiEndpoints.pluginShop}$name.json');
+  static Future<Plugin> getPlugin(String name, {String? repositoryUrl}) async {
+    final configuredUrl = repositoryUrl ??
+        GStorage.getSetting<String>(SettingsKeys.ruleRepositoryUrl);
+    final raw = await _client.getText(
+      RulesRepositoryConfig.ruleUri(configuredUrl, name).toString(),
+    );
     final jsonData = json.decode(raw);
     if (jsonData is! Map) {
       throw FormatException('Rule $name must be a JSON object');

--- a/lib/request/config/rules_repository_config.dart
+++ b/lib/request/config/rules_repository_config.dart
@@ -1,0 +1,52 @@
+import 'package:kazumi/request/config/api_endpoints.dart';
+
+class RulesRepositoryConfig {
+  const RulesRepositoryConfig._();
+
+  static Uri baseUri(String configuredUrl) {
+    final value = configuredUrl.trim();
+    if (value.isEmpty) {
+      return Uri.parse(ApiEndpoints.pluginShop);
+    }
+
+    final uri = Uri.tryParse(value);
+    if (uri == null ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        !uri.hasAuthority ||
+        uri.host.isEmpty) {
+      throw const FormatException('规则仓库地址必须是有效的 HTTP 或 HTTPS URL');
+    }
+
+    var path = uri.path;
+    if (path.endsWith('/index.json')) {
+      path = path.substring(0, path.length - 'index.json'.length);
+    } else if (!path.endsWith('/')) {
+      path = '$path/';
+    }
+
+    return Uri(
+      scheme: uri.scheme,
+      userInfo: uri.userInfo,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      path: path,
+    );
+  }
+
+  static String normalizeForStorage(String configuredUrl) {
+    if (configuredUrl.trim().isEmpty) {
+      return '';
+    }
+    return baseUri(configuredUrl).toString();
+  }
+
+  static Uri catalogUri(String configuredUrl) {
+    return baseUri(configuredUrl).resolve('index.json');
+  }
+
+  static Uri ruleUri(String configuredUrl, String ruleName) {
+    return baseUri(
+      configuredUrl,
+    ).resolveUri(Uri(pathSegments: ['$ruleName.json']));
+  }
+}

--- a/lib/request/config/rules_repository_config.dart
+++ b/lib/request/config/rules_repository_config.dart
@@ -23,29 +23,29 @@ class RulesRepositoryConfig {
       throw const FormatException('规则仓库地址不能包含查询参数或片段');
     }
 
-    var path = uri.path;
     final pathSegments =
         uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
     final lastSegment = pathSegments.isEmpty ? null : pathSegments.last;
+    late final List<String> directorySegments;
     if (lastSegment?.toLowerCase() == 'index.json') {
-      path = path.substring(0, path.length - 'index.json'.length);
+      directorySegments = pathSegments.sublist(0, pathSegments.length - 1);
     } else {
-      if (lastSegment != null && lastSegment.contains('.')) {
+      if (lastSegment != null &&
+          lastSegment.contains('.') &&
+          !uri.path.endsWith('/')) {
         throw const FormatException('规则仓库地址必须是目录或以 index.json 结尾');
       }
       if (uri.host.toLowerCase() == 'github.com') {
         throw const FormatException('请使用 raw 文件地址，不要使用 GitHub 仓库网页地址');
       }
-      if (!path.endsWith('/')) {
-        path = '$path/';
-      }
+      directorySegments = pathSegments;
     }
 
     return Uri(
       scheme: uri.scheme,
       host: uri.host,
       port: uri.hasPort ? uri.port : null,
-      path: path,
+      pathSegments: [...directorySegments, ''],
     );
   }
 

--- a/lib/request/config/rules_repository_config.dart
+++ b/lib/request/config/rules_repository_config.dart
@@ -16,17 +16,33 @@ class RulesRepositoryConfig {
         uri.host.isEmpty) {
       throw const FormatException('规则仓库地址必须是有效的 HTTP 或 HTTPS URL');
     }
+    if (uri.userInfo.isNotEmpty) {
+      throw const FormatException('规则仓库地址不能包含用户名或密码');
+    }
+    if (uri.hasQuery || uri.hasFragment) {
+      throw const FormatException('规则仓库地址不能包含查询参数或片段');
+    }
 
     var path = uri.path;
-    if (path.endsWith('/index.json')) {
+    final pathSegments =
+        uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
+    final lastSegment = pathSegments.isEmpty ? null : pathSegments.last;
+    if (lastSegment?.toLowerCase() == 'index.json') {
       path = path.substring(0, path.length - 'index.json'.length);
-    } else if (!path.endsWith('/')) {
-      path = '$path/';
+    } else {
+      if (lastSegment != null && lastSegment.contains('.')) {
+        throw const FormatException('规则仓库地址必须是目录或以 index.json 结尾');
+      }
+      if (uri.host.toLowerCase() == 'github.com') {
+        throw const FormatException('请使用 raw 文件地址，不要使用 GitHub 仓库网页地址');
+      }
+      if (!path.endsWith('/')) {
+        path = '$path/';
+      }
     }
 
     return Uri(
       scheme: uri.scheme,
-      userInfo: uri.userInfo,
       host: uri.host,
       port: uri.hasPort ? uri.port : null,
       path: path,
@@ -37,7 +53,18 @@ class RulesRepositoryConfig {
     if (configuredUrl.trim().isEmpty) {
       return '';
     }
-    return baseUri(configuredUrl).toString();
+    final normalized = baseUri(configuredUrl).toString();
+    return normalized.startsWith(ApiEndpoints.pluginShop) ? '' : normalized;
+  }
+
+  static bool isCustomRepository(String configuredUrl) {
+    final value = configuredUrl.trim();
+    if (value.isEmpty) return false;
+    try {
+      return !baseUri(value).toString().startsWith(ApiEndpoints.pluginShop);
+    } on FormatException {
+      return true;
+    }
   }
 
   static Uri catalogUri(String configuredUrl) {

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -253,6 +253,11 @@ class SettingsKeys {
     true,
     group: SettingGroup.proxy,
   );
+  static const ruleRepositoryUrl = SettingKey<String>(
+    'ruleRepositoryUrl',
+    '',
+    group: SettingGroup.proxy,
+  );
   static const enableBangumiProxy = SettingKey<bool>(
     _SettingBoxKey.enableBangumiProxy,
     true,
@@ -564,6 +569,7 @@ class SettingsKeys {
     oledEnhance,
     displayMode,
     enableGitProxy,
+    ruleRepositoryUrl,
     enableBangumiProxy,
     enableSystemProxy,
     defaultStartupPage,

--- a/test/plugins_controller_catalog_test.dart
+++ b/test/plugins_controller_catalog_test.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/modules/plugin/plugin_http_module.dart';
+import 'package:kazumi/plugins/plugins_controller.dart';
+
+void main() {
+  PluginHTTPItem catalogItem(String name) {
+    return PluginHTTPItem(
+      name: name,
+      version: '1.0',
+      useNativePlayer: false,
+      author: 'test',
+      lastUpdate: 0,
+    );
+  }
+
+  test('repository invalidation retries an active catalog request', () async {
+    final firstLoad = Completer<List<PluginHTTPItem>>();
+    final secondLoad = Completer<List<PluginHTTPItem>>();
+    var loadCount = 0;
+    final controller = PluginsController(
+      catalogLoader: () {
+        loadCount++;
+        return loadCount == 1 ? firstLoad.future : secondLoad.future;
+      },
+    );
+
+    final initialRefresh = controller.refreshPluginCatalog();
+    expect(loadCount, 1);
+
+    controller.invalidatePluginCatalog();
+    final repositoryRefresh = controller.refreshPluginCatalog();
+    firstLoad.complete([catalogItem('old')]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(loadCount, 2);
+    expect(controller.pluginHTTPList, isEmpty);
+
+    secondLoad.complete([catalogItem('new')]);
+    expect((await initialRefresh).single.name, 'new');
+    expect((await repositoryRefresh).single.name, 'new');
+    expect(controller.pluginHTTPList.single.name, 'new');
+    expect(controller.isPluginCatalogFresh, isTrue);
+  });
+}

--- a/test/plugins_controller_catalog_test.dart
+++ b/test/plugins_controller_catalog_test.dart
@@ -31,6 +31,8 @@ void main() {
 
     controller.invalidatePluginCatalog();
     final repositoryRefresh = controller.refreshPluginCatalog();
+    expect(loadCount, 2);
+
     firstLoad.complete([catalogItem('old')]);
     await Future<void>.delayed(Duration.zero);
 

--- a/test/rules_repository_config_test.dart
+++ b/test/rules_repository_config_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/request/config/api_endpoints.dart';
+import 'package:kazumi/request/config/rules_repository_config.dart';
+
+void main() {
+  group('RulesRepositoryConfig', () {
+    test('uses the official repository when the setting is blank', () {
+      expect(
+        RulesRepositoryConfig.baseUri('   ').toString(),
+        ApiEndpoints.pluginShop,
+      );
+    });
+
+    test('normalizes a repository directory URL', () {
+      expect(
+        RulesRepositoryConfig.normalizeForStorage('https://example.com/rules'),
+        'https://example.com/rules/',
+      );
+    });
+
+    test('accepts a direct index URL and removes query and fragment', () {
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          'https://example.com/rules/index.json?cache=1#catalog',
+        ),
+        'https://example.com/rules/',
+      );
+    });
+
+    test('resolves catalog and rule URLs from the same repository', () {
+      const repository = 'https://example.com/rules/';
+      expect(
+        RulesRepositoryConfig.catalogUri(repository).toString(),
+        'https://example.com/rules/index.json',
+      );
+      expect(
+        RulesRepositoryConfig.ruleUri(repository, 'demo').toString(),
+        'https://example.com/rules/demo.json',
+      );
+    });
+
+    test('rejects non-HTTP repository URLs', () {
+      expect(
+        () => RulesRepositoryConfig.baseUri('file:///tmp/rules/'),
+        throwsFormatException,
+      );
+      expect(
+        () => RulesRepositoryConfig.baseUri('example.com/rules'),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/rules_repository_config_test.dart
+++ b/test/rules_repository_config_test.dart
@@ -18,12 +18,35 @@ void main() {
       );
     });
 
-    test('accepts a direct index URL and removes query and fragment', () {
+    test('accepts a case-insensitive direct index URL', () {
       expect(
         RulesRepositoryConfig.normalizeForStorage(
-          'https://example.com/rules/index.json?cache=1#catalog',
+          'https://example.com/rules/INDEX.JSON',
         ),
         'https://example.com/rules/',
+      );
+    });
+
+    test('normalizes official repository URLs back to the default setting', () {
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(ApiEndpoints.pluginShop),
+        isEmpty,
+      );
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          '${ApiEndpoints.pluginShop}index.json',
+        ),
+        isEmpty,
+      );
+      expect(
+        RulesRepositoryConfig.isCustomRepository(ApiEndpoints.pluginShop),
+        isFalse,
+      );
+      expect(
+        RulesRepositoryConfig.isCustomRepository(
+          'https://example.com/rules/',
+        ),
+        isTrue,
       );
     });
 
@@ -46,6 +69,42 @@ void main() {
       );
       expect(
         () => RulesRepositoryConfig.baseUri('example.com/rules'),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects URLs with credentials, query parameters or fragments', () {
+      expect(
+        () => RulesRepositoryConfig.baseUri(
+          'https://user:pass@example.com/rules/',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => RulesRepositoryConfig.baseUri(
+          'https://example.com/rules/index.json?cache=1',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => RulesRepositoryConfig.baseUri(
+          'https://example.com/rules/#catalog',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects file URLs and GitHub repository pages', () {
+      expect(
+        () => RulesRepositoryConfig.baseUri(
+          'https://example.com/rules/catalog.json',
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => RulesRepositoryConfig.baseUri(
+          'https://github.com/example/rules',
+        ),
         throwsFormatException,
       );
     });

--- a/test/rules_repository_config_test.dart
+++ b/test/rules_repository_config_test.dart
@@ -27,6 +27,37 @@ void main() {
       );
     });
 
+    test('normalizes trailing and encoded index URL variants', () {
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          'https://example.com/rules/index.json/',
+        ),
+        'https://example.com/rules/',
+      );
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          'https://example.com/rules/%69ndex.json',
+        ),
+        'https://example.com/rules/',
+      );
+    });
+
+    test('accepts explicit directory URLs whose last segment contains dots',
+        () {
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          'https://example.com/rules/v1.2/',
+        ),
+        'https://example.com/rules/v1.2/',
+      );
+      expect(
+        RulesRepositoryConfig.normalizeForStorage(
+          'https://example.com/rules.d/',
+        ),
+        'https://example.com/rules.d/',
+      );
+    });
+
     test('normalizes official repository URLs back to the default setting', () {
       expect(
         RulesRepositoryConfig.normalizeForStorage(ApiEndpoints.pluginShop),


### PR DESCRIPTION
## 描述  为规则仓库增加可配置入口，使 fork、镜像或独立规则仓库能够继续使用目录浏览、规则安装和已安装规则更新能力。  主要改动：  - 在规则仓库页面增加“设置规则仓库”入口。 - 支持填写仓库目录 URL 或完整 `index.json` URL。 - 保存后，规则目录、安装和更新统一使用自定义仓库。 - 支持恢复官方仓库，并保持未配置用户的原有行为。 - 官方 GitHub 镜像只改写官方仓库地址，避免影响第三方仓库。 - 增加安全提示、配置持久化与专项测试。  ![自定义规则仓库运行截图](https://github.com/chendianshuiyin/Kazumi/releases/download/v2.2.8-custom.1/custom-rule-repository.png)  验证：  - `flutter analyze --no-fatal-infos --fatal-warnings` 通过，仅有项目原有的 `avoid_print` info。 - 专项测试 5/5 通过。 - 完整测试 137/137 通过。  ## 关联的 Issues  Closes #2485  ## PR 类型  - [ ] Bug 修复 - [x] 添加新功能 - [ ] 重构实现 - [ ] 文档或格式 - [ ] 其它  ## AI 辅助开发  - [ ] 没有使用 AI 辅助 - [ ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码 - [x] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物  AI 辅助模型: `OpenAI GPT-5.6 Sol`  AI 辅助范围：实现、检查和测试。涉及个人理解的确认项未由自动化代为勾选。  ## 提交前检查  - [x] 我已经填写了 PR 模板中的所有内容 - [ ] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发 - [ ] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动  ## 附注  该改动不引入新依赖；第三方规则仓库仍应由用户自行判断可信度。 