### PR TITLE
修复剧集更新后的历史播放进度错配

### DIFF
--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -34,6 +34,18 @@ abstract class _HistoryController with Store {
     init();
   }
 
+  History? getHistory(
+    BangumiItem bangumiItem,
+    String adapterName, {
+    String entryKind = HistoryEntryKind.online,
+  }) {
+    return _historyRepository.getHistory(
+      adapterName,
+      bangumiItem,
+      entryKind: entryKind,
+    );
+  }
+
   Progress? lastWatching(
     BangumiItem bangumiItem,
     String adapterName, {

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -206,15 +206,25 @@ class _VideoPageState extends State<VideoPage>
   void _initOnlineMode(PlayerController playerController) {
     videoPageController.historyOffset = 0;
 
-    var progress = historyController.lastWatching(
+    final history = historyController.getHistory(
         videoPageController.bangumiItem,
         videoPageController.currentPlugin.name);
+    final progress =
+        history == null ? null : history.progresses[history.lastWatchEpisode];
+    final episodePageUrl = history?.episodePageUrl ?? '';
     if (progress != null) {
       if (videoPageController.roadList.length > progress.road) {
-        if (videoPageController.roadList[progress.road].data.length >=
-            progress.episode) {
+        final road = videoPageController.roadList[progress.road];
+        var episode = progress.episode;
+        if (episodePageUrl.isNotEmpty) {
+          final currentIndex = road.data.indexOf(episodePageUrl);
+          if (currentIndex >= 0) {
+            episode = currentIndex + 1;
+          }
+        }
+        if (road.data.length >= episode) {
           videoPageController.resetEpisodeState(
-            episode: progress.episode,
+            episode: episode,
             road: progress.road,
           );
           if (playResume) {

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -209,8 +209,9 @@ class _VideoPageState extends State<VideoPage>
     final history = historyController.getHistory(
         videoPageController.bangumiItem,
         videoPageController.currentPlugin.name);
-    final progress =
-        history == null ? null : history.progresses[history.lastWatchEpisode];
+    final progress = historyController.lastWatching(
+        videoPageController.bangumiItem,
+        videoPageController.currentPlugin.name);
     final episodePageUrl = history?.episodePageUrl ?? '';
     if (progress != null) {
       if (videoPageController.roadList.length > progress.road) {


### PR DESCRIPTION
## 问题

在线历史目前使用剧集在片源列表中的位置恢复播放。当倒序片源在列表前插入新剧集，或片源调整剧集顺序后，原位置可能已经对应另一集，导致新剧集错误复用旧剧集的播放进度。

## 修改

- 恢复在线历史时，优先使用已有的 `episodePageUrl` 在原线路中精确定位剧集。
- 找到相同 URL 后，使用它在当前列表中的新位置，并继续恢复原进度。
- 对 URL 为空或当前片源已找不到该 URL 的旧历史，保留原有的线路和数字索引回退行为。
- 不修改历史存储结构，不增加启发式剧集排序或标题解析。

## 验证

- [x] `flutter test --no-pub`（149 项通过）
- [x] `flutter analyze --no-pub --no-fatal-infos --fatal-warnings`（无 warning/error；仅仓库已有的 5 项 `avoid_print` info）
- [x] macOS / Flutter 3.47.2 手动验证：在第 14 集播放至约 5:05 后，本地模拟在剧集列表前插入一集；再次从历史进入，仍定位原第 14 集并恢复至约 5:05。