### PR TITLE
feat(plugin): support bulk rule imports

### DIFF
--- a/lib/pages/plugin_editor/plugin_view_page.dart
+++ b/lib/pages/plugin_editor/plugin_view_page.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -11,6 +13,7 @@ import 'package:kazumi/plugins/plugins_controller.dart';
 import 'package:kazumi/bean/settings/settings_detail_scaffold.dart';
 import 'package:kazumi/pages/plugin_editor/plugin_update_actions.dart';
 import 'package:kazumi/services/logging/logger.dart';
+import 'package:kazumi/services/plugin/plugin_import_parser.dart';
 import 'package:kazumi/utils/encoding.dart';
 
 class PluginViewPage extends StatefulWidget {
@@ -80,9 +83,19 @@ class _PluginViewPageState extends State<PluginViewPage> {
               const SizedBox(height: 10),
               ListTile(
                 title: const Text('从剪贴板导入'),
+                onTap: () async {
+                  KazumiDialog.dismiss();
+                  final clipboard =
+                      await Clipboard.getData(Clipboard.kTextPlain);
+                  _showInputDialog(initialValue: clipboard?.text ?? '');
+                },
+              ),
+              const SizedBox(height: 10),
+              ListTile(
+                title: const Text('从文件导入'),
                 onTap: () {
                   KazumiDialog.dismiss();
-                  _showInputDialog();
+                  _importFromFile();
                 },
               ),
             ],
@@ -92,18 +105,25 @@ class _PluginViewPageState extends State<PluginViewPage> {
     });
   }
 
-  void _showInputDialog() {
-    String pluginText = '';
+  void _showInputDialog({String initialValue = ''}) {
+    final textController = TextEditingController(text: initialValue);
     KazumiDialog.show(
+      onDismiss: textController.dispose,
       builder: (context) {
         return AlertDialog(
-          title: const Text('导入规则'),
-          content: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-            return TextField(
-              onChanged: (value) => pluginText = value,
-            );
-          }),
+          title: const Text('从剪贴板导入规则'),
+          content: SizedBox(
+            width: 520,
+            child: TextField(
+              controller: textController,
+              minLines: 4,
+              maxLines: 10,
+              decoration: const InputDecoration(
+                hintText: '可粘贴多条 kazumi:// 链接或 JSON 数组',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
           actions: [
             TextButton(
               onPressed: () => KazumiDialog.dismiss(),
@@ -112,41 +132,74 @@ class _PluginViewPageState extends State<PluginViewPage> {
                 style: TextStyle(color: Theme.of(context).colorScheme.outline),
               ),
             ),
-            StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-              return TextButton(
-                onPressed: () async {
-                  try {
-                    final plugin = Plugin.fromJson(
-                      json.decode(kazumiBase64ToJson(pluginText)),
-                    );
-                    if (plugin.requiresNewerClient) {
-                      KazumiDialog.dismiss();
-                      KazumiDialog.showToast(
-                        message: '规则需要更高版本客户端',
-                      );
-                      return;
-                    }
-                    await pluginsController.updatePlugin(plugin);
-                    KazumiDialog.dismiss();
-                    KazumiDialog.showToast(message: '导入成功');
-                  } catch (e, stackTrace) {
-                    KazumiLogger().e(
-                      'Plugin: failed to import rule link',
-                      error: e,
-                      stackTrace: stackTrace,
-                    );
-                    KazumiDialog.dismiss();
-                    KazumiDialog.showToast(message: '导入失败 ${e.toString()}');
-                  }
-                },
-                child: const Text('导入'),
-              );
-            })
+            TextButton(
+              onPressed: () => _importFromText(
+                textController.text,
+                dismissDialog: true,
+              ),
+              child: const Text('导入'),
+            ),
           ],
         );
       },
     );
+  }
+
+  Future<void> _importFromFile() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['json', 'txt'],
+        withData: true,
+      );
+      if (result == null) return;
+      final file = result.files.single;
+      final bytes = file.bytes ??
+          (file.path == null ? null : await File(file.path!).readAsBytes());
+      if (bytes == null) {
+        throw const FileSystemException('无法读取所选文件');
+      }
+      await _importFromText(utf8.decode(bytes));
+    } catch (error, stackTrace) {
+      KazumiLogger().e(
+        'Plugin: failed to import rules from file',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      KazumiDialog.showToast(message: '读取规则文件失败：$error');
+    }
+  }
+
+  Future<void> _importFromText(
+    String text, {
+    bool dismissDialog = false,
+  }) async {
+    final result = PluginImportParser.parse(text);
+    if (result.plugins.isEmpty) {
+      if (dismissDialog) KazumiDialog.dismiss();
+      KazumiDialog.showToast(
+        message: result.failures.isEmpty ? '没有可导入的规则' : result.failures.first,
+      );
+      return;
+    }
+
+    try {
+      await pluginsController.updatePlugins(result.plugins);
+      if (dismissDialog) KazumiDialog.dismiss();
+      if (mounted) setState(() {});
+      KazumiDialog.showToast(
+        message: '导入完成：成功 ${result.plugins.length} 条，'
+            '跳过重复 ${result.duplicateCount} 条，失败 ${result.failureCount} 条',
+      );
+    } catch (error, stackTrace) {
+      KazumiLogger().e(
+        'Plugin: failed to persist imported rules',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (dismissDialog) KazumiDialog.dismiss();
+      KazumiDialog.showToast(message: '保存导入规则失败：$error');
+    }
   }
 
   void onBackPressed(BuildContext context) {

--- a/lib/pages/plugin_editor/plugin_view_page.dart
+++ b/lib/pages/plugin_editor/plugin_view_page.dart
@@ -183,9 +183,9 @@ class _PluginViewPageState extends State<PluginViewPage> {
       return;
     }
 
+    if (dismissDialog) KazumiDialog.dismiss();
     try {
       await pluginsController.updatePlugins(result.plugins);
-      if (dismissDialog) KazumiDialog.dismiss();
       if (mounted) setState(() {});
       KazumiDialog.showToast(
         message: '导入完成：成功 ${result.plugins.length} 条，'
@@ -197,7 +197,6 @@ class _PluginViewPageState extends State<PluginViewPage> {
         error: error,
         stackTrace: stackTrace,
       );
-      if (dismissDialog) KazumiDialog.dismiss();
       KazumiDialog.showToast(message: '保存导入规则失败：$error');
     }
   }

--- a/lib/pages/plugin_editor/plugin_view_page.dart
+++ b/lib/pages/plugin_editor/plugin_view_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -87,6 +88,7 @@ class _PluginViewPageState extends State<PluginViewPage> {
                   KazumiDialog.dismiss();
                   final clipboard =
                       await Clipboard.getData(Clipboard.kTextPlain);
+                  if (!mounted) return;
                   _showInputDialog(initialValue: clipboard?.text ?? '');
                 },
               ),
@@ -106,16 +108,16 @@ class _PluginViewPageState extends State<PluginViewPage> {
   }
 
   void _showInputDialog({String initialValue = ''}) {
-    final textController = TextEditingController(text: initialValue);
+    var pluginText = initialValue;
     KazumiDialog.show(
-      onDismiss: textController.dispose,
       builder: (context) {
         return AlertDialog(
           title: const Text('从剪贴板导入规则'),
           content: SizedBox(
             width: 520,
-            child: TextField(
-              controller: textController,
+            child: TextFormField(
+              initialValue: initialValue,
+              onChanged: (value) => pluginText = value,
               minLines: 4,
               maxLines: 10,
               decoration: const InputDecoration(
@@ -134,7 +136,7 @@ class _PluginViewPageState extends State<PluginViewPage> {
             ),
             TextButton(
               onPressed: () => _importFromText(
-                textController.text,
+                pluginText,
                 dismissDialog: true,
               ),
               child: const Text('导入'),
@@ -186,7 +188,6 @@ class _PluginViewPageState extends State<PluginViewPage> {
     if (dismissDialog) KazumiDialog.dismiss();
     try {
       await pluginsController.updatePlugins(result.plugins);
-      if (mounted) setState(() {});
       KazumiDialog.showToast(
         message: '导入完成：成功 ${result.plugins.length} 条，'
             '跳过重复 ${result.duplicateCount} 条，失败 ${result.failureCount} 条',

--- a/lib/pages/plugin_editor/plugin_view_page.dart
+++ b/lib/pages/plugin_editor/plugin_view_page.dart
@@ -149,7 +149,7 @@ class _PluginViewPageState extends State<PluginViewPage> {
     try {
       final result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
-        allowedExtensions: const ['json', 'txt'],
+        allowedExtensions: const ['json'],
         withData: true,
       );
       if (result == null) return;

--- a/lib/plugins/plugins.dart
+++ b/lib/plugins/plugins.dart
@@ -14,6 +14,8 @@ export 'package:kazumi/services/plugin/rule_engine_models.dart'
         SearchErrorException,
         ChapterErrorException;
 
+String pluginNameKey(String name) => name.toLowerCase();
+
 class Plugin {
   static final RuleEngine _ruleEngine = RuleEngine();
 

--- a/lib/plugins/plugins_controller.dart
+++ b/lib/plugins/plugins_controller.dart
@@ -264,6 +264,17 @@ abstract class _PluginsController with Store {
     );
   }
 
+  Future<void> updatePlugins(Iterable<Plugin> plugins) {
+    return _mutateAndPersist(
+      () {
+        for (final plugin in plugins) {
+          _replacePlugin(plugin);
+        }
+      },
+      errorMessage: 'Plugin: failed to persist imported rules',
+    );
+  }
+
   Future<void> onReorder(int oldIndex, int newIndex) {
     final previous = List<Plugin>.from(pluginList);
     final plugin = pluginList.removeAt(oldIndex);

--- a/lib/plugins/plugins_controller.dart
+++ b/lib/plugins/plugins_controller.dart
@@ -356,7 +356,7 @@ abstract class _PluginsController with Store {
     return _updatablePluginNames().length;
   }
 
-  String _catalogKey(String name) => name.toLowerCase();
+  String _catalogKey(String name) => pluginNameKey(name);
 
   bool _remoteIsNewer(String localVersion, String remoteVersion) {
     try {

--- a/lib/plugins/plugins_controller.dart
+++ b/lib/plugins/plugins_controller.dart
@@ -201,7 +201,8 @@ abstract class _PluginsController with Store {
   Future<void> removePlugin(Plugin plugin) {
     return _mutateAndPersist(
       () => pluginList.removeWhere(
-        (candidate) => _catalogKey(candidate.name) == _catalogKey(plugin.name),
+        (candidate) =>
+            pluginNameKey(candidate.name) == pluginNameKey(plugin.name),
       ),
       errorMessage: 'Plugin: failed to persist rule removal',
     );
@@ -216,7 +217,7 @@ abstract class _PluginsController with Store {
   void _replacePlugin(Plugin plugin) {
     bool flag = false;
     for (int i = 0; i < pluginList.length; ++i) {
-      if (_catalogKey(pluginList[i].name) == _catalogKey(plugin.name)) {
+      if (pluginNameKey(pluginList[i].name) == pluginNameKey(plugin.name)) {
         pluginList.replaceRange(i, i + 1, [plugin]);
         flag = true;
         break;
@@ -321,7 +322,7 @@ abstract class _PluginsController with Store {
       try {
         final catalog = await _catalogLoader();
         _pluginCatalogByName = {
-          for (final item in catalog) _catalogKey(item.name): item,
+          for (final item in catalog) pluginNameKey(item.name): item,
         };
         pluginHTTPList
           ..clear()
@@ -356,8 +357,6 @@ abstract class _PluginsController with Store {
     return _updatablePluginNames().length;
   }
 
-  String _catalogKey(String name) => pluginNameKey(name);
-
   bool _remoteIsNewer(String localVersion, String remoteVersion) {
     try {
       return needUpdate(localVersion, remoteVersion);
@@ -369,7 +368,7 @@ abstract class _PluginsController with Store {
   PluginCatalogItemStatus pluginStatus(PluginHTTPItem pluginHTTPItem) {
     var pluginStatus = PluginCatalogItemStatus.install;
     for (Plugin plugin in pluginList) {
-      if (_catalogKey(pluginHTTPItem.name) == _catalogKey(plugin.name)) {
+      if (pluginNameKey(pluginHTTPItem.name) == pluginNameKey(plugin.name)) {
         if (_remoteIsNewer(plugin.version, pluginHTTPItem.version)) {
           pluginStatus = PluginCatalogItemStatus.update;
         } else {
@@ -385,7 +384,7 @@ abstract class _PluginsController with Store {
     if (_pluginCatalogRefreshedAt == null) {
       return PluginUpdateAvailability.unknown;
     }
-    final remote = _pluginCatalogByName[_catalogKey(plugin.name)];
+    final remote = _pluginCatalogByName[pluginNameKey(plugin.name)];
     if (remote == null) {
       return PluginUpdateAvailability.notInCatalog;
     }
@@ -398,13 +397,14 @@ abstract class _PluginsController with Store {
     return [
       for (final plugin in pluginList)
         if (pluginUpdateStatus(plugin) == PluginUpdateAvailability.updatable)
-          _pluginCatalogByName[_catalogKey(plugin.name)]!.name,
+          _pluginCatalogByName[pluginNameKey(plugin.name)]!.name,
     ];
   }
 
   Future<PluginUpdateResult> tryUpdatePluginByName(String name) {
     return _mutations.run(() async {
-      final catalogName = _pluginCatalogByName[_catalogKey(name)]?.name ?? name;
+      final catalogName =
+          _pluginCatalogByName[pluginNameKey(name)]?.name ?? name;
       final attempt = await _preparePluginUpdate(catalogName);
       if (attempt.result == PluginUpdateResult.updated) {
         await _mutateAndPersistNow(
@@ -432,7 +432,7 @@ abstract class _PluginsController with Store {
     // Validate at the injected loader boundary so production and test/custom
     // loaders follow the same integrity rule. Preserve the catalog spelling.
     if (remotePlugin.name.isEmpty ||
-        _catalogKey(remotePlugin.name) != _catalogKey(name)) {
+        pluginNameKey(remotePlugin.name) != pluginNameKey(name)) {
       final error = FormatException(
         'Downloaded rule name ${remotePlugin.name} does not match $name',
       );
@@ -461,7 +461,7 @@ abstract class _PluginsController with Store {
     }
     Plugin? local;
     for (final plugin in pluginList) {
-      if (_catalogKey(plugin.name) == _catalogKey(name)) {
+      if (pluginNameKey(plugin.name) == pluginNameKey(name)) {
         local = plugin;
         break;
       }

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:kazumi/plugins/plugins.dart';
+import 'package:kazumi/utils/encoding.dart';
+
+class PluginImportParseResult {
+  const PluginImportParseResult({
+    required this.plugins,
+    required this.failures,
+    required this.duplicateCount,
+  });
+
+  final List<Plugin> plugins;
+  final List<String> failures;
+  final int duplicateCount;
+
+  int get failureCount => failures.length;
+}
+
+class PluginImportParser {
+  const PluginImportParser._();
+
+  static final RegExp _ruleLinkPattern = RegExp(
+    r'kazumi:(?://)?[A-Za-z0-9+/_=%-]+',
+    caseSensitive: false,
+  );
+
+  static PluginImportParseResult parse(String input) {
+    final value = input.trim();
+    if (value.isEmpty) {
+      return const PluginImportParseResult(
+        plugins: [],
+        failures: ['导入内容为空'],
+        duplicateCount: 0,
+      );
+    }
+
+    final parsed = <Plugin>[];
+    final failures = <String>[];
+    Object? jsonValue;
+    var decodedAsJson = false;
+    try {
+      jsonValue = json.decode(value);
+      decodedAsJson = true;
+    } on FormatException {
+      // Share links and text files are parsed below.
+    }
+
+    if (decodedAsJson) {
+      if (jsonValue is List) {
+        for (var index = 0; index < jsonValue.length; index++) {
+          _parseEntry(jsonValue[index], index + 1, parsed, failures);
+        }
+      } else {
+        _parseEntry(jsonValue, 1, parsed, failures);
+      }
+    } else {
+      final matches = _ruleLinkPattern.allMatches(value).toList();
+      if (matches.isEmpty) {
+        failures.add('未找到有效的 JSON 或 kazumi:// 规则链接');
+      } else {
+        for (var index = 0; index < matches.length; index++) {
+          _parseEntry(matches[index].group(0), index + 1, parsed, failures);
+        }
+      }
+    }
+
+    final uniquePlugins = <String, Plugin>{};
+    var duplicateCount = 0;
+    for (final plugin in parsed) {
+      final key = plugin.name.toLowerCase();
+      if (uniquePlugins.containsKey(key)) {
+        duplicateCount++;
+      }
+      uniquePlugins[key] = plugin;
+    }
+
+    return PluginImportParseResult(
+      plugins: List.unmodifiable(uniquePlugins.values),
+      failures: List.unmodifiable(failures),
+      duplicateCount: duplicateCount,
+    );
+  }
+
+  static void _parseEntry(
+    Object? entry,
+    int index,
+    List<Plugin> plugins,
+    List<String> failures,
+  ) {
+    try {
+      late final Plugin plugin;
+      if (entry is Map) {
+        plugin = Plugin.fromJson(Map<String, dynamic>.from(entry));
+      } else if (entry is String) {
+        final decoded = json.decode(kazumiBase64ToJson(entry));
+        if (decoded is! Map) {
+          throw const FormatException('规则链接内容必须是 JSON object');
+        }
+        plugin = Plugin.fromJson(Map<String, dynamic>.from(decoded));
+      } else {
+        throw const FormatException('规则必须是 JSON object 或 kazumi:// 链接');
+      }
+
+      if (plugin.name.trim().isEmpty) {
+        throw const FormatException('规则名称不能为空');
+      }
+      if (plugin.requiresNewerClient) {
+        throw const FormatException('规则需要更高版本客户端');
+      }
+      plugins.add(plugin);
+    } catch (error) {
+      failures.add('第 $index 条：$error');
+    }
+  }
+}

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -79,7 +79,7 @@ class PluginImportParser {
     final uniquePlugins = <String, Plugin>{};
     var duplicateCount = 0;
     for (final plugin in parsed) {
-      final key = plugin.name.toLowerCase();
+      final key = pluginNameKey(plugin.name);
       if (uniquePlugins.containsKey(key)) {
         duplicateCount++;
       }

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -20,8 +20,8 @@ class PluginImportParseResult {
 class PluginImportParser {
   const PluginImportParser._();
 
-  static final RegExp _ruleLinkPattern = RegExp(
-    r'kazumi:(?://)?[A-Za-z0-9+/_=%-]+',
+  static final RegExp _ruleLinkSchemePattern = RegExp(
+    r'kazumi:(?://)?',
     caseSensitive: false,
   );
 
@@ -55,12 +55,20 @@ class PluginImportParser {
         _parseEntry(jsonValue, 1, parsed, failures);
       }
     } else {
-      final matches = _ruleLinkPattern.allMatches(value).toList();
+      final matches = _ruleLinkSchemePattern.allMatches(value).toList();
       if (matches.isEmpty) {
         failures.add('未找到有效的 JSON 或 kazumi:// 规则链接');
       } else {
         for (var index = 0; index < matches.length; index++) {
-          _parseEntry(matches[index].group(0), index + 1, parsed, failures);
+          final end = index + 1 < matches.length
+              ? matches[index + 1].start
+              : value.length;
+          _parseEntry(
+            value.substring(matches[index].start, end).trim(),
+            index + 1,
+            parsed,
+            failures,
+          );
         }
       }
     }

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -20,13 +20,10 @@ class PluginImportParseResult {
 class PluginImportParser {
   const PluginImportParser._();
 
-  static final RegExp _ruleLinkSchemePattern = RegExp(
-    r'kazumi:(?://)?',
-    caseSensitive: false,
-  );
   static final RegExp _ruleLinkPayloadPrefixPattern = RegExp(
     r'^[A-Za-z0-9+/_=%\-\s]+',
   );
+  static final RegExp _whitespacePattern = RegExp(r'\s+');
 
   static PluginImportParseResult parse(String input) {
     final value = input.trim();
@@ -58,16 +55,15 @@ class PluginImportParser {
         _parseEntry(jsonValue, 1, parsed, failures);
       }
     } else {
-      final matches = _ruleLinkSchemePattern.allMatches(value).toList();
-      if (matches.isEmpty) {
+      final segments = findKazumiRuleLinkSegments(value).toList();
+      if (segments.isEmpty) {
         failures.add('未找到有效的 JSON 或 kazumi:// 规则链接');
       } else {
-        for (var index = 0; index < matches.length; index++) {
-          final end = index + 1 < matches.length
-              ? matches[index + 1].start
-              : value.length;
-          _parseEntry(
-            _extractRuleLink(value, matches[index], end),
+        for (var index = 0; index < segments.length; index++) {
+          final segment = segments[index];
+          _parseRuleLinkSegment(
+            segment.scheme,
+            segment.rawPayload,
             index + 1,
             parsed,
             failures,
@@ -93,17 +89,35 @@ class PluginImportParser {
     );
   }
 
-  static String _extractRuleLink(String input, Match schemeMatch, int end) {
-    final scheme = schemeMatch.group(0)!;
-    final rawPayload = input.substring(schemeMatch.end, end);
+  static void _parseRuleLinkSegment(
+    String scheme,
+    String rawPayload,
+    int index,
+    List<Plugin> plugins,
+    List<String> failures,
+  ) {
+    try {
+      final entry = _decodeRuleEntry(scheme, rawPayload);
+      _parseEntry(entry, index, plugins, failures);
+    } catch (error) {
+      failures.add('第 $index 条：$error');
+    }
+  }
+
+  static Map<String, dynamic> _decodeRuleEntry(
+    String scheme,
+    String rawPayload,
+  ) {
     final payload = _ruleLinkPayloadPrefixPattern
         .firstMatch(rawPayload)
         ?.group(0)
         ?.trimRight();
-    if (payload == null || payload.isEmpty) return scheme;
+    if (payload == null || payload.isEmpty) {
+      throw const FormatException('Missing payload in Kazumi rule link');
+    }
 
     final candidates = <String>[payload];
-    final whitespaceMatches = RegExp(r'\s+').allMatches(payload).toList();
+    final whitespaceMatches = _whitespacePattern.allMatches(payload).toList();
     for (final whitespaceMatch in whitespaceMatches.reversed) {
       final candidate = payload.substring(0, whitespaceMatch.start).trimRight();
       if (candidate.isNotEmpty && candidate != candidates.last) {
@@ -111,15 +125,21 @@ class PluginImportParser {
       }
     }
 
+    FormatException? firstError;
     for (final candidate in candidates) {
       try {
         final decoded = json.decode(kazumiBase64ToJson('$scheme$candidate'));
-        if (decoded is Map) return '$scheme$candidate';
-      } catch (_) {
+        if (decoded is Map) {
+          return Map<String, dynamic>.from(decoded);
+        }
+        firstError ??=
+            const FormatException('规则链接内容必须是 JSON object');
+      } on FormatException catch (error) {
+        firstError ??= error;
         // Try a shorter prefix in case prose follows the rule link.
       }
     }
-    return '$scheme$payload';
+    throw firstError ?? const FormatException('Invalid Kazumi rule link');
   }
 
   static void _parseEntry(

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -24,6 +24,9 @@ class PluginImportParser {
     r'kazumi:(?://)?',
     caseSensitive: false,
   );
+  static final RegExp _ruleLinkPayloadPrefixPattern = RegExp(
+    r'^[A-Za-z0-9+/_=%\-\s]+',
+  );
 
   static PluginImportParseResult parse(String input) {
     final value = input.trim();
@@ -64,7 +67,7 @@ class PluginImportParser {
               ? matches[index + 1].start
               : value.length;
           _parseEntry(
-            value.substring(matches[index].start, end).trim(),
+            _extractRuleLink(value, matches[index], end),
             index + 1,
             parsed,
             failures,
@@ -88,6 +91,35 @@ class PluginImportParser {
       failures: List.unmodifiable(failures),
       duplicateCount: duplicateCount,
     );
+  }
+
+  static String _extractRuleLink(String input, Match schemeMatch, int end) {
+    final scheme = schemeMatch.group(0)!;
+    final rawPayload = input.substring(schemeMatch.end, end);
+    final payload = _ruleLinkPayloadPrefixPattern
+        .firstMatch(rawPayload)
+        ?.group(0)
+        ?.trimRight();
+    if (payload == null || payload.isEmpty) return scheme;
+
+    final candidates = <String>[payload];
+    final whitespaceMatches = RegExp(r'\s+').allMatches(payload).toList();
+    for (final whitespaceMatch in whitespaceMatches.reversed) {
+      final candidate = payload.substring(0, whitespaceMatch.start).trimRight();
+      if (candidate.isNotEmpty && candidate != candidates.last) {
+        candidates.add(candidate);
+      }
+    }
+
+    for (final candidate in candidates) {
+      try {
+        final decoded = json.decode(kazumiBase64ToJson('$scheme$candidate'));
+        if (decoded is Map) return '$scheme$candidate';
+      } on FormatException {
+        // Try a shorter prefix in case prose follows the rule link.
+      }
+    }
+    return '$scheme$payload';
   }
 
   static void _parseEntry(

--- a/lib/services/plugin/plugin_import_parser.dart
+++ b/lib/services/plugin/plugin_import_parser.dart
@@ -115,7 +115,7 @@ class PluginImportParser {
       try {
         final decoded = json.decode(kazumiBase64ToJson('$scheme$candidate'));
         if (decoded is Map) return '$scheme$candidate';
-      } on FormatException {
+      } catch (_) {
         // Try a shorter prefix in case prose follows the rule link.
       }
     }

--- a/lib/utils/encoding.dart
+++ b/lib/utils/encoding.dart
@@ -1,5 +1,26 @@
 import 'dart:convert';
 
+final RegExp _kazumiRuleLinkSchemePattern = RegExp(
+  r'kazumi:(?://)?',
+  caseSensitive: false,
+);
+
+Iterable<({String scheme, String rawPayload})> findKazumiRuleLinkSegments(
+  String input,
+) sync* {
+  final matches = _kazumiRuleLinkSchemePattern.allMatches(input).toList();
+  for (var index = 0; index < matches.length; index++) {
+    final match = matches[index];
+    final end = index + 1 < matches.length
+        ? matches[index + 1].start
+        : input.length;
+    yield (
+      scheme: match.group(0)!,
+      rawPayload: input.substring(match.end, end),
+    );
+  }
+}
+
 String jsonToKazumiBase64(String jsonStr) {
   final base64Str = base64Encode(utf8.encode(jsonStr));
   return 'kazumi://$base64Str';
@@ -7,10 +28,7 @@ String jsonToKazumiBase64(String jsonStr) {
 
 String kazumiBase64ToJson(String kazumiBase64Str) {
   final input = kazumiBase64Str.trim();
-  final schemeMatch = RegExp(
-    r'^kazumi:(?://)?',
-    caseSensitive: false,
-  ).firstMatch(input);
+  final schemeMatch = _kazumiRuleLinkSchemePattern.matchAsPrefix(input);
   if (schemeMatch == null) {
     throw const FormatException('Invalid Kazumi rule link');
   }
@@ -19,6 +37,8 @@ String kazumiBase64ToJson(String kazumiBase64Str) {
   try {
     payload = Uri.decodeComponent(payload);
   } on FormatException {
+    throw const FormatException('Invalid encoding in Kazumi rule link');
+  } on ArgumentError {
     throw const FormatException('Invalid encoding in Kazumi rule link');
   }
   payload = payload.replaceAll(RegExp(r'\s'), '');

--- a/test/plugin_api_config_test.dart
+++ b/test/plugin_api_config_test.dart
@@ -204,6 +204,10 @@ void main() {
       () => kazumiBase64ToJson('kazumi://not-base64!'),
       throwsA(isA<FormatException>()),
     );
+    expect(
+      () => kazumiBase64ToJson('kazumi://%zz'),
+      throwsA(isA<FormatException>()),
+    );
   });
 }
 

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/plugins/plugins.dart';
+import 'package:kazumi/plugins/plugins_controller.dart';
+import 'package:kazumi/services/plugin/plugin_import_parser.dart';
+import 'package:kazumi/utils/encoding.dart';
+
+void main() {
+  Plugin plugin(String name) {
+    return Plugin.fromTemplate()
+      ..name = name
+      ..version = '1.0';
+  }
+
+  String linkFor(Plugin value) {
+    return jsonToKazumiBase64(jsonEncode(value.toJson()));
+  }
+
+  group('PluginImportParser', () {
+    test('keeps single-link import backward compatible', () {
+      final result = PluginImportParser.parse(linkFor(plugin('single')));
+
+      expect(result.plugins.single.name, 'single');
+      expect(result.failureCount, 0);
+    });
+
+    test('imports multiple Kazumi links from text', () {
+      final result = PluginImportParser.parse(
+        '${linkFor(plugin('one'))}\n${linkFor(plugin('two'))}',
+      );
+
+      expect(result.plugins.map((item) => item.name), ['one', 'two']);
+      expect(result.failureCount, 0);
+      expect(result.duplicateCount, 0);
+    });
+
+    test('imports a JSON array of rules', () {
+      final result = PluginImportParser.parse(
+        jsonEncode([plugin('one').toJson(), plugin('two').toJson()]),
+      );
+
+      expect(result.plugins.map((item) => item.name), ['one', 'two']);
+      expect(result.failureCount, 0);
+    });
+
+    test('keeps valid links when another link is invalid', () {
+      final result = PluginImportParser.parse(
+        '${linkFor(plugin('valid'))}\nkazumi://not-base64!',
+      );
+
+      expect(result.plugins.single.name, 'valid');
+      expect(result.failureCount, 1);
+    });
+
+    test('keeps the last duplicate rule', () {
+      final first = plugin('same')..version = '1.0';
+      final second = plugin('SAME')..version = '2.0';
+      final result = PluginImportParser.parse(
+        '${linkFor(first)}\n${linkFor(second)}',
+      );
+
+      expect(result.plugins.single.version, '2.0');
+      expect(result.duplicateCount, 1);
+    });
+
+    test('rejects unsupported JSON values', () {
+      final result = PluginImportParser.parse('[42, null]');
+
+      expect(result.plugins, isEmpty);
+      expect(result.failureCount, 2);
+    });
+
+    test('imports all parsed rules with one persistence write', () async {
+      var writeCount = 0;
+      late String persistedJson;
+      final controller = PluginsController(
+        pluginJsonWriter: (jsonData) async {
+          writeCount++;
+          persistedJson = jsonData;
+        },
+      );
+
+      await controller.updatePlugins([plugin('one'), plugin('two')]);
+
+      expect(writeCount, 1);
+      expect(controller.pluginList.map((item) => item.name), ['one', 'two']);
+      expect(
+        (jsonDecode(persistedJson) as List)
+            .map((item) => (item as Map<String, dynamic>)['name']),
+        ['one', 'two'],
+      );
+    });
+  });
+}

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -35,6 +35,33 @@ void main() {
       expect(result.duplicateCount, 0);
     });
 
+    test('imports a rule link wrapped across lines', () {
+      final link = linkFor(plugin('wrapped'));
+      final splitAt = link.length ~/ 2;
+      final wrapped = '${link.substring(0, splitAt)}\n'
+          '  ${link.substring(splitAt)}';
+
+      final result = PluginImportParser.parse(wrapped);
+
+      expect(result.plugins.single.name, 'wrapped');
+      expect(result.failureCount, 0);
+    });
+
+    test('does not merge adjacent wrapped rule links', () {
+      String wrap(String link) {
+        final splitAt = link.length ~/ 2;
+        return '${link.substring(0, splitAt)}\n${link.substring(splitAt)}';
+      }
+
+      final result = PluginImportParser.parse(
+        '${wrap(linkFor(plugin('one')))}\n'
+        '${wrap(linkFor(plugin('two')))}',
+      );
+
+      expect(result.plugins.map((item) => item.name), ['one', 'two']);
+      expect(result.failureCount, 0);
+    });
+
     test('imports a JSON array of rules', () {
       final result = PluginImportParser.parse(
         jsonEncode([plugin('one').toJson(), plugin('two').toJson()]),

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -127,7 +127,9 @@ void main() {
       expect(result.plugins, isEmpty);
       expect(result.failureCount, 2);
     });
+  });
 
+  group('PluginsController.updatePlugins', () {
     test('imports all parsed rules with one persistence write', () async {
       var writeCount = 0;
       late String persistedJson;
@@ -147,6 +149,37 @@ void main() {
             .map((item) => (item as Map<String, dynamic>)['name']),
         ['one', 'two'],
       );
+    });
+
+    test('batch update replaces an installed rule case-insensitively',
+        () async {
+      var writeCount = 0;
+      final controller = PluginsController(
+        pluginJsonWriter: (_) async => writeCount++,
+      );
+      controller.pluginList.add(plugin('same')..version = '1.0');
+
+      await controller.updatePlugins([plugin('SAME')..version = '2.0']);
+
+      expect(writeCount, 1);
+      expect(controller.pluginList, hasLength(1));
+      expect(controller.pluginList.single.name, 'SAME');
+      expect(controller.pluginList.single.version, '2.0');
+    });
+
+    test('batch update rolls back all rules when persistence fails', () async {
+      final controller = PluginsController(
+        pluginJsonWriter: (_) async => throw StateError('write failed'),
+        errorReporter: (_, __, ___) {},
+      );
+      controller.pluginList.add(plugin('installed'));
+
+      await expectLater(
+        controller.updatePlugins([plugin('one'), plugin('two')]),
+        throwsStateError,
+      );
+
+      expect(controller.pluginList.map((item) => item.name), ['installed']);
     });
   });
 }

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -35,6 +35,16 @@ void main() {
       expect(result.duplicateCount, 0);
     });
 
+    test('imports a link with an uppercase scheme', () {
+      final link = linkFor(plugin('uppercase'))
+          .replaceFirst('kazumi://', 'KAZUMI://');
+
+      final result = PluginImportParser.parse(link);
+
+      expect(result.plugins.single.name, 'uppercase');
+      expect(result.failureCount, 0);
+    });
+
     test('imports a rule link wrapped across lines', () {
       final link = linkFor(plugin('wrapped'));
       final splitAt = link.length ~/ 2;
@@ -74,6 +84,25 @@ void main() {
       expect(englishResult.failureCount, 0);
     });
 
+    test('imports a percent-encoded link followed by prose', () {
+      final link = linkFor(plugin('encoded'));
+      final payload = link.substring('kazumi://'.length);
+      final firstByte = payload.codeUnitAt(0)
+          .toRadixString(16)
+          .padLeft(2, '0')
+          .toUpperCase();
+      final encodedPayload = '%$firstByte${payload.substring(1)}';
+
+      expect(encodedPayload, isNot(payload));
+
+      final result = PluginImportParser.parse(
+        'kazumi:$encodedPayload thanks',
+      );
+
+      expect(result.plugins.single.name, 'encoded');
+      expect(result.failureCount, 0);
+    });
+
     test('imports links separated by punctuation', () {
       final result = PluginImportParser.parse(
         '${linkFor(plugin('one'))}、${linkFor(plugin('two'))}',
@@ -95,6 +124,16 @@ void main() {
     test('keeps valid links when another link is invalid', () {
       final result = PluginImportParser.parse(
         '${linkFor(plugin('valid'))}\nkazumi://not-base64!',
+      );
+
+      expect(result.plugins.single.name, 'valid');
+      expect(result.failureCount, 1);
+    });
+
+    test('keeps valid links when a decoded link is not an object', () {
+      final result = PluginImportParser.parse(
+        '${jsonToKazumiBase64(jsonEncode([42]))}\n'
+        '${linkFor(plugin('valid'))}',
       );
 
       expect(result.plugins.single.name, 'valid');

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -101,6 +101,15 @@ void main() {
       expect(result.failureCount, 1);
     });
 
+    test('keeps valid links after malformed percent encoding', () {
+      final result = PluginImportParser.parse(
+        'kazumi://%zz\n${linkFor(plugin('valid'))}',
+      );
+
+      expect(result.plugins.single.name, 'valid');
+      expect(result.failureCount, 1);
+    });
+
     test('keeps the last duplicate rule', () {
       final first = plugin('same')..version = '1.0';
       final second = plugin('SAME')..version = '2.0';

--- a/test/plugin_import_parser_test.dart
+++ b/test/plugin_import_parser_test.dart
@@ -62,6 +62,27 @@ void main() {
       expect(result.failureCount, 0);
     });
 
+    test('ignores prose after a rule link', () {
+      final link = linkFor(plugin('shared'));
+
+      final chineseResult = PluginImportParser.parse('$link 谢谢分享');
+      final englishResult = PluginImportParser.parse('$link thanks');
+
+      expect(chineseResult.plugins.single.name, 'shared');
+      expect(chineseResult.failureCount, 0);
+      expect(englishResult.plugins.single.name, 'shared');
+      expect(englishResult.failureCount, 0);
+    });
+
+    test('imports links separated by punctuation', () {
+      final result = PluginImportParser.parse(
+        '${linkFor(plugin('one'))}、${linkFor(plugin('two'))}',
+      );
+
+      expect(result.plugins.map((item) => item.name), ['one', 'two']);
+      expect(result.failureCount, 0);
+    });
+
     test('imports a JSON array of rules', () {
       final result = PluginImportParser.parse(
         jsonEncode([plugin('one').toJson(), plugin('two').toJson()]),


### PR DESCRIPTION
## 描述  扩展规则导入流程，使剪贴板可以一次导入多条 `kazumi://` 链接，并支持从 `.json` 文件导入规则集合，同时保持原有单条导入行为兼容。  主要改动：  - 从剪贴板识别并导入多条 `kazumi://` 规则链接。 - 支持 JSON 数组格式的规则集合。 - 支持从 `.json` 文件导入。 - 有效规则继续导入，无效条目单独计入失败结果。 - 对同名规则去重，并显示成功、重复和失败数量。 - 批量解析完成后仅执行一次持久化写入。 - 复用项目已有的 `file_picker`，不引入新依赖。  ![批量规则导入运行截图](https://github.com/chendianshuiyin/Kazumi/releases/download/v2.2.8-custom.1/bulk-rule-import.png)  验证：  - `flutter analyze --no-fatal-infos --fatal-warnings` 通过，仅有项目原有的 `avoid_print` info。 - 专项测试 7/7 通过。 - 完整测试 139/139 通过。  ## 关联的 Issues  Closes #2486  ## PR 类型  - [ ] Bug 修复 - [x] 添加新功能 - [ ] 重构实现 - [ ] 文档或格式 - [ ] 其它  ## AI 辅助开发  - [ ] 没有使用 AI 辅助 - [ ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码 - [x] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物  AI 辅助模型: `OpenAI GPT-5.6 Sol`  AI 辅助范围：实现、检查和测试。涉及个人理解的确认项未由自动化代为勾选。  ## 提交前检查  - [x] 我已经填写了 PR 模板中的所有内容 - [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发 - [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动  ## 附注  该改动保持原有单条导入兼容；无效条目不会阻止其余有效规则导入。 