### PR TITLE
feat: 适配安卓16沉浸式标题栏

### DIFF
--- a/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/kazumi/MainActivity.kt
@@ -19,6 +19,7 @@ import android.app.PictureInPictureParams
 import android.graphics.drawable.Icon
 import android.util.Rational
 import android.view.View
+import android.view.WindowInsets
 import androidx.annotation.NonNull
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
@@ -33,8 +34,10 @@ class MainActivity: AudioServiceActivity() {
     private val CHANNEL = "com.predidit.kazumi/intent"
     private val STORAGE_CHANNEL = "com.predidit.kazumi/storage"
     private val PIP_CHANNEL = "com.predidit.kazumi/pip"
+    private val CAPTION_BAR_CHANNEL = "com.predidit.kazumi/caption_bar"
     private var intentChannel: MethodChannel? = null
     private var pipChannel: MethodChannel? = null
+    private var captionBarChannel: MethodChannel? = null
 
     private var pipIsPlaying = false
     private var pipDanmakuEnabled = false
@@ -69,6 +72,7 @@ class MainActivity: AudioServiceActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        applyTransparentCaptionBar()
         registerPipActionReceiverIfNeeded()
     }
 
@@ -82,10 +86,15 @@ class MainActivity: AudioServiceActivity() {
         if (hasFocus && androidFullscreen) {
             applySystemBarsState()
         }
+        if (hasFocus) {
+            notifyCaptionBarTopInset()
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+        applyTransparentCaptionBar()
+        notifyCaptionBarTopInset()
         syncPictureInPictureMode()
     }
 
@@ -168,6 +177,18 @@ class MainActivity: AudioServiceActivity() {
                 result.notImplemented()
             }
         }
+
+        captionBarChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CAPTION_BAR_CHANNEL)
+        captionBarChannel?.setMethodCallHandler { call, result ->
+            if (call.method == "getCaptionBarTopInset") {
+                result.success(getCaptionBarTopInset())
+            } else {
+                result.notImplemented()
+            }
+        }
+        window.decorView.post {
+            notifyCaptionBarTopInset()
+        }
     }
 
     private fun openWithMime(url: String, mimeType: String) {
@@ -213,6 +234,40 @@ class MainActivity: AudioServiceActivity() {
         } else {
             controller.show(WindowInsetsCompat.Type.systemBars())
         }
+        applyTransparentCaptionBar()
+        notifyCaptionBarTopInset()
+    }
+
+    private fun applyTransparentCaptionBar() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return
+        }
+
+        val transparentCaptionBarBackground = 128
+        val lightCaptionBars = 256
+        val lightSystemBars =
+            resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+                Configuration.UI_MODE_NIGHT_YES
+        val appearance = transparentCaptionBarBackground or
+            (if (lightSystemBars) lightCaptionBars else 0)
+        val mask = transparentCaptionBarBackground or lightCaptionBars
+        window.insetsController?.setSystemBarsAppearance(appearance, mask)
+    }
+
+    private fun getCaptionBarTopInset(): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return 0
+        }
+        return window.decorView.rootWindowInsets
+            ?.getInsets(WindowInsets.Type.captionBar())
+            ?.top ?: 0
+    }
+
+    private fun notifyCaptionBarTopInset() {
+        captionBarChannel?.invokeMethod(
+            "onCaptionBarTopInsetChanged",
+            mapOf("topInset" to getCaptionBarTopInset())
+        )
     }
 
     // Single entry point: the mode callback and the configuration change both

--- a/lib/bean/widget/android_caption_bar_padding.dart
+++ b/lib/bean/widget/android_caption_bar_padding.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:kazumi/services/platform/android_caption_bar.dart';
+
+class AndroidCaptionBarTopPadding extends StatelessWidget {
+  const AndroidCaptionBarTopPadding({
+    super.key,
+    required this.child,
+    this.enabled = true,
+  });
+
+  final Widget child;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) {
+      return child;
+    }
+    AndroidCaptionBar.ensureInitialized();
+    return ValueListenableBuilder<double>(
+      valueListenable: AndroidCaptionBar.topInset,
+      child: child,
+      builder: (context, topInset, child) {
+        return Padding(
+          padding: EdgeInsets.only(
+            top: topInset / MediaQuery.devicePixelRatioOf(context),
+          ),
+          child: child!,
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:kazumi/bean/widget/android_caption_bar_padding.dart';
 import 'package:kazumi/bean/widget/play_pause_icon.dart';
 import 'package:kazumi/pages/player/player_adjustment_hud.dart';
 import 'package:kazumi/pages/player/controller/player_aspect_ratio.dart';
@@ -959,184 +960,161 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   }
 
   Widget get topControlWidget {
-    return EmbeddedNativeControlArea(
-      requireOffset: !videoPageController.isFullscreen,
-      child: SafeArea(
-        top: false,
-        bottom: false,
-        left: videoPageController.isFullscreen,
-        right: videoPageController.isFullscreen,
-        child: PlayerPanelHoldMouseRegion(
-          acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
-          cursor: (videoPageController.isFullscreen &&
-                  !playerController.panel.showVideoController)
-              ? SystemMouseCursors.none
-              : SystemMouseCursors.basic,
-          child: Row(
-            children: [
-              IconButton(
-                color: Colors.white,
-                icon: const Icon(Icons.arrow_back_rounded),
-                tooltip: '返回',
-                onPressed: () {
-                  widget.onBackPressed(context);
-                },
-              ),
-              Expanded(
-                child: dtb.DragToMoveArea(
-                  child: Text(
-                    ' ${videoPageController.title} [${videoPageController.roadList[videoPageController.selectedEpisode.road].identifier[videoPageController.selectedEpisode.episode - 1]}]',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize:
-                          Theme.of(context).textTheme.titleMedium!.fontSize,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ),
-              ),
-              forwardIcon(),
-              if ((isDesktop() && !videoPageController.isFullscreen) ||
-                  Platform.isAndroid)
+    return AndroidCaptionBarTopPadding(
+      enabled: videoPageController.isFullscreen && !videoPageController.isPip,
+      child: EmbeddedNativeControlArea(
+        requireOffset: !videoPageController.isFullscreen,
+        child: SafeArea(
+          top: false,
+          bottom: false,
+          left: videoPageController.isFullscreen,
+          right: videoPageController.isFullscreen,
+          child: PlayerPanelHoldMouseRegion(
+            acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
+            cursor: (videoPageController.isFullscreen &&
+                    !playerController.panel.showVideoController)
+                ? SystemMouseCursors.none
+                : SystemMouseCursors.basic,
+            child: Row(
+              children: [
                 IconButton(
-                  onPressed: () async {
-                    if (isDesktop()) {
-                      if (videoPageController.isPip) {
-                        await PipUtils.exitDesktopPIPWindow();
-                      } else {
-                        await PipUtils.enterDesktopPIPWindow(
-                          width: playerController.debug.playerWidth,
-                          height: playerController.debug.playerHeight,
-                        );
-                      }
-                      videoPageController.isPip = !videoPageController.isPip;
-                      return;
-                    }
-                    await widget.enterAndroidPictureInPicture();
+                  color: Colors.white,
+                  icon: const Icon(Icons.arrow_back_rounded),
+                  tooltip: '返回',
+                  onPressed: () {
+                    widget.onBackPressed(context);
                   },
-                  tooltip: '画中画',
-                  icon: const Icon(
-                    Icons.picture_in_picture,
-                    color: Colors.white,
+                ),
+                Expanded(
+                  child: dtb.DragToMoveArea(
+                    child: Text(
+                      ' ${videoPageController.title} [${videoPageController.roadList[videoPageController.selectedEpisode.road].identifier[videoPageController.selectedEpisode.episode - 1]}]',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize:
+                            Theme.of(context).textTheme.titleMedium!.fontSize,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
                   ),
                 ),
-              PlayerPanelHoldCollectButton(
-                acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
-                bangumiItem: videoPageController.bangumiItem,
-              ),
-              PlayerPanelHoldMenuAnchor(
-                acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
-                onVisibilityChanged: widget.onMenuVisibilityChanged,
-                consumeOutsideTap: true,
-                builder: (BuildContext context, MenuController controller,
-                    Widget? child) {
-                  return IconButton(
-                    onPressed: () {
-                      if (controller.isOpen) {
-                        controller.close();
-                      } else {
-                        controller.open();
+                forwardIcon(),
+                if ((isDesktop() && !videoPageController.isFullscreen) ||
+                    Platform.isAndroid)
+                  IconButton(
+                    onPressed: () async {
+                      if (isDesktop()) {
+                        if (videoPageController.isPip) {
+                          await PipUtils.exitDesktopPIPWindow();
+                        } else {
+                          await PipUtils.enterDesktopPIPWindow(
+                            width: playerController.debug.playerWidth,
+                            height: playerController.debug.playerHeight,
+                          );
+                        }
+                        videoPageController.isPip = !videoPageController.isPip;
+                        return;
                       }
+                      await widget.enterAndroidPictureInPicture();
                     },
-                    tooltip: '更多选项',
+                    tooltip: '画中画',
                     icon: const Icon(
-                      Icons.more_vert,
+                      Icons.picture_in_picture,
                       color: Colors.white,
                     ),
-                  );
-                },
-                menuChildren: [
-                  MenuItemButton(
-                    onPressed: () {
-                      widget.showDanmakuSwitch();
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("弹幕切换"),
-                      ),
-                    ),
                   ),
-                  MenuItemButton(
-                    onPressed: () {
-                      widget.showVideoInfo();
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("视频详情"),
-                      ),
-                    ),
-                  ),
-                  MenuItemButton(
-                    onPressed: () {
-                      bool needRestart = playerController.playback.playing;
-                      playerController.pause();
-                      RemotePlay()
-                          .castVideo(playerController.videoUrl,
-                              videoPageController.currentPlugin.referer)
-                          .whenComplete(() {
-                        if (mounted && needRestart) {
-                          playerController.play();
+                PlayerPanelHoldCollectButton(
+                  acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
+                  bangumiItem: videoPageController.bangumiItem,
+                ),
+                PlayerPanelHoldMenuAnchor(
+                  acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
+                  onVisibilityChanged: widget.onMenuVisibilityChanged,
+                  consumeOutsideTap: true,
+                  builder: (BuildContext context, MenuController controller,
+                      Widget? child) {
+                    return IconButton(
+                      onPressed: () {
+                        if (controller.isOpen) {
+                          controller.close();
+                        } else {
+                          controller.open();
                         }
-                      });
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("远程投屏"),
+                      },
+                      tooltip: '更多选项',
+                      icon: const Icon(
+                        Icons.more_vert,
+                        color: Colors.white,
                       ),
-                    ),
-                  ),
-                  MenuItemButton(
-                    onPressed: () {
-                      playerController.launchExternalPlayer();
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("外部播放"),
-                      ),
-                    ),
-                  ),
-                  SubmenuButton(
-                    menuChildren: [
-                      MenuItemButton(
-                        onPressed: () {
-                          TimedShutdownService().cancel();
-                        },
-                        child: Container(
-                          height: 48,
-                          constraints: BoxConstraints(minWidth: 112),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              "不开启",
-                              style: TextStyle(
-                                color: !TimedShutdownService().isActive
-                                    ? Theme.of(context).colorScheme.primary
-                                    : null,
-                              ),
-                            ),
-                          ),
+                    );
+                  },
+                  menuChildren: [
+                    MenuItemButton(
+                      onPressed: () {
+                        widget.showDanmakuSwitch();
+                      },
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("弹幕切换"),
                         ),
                       ),
-                      for (final int minutes in [15, 30, 60])
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        widget.showVideoInfo();
+                      },
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("视频详情"),
+                        ),
+                      ),
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        bool needRestart = playerController.playback.playing;
+                        playerController.pause();
+                        RemotePlay()
+                            .castVideo(playerController.videoUrl,
+                                videoPageController.currentPlugin.referer)
+                            .whenComplete(() {
+                          if (mounted && needRestart) {
+                            playerController.play();
+                          }
+                        });
+                      },
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("远程投屏"),
+                        ),
+                      ),
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        playerController.launchExternalPlayer();
+                      },
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("外部播放"),
+                        ),
+                      ),
+                    ),
+                    SubmenuButton(
+                      menuChildren: [
                         MenuItemButton(
                           onPressed: () {
-                            TimedShutdownService().start(minutes,
-                                onExpired: widget.pauseForTimedShutdown);
-                            KazumiDialog.showToast(
-                                message:
-                                    '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
+                            TimedShutdownService().cancel();
                           },
                           child: Container(
                             height: 48,
@@ -1144,10 +1122,9 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                             child: Align(
                               alignment: Alignment.centerLeft,
                               child: Text(
-                                "$minutes 分钟",
+                                "不开启",
                                 style: TextStyle(
-                                  color: TimedShutdownService().setMinutes ==
-                                          minutes
+                                  color: !TimedShutdownService().isActive
                                       ? Theme.of(context).colorScheme.primary
                                       : null,
                                 ),
@@ -1155,57 +1132,84 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
                             ),
                           ),
                         ),
-                      MenuItemButton(
-                        onPressed: () {
-                          TimedShutdownService.showCustomTimerDialog(
-                            onExpired: widget.pauseForTimedShutdown,
-                          );
-                        },
-                        child: Container(
-                          height: 48,
-                          constraints: BoxConstraints(minWidth: 112),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text("自定义"),
+                        for (final int minutes in [15, 30, 60])
+                          MenuItemButton(
+                            onPressed: () {
+                              TimedShutdownService().start(minutes,
+                                  onExpired: widget.pauseForTimedShutdown);
+                              KazumiDialog.showToast(
+                                  message:
+                                      '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
+                            },
+                            child: Container(
+                              height: 48,
+                              constraints: BoxConstraints(minWidth: 112),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  "$minutes 分钟",
+                                  style: TextStyle(
+                                    color: TimedShutdownService().setMinutes ==
+                                            minutes
+                                        ? Theme.of(context).colorScheme.primary
+                                        : null,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        MenuItemButton(
+                          onPressed: () {
+                            TimedShutdownService.showCustomTimerDialog(
+                              onExpired: widget.pauseForTimedShutdown,
+                            );
+                          },
+                          child: Container(
+                            height: 48,
+                            constraints: BoxConstraints(minWidth: 112),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text("自定义"),
+                            ),
+                          ),
+                        ),
+                      ],
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: ValueListenableBuilder<int>(
+                            valueListenable:
+                                TimedShutdownService().remainingSecondsNotifier,
+                            builder: (context, remainingSeconds, child) {
+                              return Text(
+                                remainingSeconds > 0
+                                    ? "定时关闭 (${TimedShutdownService().formatRemainingTime()})"
+                                    : "定时关闭",
+                              );
+                            },
                           ),
                         ),
                       ),
-                    ],
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: ValueListenableBuilder<int>(
-                          valueListenable:
-                              TimedShutdownService().remainingSecondsNotifier,
-                          builder: (context, remainingSeconds, child) {
-                            return Text(
-                              remainingSeconds > 0
-                                  ? "定时关闭 (${TimedShutdownService().formatRemainingTime()})"
-                                  : "定时关闭",
-                            );
-                          },
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        widget.showSyncPlayPanel();
+                      },
+                      child: Container(
+                        height: 48,
+                        constraints: BoxConstraints(minWidth: 112),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text("一起看"),
                         ),
                       ),
                     ),
-                  ),
-                  MenuItemButton(
-                    onPressed: () {
-                      widget.showSyncPlayPanel();
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("一起看"),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -17,6 +17,7 @@ import 'package:kazumi/pages/settings/danmaku/danmaku_settings_sheet.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/bean/appbar/drag_to_move_bar.dart' as dtb;
 import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
+import 'package:kazumi/bean/widget/android_caption_bar_padding.dart';
 import 'package:kazumi/bean/widget/embedded_native_control_area.dart';
 import 'package:kazumi/services/player/timed_shutdown_service.dart';
 import 'package:kazumi/utils/device.dart';
@@ -466,109 +467,273 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
   }
 
   Widget get topControlWidget {
-    return EmbeddedNativeControlArea(
-      child: Row(
-        children: [
-          IconButton(
-            color: Colors.white,
-            icon: const Icon(Icons.arrow_back_rounded),
-            tooltip: '返回',
-            onPressed: () {
-              widget.onBackPressed(context);
-            },
-          ),
-          const Expanded(
-            child: dtb.DragToMoveArea(child: SizedBox(height: 40)),
-          ),
-          forwardIcon(),
-          if (isDesktop() || Platform.isAndroid)
+    return AndroidCaptionBarTopPadding(
+      enabled: videoPageController.isFullscreen && !videoPageController.isPip,
+      child: EmbeddedNativeControlArea(
+        requireOffset: !videoPageController.isFullscreen,
+        child: Row(
+          children: [
             IconButton(
-                onPressed: () async {
-                  if (isDesktop()) {
-                    if (videoPageController.isPip) {
-                      await PipUtils.exitDesktopPIPWindow();
-                    } else {
-                      // Size the PiP window to the video aspect ratio to
-                      // avoid letterboxing.
-                      await PipUtils.enterDesktopPIPWindow(
-                        width: playerController.debug.playerWidth,
-                        height: playerController.debug.playerHeight,
-                      );
+              color: Colors.white,
+              icon: const Icon(Icons.arrow_back_rounded),
+              tooltip: '返回',
+              onPressed: () {
+                widget.onBackPressed(context);
+              },
+            ),
+            const Expanded(
+              child: dtb.DragToMoveArea(child: SizedBox(height: 40)),
+            ),
+            forwardIcon(),
+            if (isDesktop() || Platform.isAndroid)
+              IconButton(
+                  onPressed: () async {
+                    if (isDesktop()) {
+                      if (videoPageController.isPip) {
+                        await PipUtils.exitDesktopPIPWindow();
+                      } else {
+                        // Size the PiP window to the video aspect ratio to
+                        // avoid letterboxing.
+                        await PipUtils.enterDesktopPIPWindow(
+                          width: playerController.debug.playerWidth,
+                          height: playerController.debug.playerHeight,
+                        );
+                      }
+                      videoPageController.isPip = !videoPageController.isPip;
+                      return;
                     }
-                    videoPageController.isPip = !videoPageController.isPip;
-                    return;
-                  }
-                  await widget.enterAndroidPictureInPicture();
-                },
-                tooltip: '画中画',
-                icon:
-                    const Icon(Icons.picture_in_picture, color: Colors.white)),
-          _buildDanmakuToggleButton(context),
-          PlayerPanelHoldCollectButton(
-            acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
-            bangumiItem: videoPageController.bangumiItem,
-          ),
-          PlayerPanelHoldMenuAnchor(
-            acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
-            onVisibilityChanged: widget.onMenuVisibilityChanged,
-            consumeOutsideTap: true,
-            builder: (BuildContext context, MenuController controller,
-                Widget? child) {
-              return IconButton(
-                onPressed: () {
-                  if (controller.isOpen) {
-                    controller.close();
-                  } else {
-                    controller.open();
-                  }
-                },
-                tooltip: '更多选项',
-                icon: const Icon(
-                  Icons.more_vert,
-                  color: Colors.white,
-                ),
-              );
-            },
-            menuChildren: [
-              SubmenuButton(
-                menuChildren: [
-                  for (final aspectRatioMode in PlayerAspectRatio.values)
-                    MenuItemButton(
-                      onPressed: () => playerController.panel.aspectRatioMode =
-                          aspectRatioMode,
-                      child: Container(
-                        height: 48,
-                        constraints: BoxConstraints(minWidth: 112),
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: Text(
-                            aspectRatioMode.label,
-                            style: TextStyle(
-                                color: aspectRatioMode ==
-                                        playerController.panel.aspectRatioMode
-                                    ? Theme.of(context).colorScheme.primary
-                                    : null),
+                    await widget.enterAndroidPictureInPicture();
+                  },
+                  tooltip: '画中画',
+                  icon: const Icon(Icons.picture_in_picture,
+                      color: Colors.white)),
+            _buildDanmakuToggleButton(context),
+            PlayerPanelHoldCollectButton(
+              acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
+              bangumiItem: videoPageController.bangumiItem,
+            ),
+            PlayerPanelHoldMenuAnchor(
+              acquirePlayerPanelHold: widget.acquirePlayerPanelHold,
+              onVisibilityChanged: widget.onMenuVisibilityChanged,
+              consumeOutsideTap: true,
+              builder: (BuildContext context, MenuController controller,
+                  Widget? child) {
+                return IconButton(
+                  onPressed: () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  },
+                  tooltip: '更多选项',
+                  icon: const Icon(
+                    Icons.more_vert,
+                    color: Colors.white,
+                  ),
+                );
+              },
+              menuChildren: [
+                SubmenuButton(
+                  menuChildren: [
+                    for (final aspectRatioMode in PlayerAspectRatio.values)
+                      MenuItemButton(
+                        onPressed: () => playerController
+                            .panel.aspectRatioMode = aspectRatioMode,
+                        child: Container(
+                          height: 48,
+                          constraints: BoxConstraints(minWidth: 112),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              aspectRatioMode.label,
+                              style: TextStyle(
+                                  color: aspectRatioMode ==
+                                          playerController.panel.aspectRatioMode
+                                      ? Theme.of(context).colorScheme.primary
+                                      : null),
+                            ),
                           ),
                         ),
                       ),
+                  ],
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("视频比例"),
                     ),
-                ],
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("视频比例"),
                   ),
                 ),
-              ),
-              SubmenuButton(
-                menuChildren: [
-                  for (final double i
-                      in defaultPlaySpeedList) ...<MenuItemButton>[
+                SubmenuButton(
+                  menuChildren: [
+                    for (final double i
+                        in defaultPlaySpeedList) ...<MenuItemButton>[
+                      MenuItemButton(
+                        onPressed: () async {
+                          await widget.setPlaybackSpeed(i);
+                        },
+                        child: Container(
+                          height: 48,
+                          constraints: BoxConstraints(minWidth: 112),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              '${i}x',
+                              style: TextStyle(
+                                  color: i ==
+                                          playerController.playback.playerSpeed
+                                      ? Theme.of(context).colorScheme.primary
+                                      : null),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("倍速"),
+                    ),
+                  ),
+                ),
+                SubmenuButton(
+                  menuChildren: [
+                    for (final mode in SuperResolutionMode.values)
+                      MenuItemButton(
+                        onPressed: () =>
+                            widget.handleSuperResolutionChange(mode),
+                        child: Container(
+                          height: 48,
+                          constraints: BoxConstraints(minWidth: 112),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              mode.label,
+                              style: TextStyle(
+                                color: playerController
+                                            .playback.superResolutionMode ==
+                                        mode
+                                    ? Theme.of(context).colorScheme.primary
+                                    : null,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("超分辨率"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    widget.showSyncPlayPanel();
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("一起看"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    widget.showDanmakuSwitch();
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("弹幕切换"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    showDanmakuSettingsSheet(
+                      context: context,
+                      danmakuController:
+                          playerController.danmaku.canvasController,
+                      onUpdateDanmakuSpeed: playerController.updateDanmakuSpeed,
+                      onTimelineOffsetChanged: playerController
+                          .danmaku.clearAndInvalidateScheduledDanmakus,
+                    );
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("弹幕设置"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    widget.showVideoInfo();
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("视频详情"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    bool needRestart = playerController.playback.playing;
+                    playerController.pause();
+                    RemotePlay()
+                        .castVideo(playerController.videoUrl,
+                            videoPageController.currentPlugin.referer)
+                        .whenComplete(() {
+                      if (mounted && needRestart) {
+                        playerController.play();
+                      }
+                    });
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("远程投屏"),
+                    ),
+                  ),
+                ),
+                MenuItemButton(
+                  onPressed: () {
+                    playerController.launchExternalPlayer();
+                  },
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text("外部播放"),
+                    ),
+                  ),
+                ),
+                SubmenuButton(
+                  menuChildren: [
                     MenuItemButton(
-                      onPressed: () async {
-                        await widget.setPlaybackSpeed(i);
+                      onPressed: () {
+                        TimedShutdownService().cancel();
                       },
                       child: Container(
                         height: 48,
@@ -576,43 +741,9 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                         child: Align(
                           alignment: Alignment.centerLeft,
                           child: Text(
-                            '${i}x',
+                            "不开启",
                             style: TextStyle(
-                                color:
-                                    i == playerController.playback.playerSpeed
-                                        ? Theme.of(context).colorScheme.primary
-                                        : null),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ],
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("倍速"),
-                  ),
-                ),
-              ),
-              SubmenuButton(
-                menuChildren: [
-                  for (final mode in SuperResolutionMode.values)
-                    MenuItemButton(
-                      onPressed: () => widget.handleSuperResolutionChange(mode),
-                      child: Container(
-                        height: 48,
-                        constraints: BoxConstraints(minWidth: 112),
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: Text(
-                            mode.label,
-                            style: TextStyle(
-                              color: playerController
-                                          .playback.superResolutionMode ==
-                                      mode
+                              color: !TimedShutdownService().isActive
                                   ? Theme.of(context).colorScheme.primary
                                   : null,
                             ),
@@ -620,196 +751,71 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
                         ),
                       ),
                     ),
-                ],
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("超分辨率"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  widget.showSyncPlayPanel();
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("一起看"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  widget.showDanmakuSwitch();
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("弹幕切换"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  showDanmakuSettingsSheet(
-                    context: context,
-                    danmakuController:
-                        playerController.danmaku.canvasController,
-                    onUpdateDanmakuSpeed: playerController.updateDanmakuSpeed,
-                    onTimelineOffsetChanged: playerController
-                        .danmaku.clearAndInvalidateScheduledDanmakus,
-                  );
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("弹幕设置"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  widget.showVideoInfo();
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("视频详情"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  bool needRestart = playerController.playback.playing;
-                  playerController.pause();
-                  RemotePlay()
-                      .castVideo(playerController.videoUrl,
-                          videoPageController.currentPlugin.referer)
-                      .whenComplete(() {
-                    if (mounted && needRestart) {
-                      playerController.play();
-                    }
-                  });
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("远程投屏"),
-                  ),
-                ),
-              ),
-              MenuItemButton(
-                onPressed: () {
-                  playerController.launchExternalPlayer();
-                },
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text("外部播放"),
-                  ),
-                ),
-              ),
-              SubmenuButton(
-                menuChildren: [
-                  MenuItemButton(
-                    onPressed: () {
-                      TimedShutdownService().cancel();
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          "不开启",
-                          style: TextStyle(
-                            color: !TimedShutdownService().isActive
-                                ? Theme.of(context).colorScheme.primary
-                                : null,
+                    for (final int minutes in [15, 30, 60])
+                      MenuItemButton(
+                        onPressed: () {
+                          TimedShutdownService().start(minutes,
+                              onExpired: widget.pauseForTimedShutdown);
+                          KazumiDialog.showToast(
+                              message:
+                                  '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
+                        },
+                        child: Container(
+                          height: 48,
+                          constraints: BoxConstraints(minWidth: 112),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              "$minutes 分钟",
+                              style: TextStyle(
+                                color:
+                                    TimedShutdownService().setMinutes == minutes
+                                        ? Theme.of(context).colorScheme.primary
+                                        : null,
+                              ),
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ),
-                  for (final int minutes in [15, 30, 60])
                     MenuItemButton(
                       onPressed: () {
-                        TimedShutdownService().start(minutes,
-                            onExpired: widget.pauseForTimedShutdown);
-                        KazumiDialog.showToast(
-                            message:
-                                '已设置 ${TimedShutdownService().formatMinutesToDisplay(minutes)} 后定时关闭');
+                        TimedShutdownService.showCustomTimerDialog(
+                          onExpired: widget.pauseForTimedShutdown,
+                        );
                       },
                       child: Container(
                         height: 48,
                         constraints: BoxConstraints(minWidth: 112),
                         child: Align(
                           alignment: Alignment.centerLeft,
-                          child: Text(
-                            "$minutes 分钟",
-                            style: TextStyle(
-                              color:
-                                  TimedShutdownService().setMinutes == minutes
-                                      ? Theme.of(context).colorScheme.primary
-                                      : null,
-                            ),
-                          ),
+                          child: Text("自定义"),
                         ),
                       ),
                     ),
-                  MenuItemButton(
-                    onPressed: () {
-                      TimedShutdownService.showCustomTimerDialog(
-                        onExpired: widget.pauseForTimedShutdown,
-                      );
-                    },
-                    child: Container(
-                      height: 48,
-                      constraints: BoxConstraints(minWidth: 112),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text("自定义"),
+                  ],
+                  child: Container(
+                    height: 48,
+                    constraints: BoxConstraints(minWidth: 112),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: ValueListenableBuilder<int>(
+                        valueListenable:
+                            TimedShutdownService().remainingSecondsNotifier,
+                        builder: (context, remainingSeconds, child) {
+                          return Text(
+                            remainingSeconds > 0
+                                ? "定时关闭 (${TimedShutdownService().formatRemainingTime()})"
+                                : "定时关闭",
+                          );
+                        },
                       ),
                     ),
                   ),
-                ],
-                child: Container(
-                  height: 48,
-                  constraints: BoxConstraints(minWidth: 112),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: ValueListenableBuilder<int>(
-                      valueListenable:
-                          TimedShutdownService().remainingSecondsNotifier,
-                      builder: (context, remainingSeconds, child) {
-                        return Text(
-                          remainingSeconds > 0
-                              ? "定时关闭 (${TimedShutdownService().formatRemainingTime()})"
-                              : "定时关闭",
-                        );
-                      },
-                    ),
-                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -27,6 +27,7 @@ import 'package:kazumi/modules/download/download_module.dart';
 import 'package:kazumi/services/player/timed_shutdown_service.dart';
 import 'package:kazumi/utils/device.dart';
 import 'package:kazumi/services/platform/display_mode_service.dart';
+import 'package:kazumi/bean/widget/android_caption_bar_padding.dart';
 import 'package:mobx/mobx.dart' as mobx;
 
 class VideoPage extends StatefulWidget {
@@ -676,17 +677,7 @@ class _VideoPageState extends State<VideoPage>
               : MediaQuery.sizeOf(context).width / 3),
       child: Container(
         color: Theme.of(context).canvasColor,
-        child: (isDesktop() || isTablet())
-            ? tabBody
-            : GridViewObserver(
-                controller: observerController,
-                child: Column(
-                  children: [
-                    menuBar,
-                    menuBody,
-                  ],
-                ),
-              ),
+        child: tabBody,
       ),
     );
   }
@@ -793,54 +784,58 @@ class _VideoPageState extends State<VideoPage>
                     top: 0,
                     left: 0,
                     right: 0,
-                    child: EmbeddedNativeControlArea(
-                      requireOffset: !videoPageController.isFullscreen,
-                      child: Row(
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.arrow_back,
-                                color: Colors.white),
-                            onPressed: () => onBackPressed(context),
-                          ),
-                          const Expanded(
-                              child: dtb.DragToMoveArea(
-                                  child: SizedBox(height: 40))),
-                          IconButton(
-                            icon: const Icon(Icons.refresh_outlined,
-                                color: Colors.white),
-                            onPressed: () {
-                              changeEpisode(
-                                  videoPageController.selectedEpisode.episode,
-                                  currentRoad:
-                                      videoPageController.selectedEpisode.road);
-                            },
-                          ),
-                          Visibility(
-                            visible: MediaQuery.sizeOf(context).width >
-                                MediaQuery.sizeOf(context).height,
-                            child: IconButton(
+                    child: AndroidCaptionBarTopPadding(
+                      enabled: videoPageController.isFullscreen &&
+                          !videoPageController.isPip,
+                      child: EmbeddedNativeControlArea(
+                        requireOffset: !videoPageController.isFullscreen,
+                        child: Row(
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.arrow_back,
+                                  color: Colors.white),
+                              onPressed: () => onBackPressed(context),
+                            ),
+                            const Expanded(
+                                child: dtb.DragToMoveArea(
+                                    child: SizedBox(height: 40))),
+                            IconButton(
+                              icon: const Icon(Icons.refresh_outlined,
+                                  color: Colors.white),
                               onPressed: () {
-                                _toggleTabBodyAnimated();
+                                changeEpisode(
+                                    videoPageController.selectedEpisode.episode,
+                                    currentRoad: videoPageController
+                                        .selectedEpisode.road);
                               },
-                              icon: Icon(
-                                _tabBodyTargetVisible
-                                    ? Icons.menu_open
-                                    : Icons.menu_open_outlined,
-                                color: Colors.white,
+                            ),
+                            Visibility(
+                              visible: MediaQuery.sizeOf(context).width >
+                                  MediaQuery.sizeOf(context).height,
+                              child: IconButton(
+                                onPressed: () {
+                                  _toggleTabBodyAnimated();
+                                },
+                                icon: Icon(
+                                  _tabBodyTargetVisible
+                                      ? Icons.menu_open
+                                      : Icons.menu_open_outlined,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
-                          ),
-                          IconButton(
-                            icon: Icon(
-                                showDebugLog
-                                    ? Icons.bug_report
-                                    : Icons.bug_report_outlined,
-                                color: Colors.white),
-                            onPressed: () {
-                              switchDebugConsole();
-                            },
-                          ),
-                        ],
+                            IconButton(
+                              icon: Icon(
+                                  showDebugLog
+                                      ? Icons.bug_report
+                                      : Icons.bug_report_outlined,
+                                  color: Colors.white),
+                              onPressed: () {
+                                switchDebugConsole();
+                              },
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/lib/services/platform/android_caption_bar.dart
+++ b/lib/services/platform/android_caption_bar.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class AndroidCaptionBar {
+  static const MethodChannel _channel =
+      MethodChannel('com.predidit.kazumi/caption_bar');
+
+  static final ValueNotifier<double> topInset = ValueNotifier<double>(0);
+
+  static bool _initialized = false;
+
+  static void ensureInitialized() {
+    if (_initialized || !Platform.isAndroid) {
+      return;
+    }
+    _initialized = true;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onCaptionBarTopInsetChanged') {
+        final Object? value = call.arguments is Map
+            ? (call.arguments as Map)['topInset']
+            : call.arguments;
+        _setTopInset(value);
+      }
+    });
+    refresh();
+  }
+
+  static Future<void> refresh() async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+    try {
+      final double inset =
+          (await _channel.invokeMethod<num>('getCaptionBarTopInset'))
+                  ?.toDouble() ??
+              0;
+      _setTopInset(inset);
+    } catch (_) {
+      _setTopInset(0);
+    }
+  }
+
+  static void _setTopInset(Object? value) {
+    final double inset = value is num ? value.toDouble() : 0;
+    if (topInset.value == inset) {
+      return;
+    }
+    topInset.value = inset;
+  }
+}


### PR DESCRIPTION
## 描述

适配安卓16沉浸式标题栏，将窗口内容延申到标题栏下方，并利用标题栏自身安全区让页面顶栏避开标题栏区域。
调整了播放器页面，使顶栏能向下避开标题栏按钮。
<img width=300 src="https://github.com/user-attachments/assets/6f2b4646-3531-47d4-9743-bdadaa7c8cac" />

## 关联的 Issues

## PR 类型

<!-- 这个 PR 属于什么类型的改动？ -->

- [ ] Bug 修复
- [x] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

<!-- 这个 PR 的工作是否用到了 AI 辅助？ -->

- [ ] 没有使用 AI 辅助
- [x] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: 

<!-- 请按照要求，填写完整的 AI 模型名称，如 “Claude Fable 5”，“Kimi-K3” -->
GPT 5.5

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

<!-- 简要写下一些附注。注意如果是对 PR 工作的描述，应该写在开头的 “描述” 一栏中 -->
或许也可以把sysappbar和播放器顶栏上移到标题栏区域，但目前拖动标题栏和点击按钮存在一定冲突，需要改动的地方较多、容易破坏设置页和番剧详情页，故暂且不做。
利用安全区让播放器顶栏下移的效果不好、且可能干扰挖孔屏手机，故封装了函数给播放器顶栏添加了标题栏高度的padding。