### PR TITLE
修复（播放器）：使用计时器而非操作系统键来触发长按倍速

### DIFF
--- a/lib/pages/player/player_keyboard_shortcuts.dart
+++ b/lib/pages/player/player_keyboard_shortcuts.dart
@@ -23,6 +23,11 @@ class PlayerLongPressShortcutActions {
 /// Dialog routes and explicitly blocked overlay interactions keep their normal
 /// key handling. Active long-press shortcuts are always released, even after
 /// focus leaves the player or this widget is disposed.
+///
+/// Long-press shortcuts are driven by timers instead of relying on OS key
+/// auto-repeat ([KeyRepeatEvent]). This keeps hold-to-repeat working with
+/// synthetic key input (e.g. mouse-button remappers that only send a single
+/// key down/up pair) and makes real-keyboard holding more responsive.
 class PlayerKeyboardShortcuts extends StatefulWidget {
   const PlayerKeyboardShortcuts({
     super.key,
@@ -45,10 +50,27 @@ class PlayerKeyboardShortcuts extends StatefulWidget {
 }
 
 class _PlayerKeyboardShortcutsState extends State<PlayerKeyboardShortcuts> {
+  /// Delay before a held key starts repeating, distinguishing a quick tap
+  /// from a long press.
+  static const Duration _longPressDelay = Duration(milliseconds: 250);
+
+  /// Interval between repeat invocations while the long press is active.
+  static const Duration _longPressRepeatInterval =
+      Duration(milliseconds: 100);
+
   late Map<String, List<String>> _shortcuts;
   final Map<LogicalKeyboardKey, PlayerLongPressShortcutActions>
       _activeLongPressKeys =
       <LogicalKeyboardKey, PlayerLongPressShortcutActions>{};
+
+  /// One-shot timers that arm the long-press repeat after [_longPressDelay].
+  final Map<LogicalKeyboardKey, Timer> _longPressArmTimers =
+      <LogicalKeyboardKey, Timer>{};
+
+  /// Periodic timers driving [PlayerLongPressShortcutActions.onRepeat] while
+  /// a long-press key stays held.
+  final Map<LogicalKeyboardKey, Timer> _longPressRepeatTimers =
+      <LogicalKeyboardKey, Timer>{};
 
   @override
   void initState() {
@@ -86,6 +108,7 @@ class _PlayerKeyboardShortcutsState extends State<PlayerKeyboardShortcuts> {
     if (event is KeyUpEvent) {
       final longPressActions = _activeLongPressKeys.remove(event.logicalKey);
       if (longPressActions != null) {
+        _cancelLongPressTimers(event.logicalKey);
         _invokeAction(longPressActions.onRelease);
         return KeyEventResult.handled;
       }
@@ -111,6 +134,7 @@ class _PlayerKeyboardShortcutsState extends State<PlayerKeyboardShortcuts> {
       final longPressActions = widget.longPressActions[actionName];
       if (longPressActions != null) {
         _activeLongPressKeys[event.logicalKey] = longPressActions;
+        _armLongPressRepeat(event.logicalKey, longPressActions);
       }
       _invokeAction(action);
       return KeyEventResult.handled;
@@ -118,14 +142,54 @@ class _PlayerKeyboardShortcutsState extends State<PlayerKeyboardShortcuts> {
 
     if (event is KeyRepeatEvent) {
       final longPressActions = _activeLongPressKeys[event.logicalKey];
-      if (longPressActions == null) {
+      // Already repeating through the timer, or no long press registered.
+      if (longPressActions == null ||
+          _longPressRepeatTimers.containsKey(event.logicalKey)) {
         return KeyEventResult.ignored;
       }
+      // OS auto-repeat arrived before our arm timer fired: activate now.
+      _activateLongPressRepeat(event.logicalKey, longPressActions);
       _invokeAction(longPressActions.onRepeat);
       return KeyEventResult.handled;
     }
 
     return KeyEventResult.ignored;
+  }
+
+  void _armLongPressRepeat(
+    LogicalKeyboardKey key,
+    PlayerLongPressShortcutActions actions,
+  ) {
+    _longPressArmTimers[key]?.cancel();
+    _longPressArmTimers[key] = Timer(_longPressDelay, () {
+      _longPressArmTimers.remove(key);
+      if (!_longPressRepeatTimers.containsKey(key)) {
+        _activateLongPressRepeat(key, actions);
+      }
+    });
+  }
+
+  void _activateLongPressRepeat(
+    LogicalKeyboardKey key,
+    PlayerLongPressShortcutActions actions,
+  ) {
+    _longPressRepeatTimers[key]?.cancel();
+    _invokeAction(actions.onRepeat);
+    _longPressRepeatTimers[key] = Timer.periodic(
+      _longPressRepeatInterval,
+      (_) {
+        if (!_activeLongPressKeys.containsKey(key)) {
+          _cancelLongPressTimers(key);
+          return;
+        }
+        _invokeAction(actions.onRepeat);
+      },
+    );
+  }
+
+  void _cancelLongPressTimers(LogicalKeyboardKey key) {
+    _longPressArmTimers.remove(key)?.cancel();
+    _longPressRepeatTimers.remove(key)?.cancel();
   }
 
   bool _shouldHandleShortcut() {
@@ -163,6 +227,12 @@ class _PlayerKeyboardShortcutsState extends State<PlayerKeyboardShortcuts> {
   }
 
   void _releaseAllLongPressShortcuts() {
+    for (final key in _longPressArmTimers.keys.toList()) {
+      _longPressArmTimers.remove(key)?.cancel();
+    }
+    for (final key in _longPressRepeatTimers.keys.toList()) {
+      _longPressRepeatTimers.remove(key)?.cancel();
+    }
     final actions = _activeLongPressKeys.values.toSet();
     _activeLongPressKeys.clear();
     for (final action in actions) {


### PR DESCRIPTION
## 描述

修复播放器"长按方向键加速"在注入式按键输入下失效的问题（例如用 X-Mouse Button Control 把鼠标右键映射为方向键右键并设置为"按下保持"时，无法实现持续加速）。

原因：原实现依赖操作系统按键自动重复事件（KeyRepeatEvent）来触发长按加速；而注入式按键只会发送一次 KeyDown/KeyUp，不会产生自动重复，导致长按加速永远不会触发。

改动：将长按逻辑改为 Timer 驱动——
- KeyDown 后启动 250ms 的"长按判定定时器"，判定为长按后以 100ms 间隔持续调用 onRepeat（加速）；
- 松开（KeyUp）时取消定时器并调用 onRelease（恢复原速或单击快进）；
- 保留 KeyRepeatEvent 作为兜底，真实键盘行为不变且响应更快。


## PR 类型

- [x] Bug 修复

## AI 辅助开发

- [ ] 没有使用 AI 辅助
- [x] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: Codex（OpenAI）

## 提交前检查

- [x] 我已经填写了 PR 模板中的所有内容
- [x] 我已经阅读了贡献指引，并遵守指引进行开发
- [x] 这个 PR 的功能已经经过我的测试，并且我完全理解我做出的改动