### PR TITLE
feat(player): add per-source episode sorting

### DIFF
--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -29,6 +29,34 @@ import 'package:kazumi/utils/device.dart';
 import 'package:kazumi/services/platform/display_mode_service.dart';
 import 'package:mobx/mobx.dart' as mobx;
 
+int episodeNumberForDisplayIndex(
+  int displayIndex,
+  int episodeCount, {
+  required bool descending,
+}) =>
+    descending ? episodeCount - displayIndex : displayIndex + 1;
+
+int displayIndexForEpisodeNumber(
+  int episodeNumber,
+  int episodeCount, {
+  required bool descending,
+}) =>
+    descending ? episodeCount - episodeNumber : episodeNumber - 1;
+
+List<String> descendingEpisodeSources(
+  Iterable<String> sources,
+  String source, {
+  required bool descending,
+}) {
+  final updated = sources.toSet();
+  if (descending) {
+    updated.add(source);
+  } else {
+    updated.remove(source);
+  }
+  return updated.toList();
+}
+
 class VideoPage extends StatefulWidget {
   const VideoPage({
     super.key,
@@ -72,6 +100,7 @@ class _VideoPageState extends State<VideoPage>
   late TabController tabController;
 
   int visibleRoad = 0;
+  late bool _episodesDescending;
   bool _tabBodyTargetVisible = true;
   int _tabBodyAnimationRun = 0;
 
@@ -82,11 +111,20 @@ class _VideoPageState extends State<VideoPage>
 
   static const Duration _offlinePlayerInitDelay = Duration(milliseconds: 400);
   static const Duration _sideTabAnimationDuration = Duration(milliseconds: 120);
+  static const String _descendingEpisodeSourcesKey = 'descendingEpisodeSources';
+
+  String get _episodeOrderSourceName => switch (widget.args) {
+        OnlineVideoPlaybackArgs(plugin: final plugin) => plugin.name,
+        OfflineVideoPlaybackArgs(pluginName: final pluginName) => pluginName,
+      };
 
   @override
   void initState() {
     super.initState();
     videoPageController.applyPlaybackArgs(widget.args);
+    _episodesDescending = GStorage.getStringListSettingByName(
+      _descendingEpisodeSourcesKey,
+    ).contains(_episodeOrderSourceName);
     windowManager.addListener(this);
     // Window fullscreen can be changed outside this page through system chrome.
     videoPageController.isDesktopFullscreen();
@@ -335,7 +373,15 @@ class _VideoPageState extends State<VideoPage>
       if (!mounted || !scrollController.hasClients) {
         return;
       }
-      final int index = videoPageController.selectedEpisode.episode - 1;
+      final episodeCount =
+          visibleRoad >= 0 && visibleRoad < videoPageController.roadList.length
+              ? videoPageController.roadList[visibleRoad].data.length
+              : 0;
+      final int index = displayIndexForEpisodeNumber(
+        videoPageController.selectedEpisode.episode,
+        episodeCount,
+        descending: _episodesDescending,
+      );
       await observerController.jumpTo(
         index: index < 0 ? 0 : index,
         isFixedHeight: true,
@@ -890,6 +936,20 @@ class _VideoPageState extends State<VideoPage>
             ),
           ),
           const SizedBox(width: 10),
+          IconButton(
+            tooltip: _episodesDescending ? '倒序' : '正序',
+            onPressed: _toggleEpisodeOrder,
+            style: IconButton.styleFrom(
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+            padding: EdgeInsets.zero,
+            icon: Transform.flip(
+              flipY: _episodesDescending,
+              child: const Icon(Icons.sort),
+            ),
+          ),
+          const SizedBox(width: 6),
           MenuAnchor(
             consumeOutsideTap: true,
             builder: (_, MenuController controller, __) {
@@ -944,6 +1004,22 @@ class _VideoPageState extends State<VideoPage>
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _toggleEpisodeOrder() async {
+    final descending = !_episodesDescending;
+    setState(() {
+      _episodesDescending = descending;
+    });
+    final sources = descendingEpisodeSources(
+      GStorage.getStringListSettingByName(_descendingEpisodeSourcesKey),
+      _episodeOrderSourceName,
+      descending: descending,
+    );
+    await GStorage.putStringListSettingByName(
+      _descendingEpisodeSourcesKey,
+      sources,
     );
   }
 
@@ -1009,9 +1085,15 @@ class _VideoPageState extends State<VideoPage>
         if (visibleRoad >= 0 &&
             visibleRoad < videoPageController.roadList.length) {
           final road = videoPageController.roadList[visibleRoad];
-          int count = 1;
-          for (var urlItem in road.data) {
-            int count0 = count;
+          for (var displayIndex = 0;
+              displayIndex < road.data.length;
+              displayIndex++) {
+            final count0 = episodeNumberForDisplayIndex(
+              displayIndex,
+              road.data.length,
+              descending: _episodesDescending,
+            );
+            final urlItem = road.data[count0 - 1];
             final episodeName = count0 - 1 < road.identifier.length
                 ? road.identifier[count0 - 1]
                 : '第$count0集';
@@ -1083,7 +1165,6 @@ class _VideoPageState extends State<VideoPage>
                 ),
               ),
             ));
-            count++;
           }
         }
         return Expanded(

--- a/test/video_episode_order_test.dart
+++ b/test/video_episode_order_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/pages/video/video_page.dart';
+
+void main() {
+  test('episode order maps display positions without changing episode numbers',
+      () {
+    expect(
+      List.generate(
+        4,
+        (index) => episodeNumberForDisplayIndex(index, 4, descending: false),
+      ),
+      [1, 2, 3, 4],
+    );
+    expect(
+      List.generate(
+        4,
+        (index) => episodeNumberForDisplayIndex(index, 4, descending: true),
+      ),
+      [4, 3, 2, 1],
+    );
+    expect(
+      displayIndexForEpisodeNumber(2, 4, descending: true),
+      2,
+    );
+  });
+
+  test('changing one source keeps other source preferences', () {
+    expect(
+      descendingEpisodeSources(
+        const ['giriGiriLove'],
+        '7sefun',
+        descending: true,
+      ),
+      unorderedEquals(['giriGiriLove', '7sefun']),
+    );
+    expect(
+      descendingEpisodeSources(
+        const ['giriGiriLove', '7sefun'],
+        '7sefun',
+        descending: false,
+      ),
+      ['giriGiriLove'],
+    );
+  });
+}


### PR DESCRIPTION
## 描述

为选集区域增加正序/倒序切换，方便《海贼王》这类集数较多的长篇作品快速查找较新的集数。

- 使用排序图标切换正序和倒序
- 切换排序时保持当前滚动位置，便于继续查找目标集数
- 按规则来源记住排序方式，避免不同来源互相影响
- 同一来源下的不同播放线路共用排序方式，保持选集体验一致
- 保持实际集数、播放记录和弹幕集数映射不变

之所以按规则来源保存，是因为不同规则返回选集的习惯可能不同；用户对某个来源设置倒序后，不应改变其他来源的显示方式。

![海贼王长篇选集倒序效果](https://raw.githubusercontent.com/moonrailgun/Kazumi/pr-assets/episode-sort-order-one-piece.png)

## 关联的 Issues

无。

## PR 类型

- [ ] Bug 修复
- [x] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [x] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: OpenAI GPT-5.6 Sol（xhigh）

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

已通过 `flutter test` 和 `flutter analyze --no-fatal-infos --fatal-warnings`。
