### PR TITLE
feat(sync): 优化 Bangumi 收藏同步

### DIFF
--- a/lib/modules/bangumi/bangumi_collection.dart
+++ b/lib/modules/bangumi/bangumi_collection.dart
@@ -76,6 +76,11 @@ class BangumiCollection {
 
   factory BangumiCollection.fromJson(Map json) {
     final subject = json['subject'] as Map? ?? const <String, dynamic>{};
+    final bangumiId = (subject['id'] as int?) ?? (json['subject_id'] as int?);
+    if (bangumiId == null || bangumiId <= 0) {
+      throw const FormatException(
+          'BangumiCollection: invalid or missing bangumi id');
+    }
     final subjectImages = Map<String, String>.from(
       (subject['images'] as Map?) ??
           const <String, String>{
@@ -94,13 +99,13 @@ class BangumiCollection {
     try {
       final updatedAtStr = json['updated_at'] as String?;
       updatedAt = updatedAtStr != null
-          ? DateTime.parse(updatedAtStr)
-          : DateTime.fromMillisecondsSinceEpoch(0);
+          ? (DateTime.tryParse(updatedAtStr) ?? DateTime.now())
+          : DateTime.now();
     } catch (_) {
-      updatedAt = DateTime.fromMillisecondsSinceEpoch(0);
+      updatedAt = DateTime.now();
     }
     return BangumiCollection(
-      subject['id'] as int? ?? json['subject_id'] as int? ?? 0,
+      bangumiId,
       subject['date'] as String?,
       updatedAt,
       BangumiCollectionType.fromValue(json['type'] as int? ?? 0),

--- a/lib/modules/bangumi/bangumi_collection.dart
+++ b/lib/modules/bangumi/bangumi_collection.dart
@@ -5,7 +5,7 @@ import 'bangumi_collection_type.dart';
 /// NOTE: 该类仅用于解析 Bangumi API 返回的收藏数据，不适用本地收藏
 class BangumiCollection {
   /// 最后更新时间
-  DateTime? updatedAt;
+  DateTime updatedAt;
 
   /// Bangumi ID
   int bangumiId;
@@ -95,14 +95,15 @@ class BangumiCollection {
         .whereType<Map>()
         .map((tag) => Map<String, dynamic>.from(tag))
         .toList();
-    DateTime? updatedAt;
-    try {
-      final updatedAtStr = json['updated_at'] as String?;
-      if (updatedAtStr != null && updatedAtStr.isNotEmpty) {
-        updatedAt = DateTime.tryParse(updatedAtStr);
-      }
-    } catch (_) {
-      updatedAt = null;
+    final updatedAtStr = json['updated_at'] as String?;
+    if (updatedAtStr == null || updatedAtStr.trim().isEmpty) {
+      throw const FormatException(
+          'BangumiCollection: missing or empty updated_at');
+    }
+    final updatedAt = DateTime.tryParse(updatedAtStr);
+    if (updatedAt == null) {
+      throw const FormatException(
+          'BangumiCollection: invalid updated_at format');
     }
     return BangumiCollection(
       bangumiId,

--- a/lib/modules/bangumi/bangumi_collection.dart
+++ b/lib/modules/bangumi/bangumi_collection.dart
@@ -5,7 +5,7 @@ import 'bangumi_collection_type.dart';
 /// NOTE: 该类仅用于解析 Bangumi API 返回的收藏数据，不适用本地收藏
 class BangumiCollection {
   /// 最后更新时间
-  DateTime updatedAt;
+  DateTime? updatedAt;
 
   /// Bangumi ID
   int bangumiId;
@@ -95,14 +95,14 @@ class BangumiCollection {
         .whereType<Map>()
         .map((tag) => Map<String, dynamic>.from(tag))
         .toList();
-    DateTime updatedAt;
+    DateTime? updatedAt;
     try {
       final updatedAtStr = json['updated_at'] as String?;
-      updatedAt = updatedAtStr != null
-          ? (DateTime.tryParse(updatedAtStr) ?? DateTime.now())
-          : DateTime.now();
+      if (updatedAtStr != null && updatedAtStr.isNotEmpty) {
+        updatedAt = DateTime.tryParse(updatedAtStr);
+      }
     } catch (_) {
-      updatedAt = DateTime.now();
+      updatedAt = null;
     }
     return BangumiCollection(
       bangumiId,

--- a/lib/modules/bangumi/bangumi_collection.dart
+++ b/lib/modules/bangumi/bangumi_collection.dart
@@ -75,9 +75,9 @@ class BangumiCollection {
   }
 
   factory BangumiCollection.fromJson(Map json) {
-    final subject = json['subject'];
+    final subject = json['subject'] as Map? ?? const <String, dynamic>{};
     final subjectImages = Map<String, String>.from(
-      subject['images'] ??
+      (subject['images'] as Map?) ??
           const <String, String>{
             'large': '',
             'common': '',
@@ -90,17 +90,26 @@ class BangumiCollection {
         .whereType<Map>()
         .map((tag) => Map<String, dynamic>.from(tag))
         .toList();
+    DateTime updatedAt;
+    try {
+      final updatedAtStr = json['updated_at'] as String?;
+      updatedAt = updatedAtStr != null
+          ? DateTime.parse(updatedAtStr)
+          : DateTime.fromMillisecondsSinceEpoch(0);
+    } catch (_) {
+      updatedAt = DateTime.fromMillisecondsSinceEpoch(0);
+    }
     return BangumiCollection(
-      subject['id'],
-      subject['date'],
-      DateTime.parse(json['updated_at']),
-      BangumiCollectionType.fromValue(json['type']),
-      subject['name'],
-      subject['name_cn'],
-      subject['short_summary'],
-      (subject['score'] as num).toDouble(),
-      subject['eps'],
-      subject['rank'],
+      subject['id'] as int? ?? json['subject_id'] as int? ?? 0,
+      subject['date'] as String?,
+      updatedAt,
+      BangumiCollectionType.fromValue(json['type'] as int? ?? 0),
+      subject['name'] as String? ?? '',
+      subject['name_cn'] as String? ?? '',
+      subject['short_summary'] as String? ?? '',
+      (subject['score'] as num?)?.toDouble() ?? 0.0,
+      subject['eps'] as int? ?? 0,
+      subject['rank'] as int? ?? 0,
       subjectImages,
       subjectTags,
     );

--- a/lib/modules/bangumi/sync_priority.dart
+++ b/lib/modules/bangumi/sync_priority.dart
@@ -1,6 +1,7 @@
 enum BangumiSyncPriority {
   localFirst(0, '本地优先'),
-  bangumiFirst(1, 'Bangumi优先');
+  bangumiFirst(1, 'Bangumi优先'),
+  timeFirst(2, '最新优先');
 
   const BangumiSyncPriority(this.value, this.label);
 

--- a/lib/modules/collect/collect_sync_merger.dart
+++ b/lib/modules/collect/collect_sync_merger.dart
@@ -174,7 +174,7 @@ class CollectSyncMerger {
           BangumiUploadMutation(bangumiId: id, type: localMap[id]!.type),
         );
       }
-    } else {
+    } else if (priority == BangumiSyncPriority.bangumiFirst) {
       for (final id in mismatchIds) {
         conflictLocalUpdates.add(
           BangumiLocalMutation(
@@ -182,6 +182,24 @@ class CollectSyncMerger {
             changeAction: 2,
           ),
         );
+      }
+    } else if (priority == BangumiSyncPriority.timeFirst) {
+      for (final id in mismatchIds) {
+        final localTime = localMap[id]!.time;
+        final remoteTime = remoteMap[id]!.updatedAt;
+        if (localTime.isAfter(remoteTime) ||
+            localTime.isAtSameMomentAs(remoteTime)) {
+          conflictUploads.add(
+            BangumiUploadMutation(bangumiId: id, type: localMap[id]!.type),
+          );
+        } else {
+          conflictLocalUpdates.add(
+            BangumiLocalMutation(
+              collectible: _fromBangumiCollection(remoteMap[id]!),
+              changeAction: 2,
+            ),
+          );
+        }
       }
     }
 

--- a/lib/modules/collect/collect_sync_merger.dart
+++ b/lib/modules/collect/collect_sync_merger.dart
@@ -187,7 +187,8 @@ class CollectSyncMerger {
       for (final id in mismatchIds) {
         final localTime = localMap[id]!.time;
         final remoteTime = remoteMap[id]!.updatedAt;
-        if (localTime.isAfter(remoteTime) ||
+        if (remoteTime == null ||
+            localTime.isAfter(remoteTime) ||
             localTime.isAtSameMomentAs(remoteTime)) {
           conflictUploads.add(
             BangumiUploadMutation(bangumiId: id, type: localMap[id]!.type),
@@ -215,7 +216,7 @@ class CollectSyncMerger {
     final localType = remote.type.toCollectType();
     return CollectedBangumi(
       remote.toBangumiItem(),
-      remote.updatedAt,
+      remote.updatedAt ?? DateTime.now(),
       localType.value,
     );
   }

--- a/lib/modules/collect/collect_sync_merger.dart
+++ b/lib/modules/collect/collect_sync_merger.dart
@@ -187,8 +187,7 @@ class CollectSyncMerger {
       for (final id in mismatchIds) {
         final localTime = localMap[id]!.time;
         final remoteTime = remoteMap[id]!.updatedAt;
-        if (remoteTime == null ||
-            localTime.isAfter(remoteTime) ||
+        if (localTime.isAfter(remoteTime) ||
             localTime.isAtSameMomentAs(remoteTime)) {
           conflictUploads.add(
             BangumiUploadMutation(bangumiId: id, type: localMap[id]!.type),
@@ -216,7 +215,7 @@ class CollectSyncMerger {
     final localType = remote.type.toCollectType();
     return CollectedBangumi(
       remote.toBangumiItem(),
-      remote.updatedAt ?? DateTime.now(),
+      remote.updatedAt,
       localType.value,
     );
   }

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -598,9 +598,17 @@ class BangumiApi {
           rethrow;
         }
 
+        if (jsonData is! Map || jsonData['data'] is! List) {
+          KazumiLogger().e(
+            'BangumiApi: invalid collection response format at offset=$offset',
+          );
+          throw const FormatException(
+              'BangumiApi: Invalid collection response format');
+        }
+
         final Map jsonMap = jsonData;
-        final List<dynamic> jsonList = jsonMap['data'] ?? [];
-        total ??= jsonMap['total'];
+        final List<dynamic> jsonList = jsonMap['data'] as List<dynamic>;
+        total ??= jsonMap['total'] as int?;
         if (!totalInitialized && total != null) {
           progressTotal = total;
           totalInitialized = true;

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -643,20 +643,7 @@ class BangumiApi {
       final List<dynamic> firstPageList =
           firstPageJson['data'] as List<dynamic>;
 
-      final firstPageReceivedCount = firstPageList.length;
-      final firstPageItems = parsePageItems(firstPageList);
-      bangumiCollection.addAll(firstPageItems);
-      progressCurrent += firstPageList.length;
-
-      // 1. 空收藏直接返回
-      if (firstPageReceivedCount == 0) {
-        KazumiLogger()
-            .d('get Bangumi collection count: ${bangumiCollection.length}');
-        KazumiLogger().d('get item failed count: $failedItemCount');
-        return bangumiCollection;
-      }
-
-      // 2. 校验 total：缺失时抛出 FormatException，防止因镜像站/异常响应导致静默返回残缺数据
+      // 1. 优先校验 total：缺失时抛出 FormatException，防止因镜像站/网关返回残缺 body（如丢失 total 的空 data）导致静默返回空快照而误覆盖云端
       if (rawTotal == null) {
         KazumiLogger().e(
           'BangumiApi: missing or invalid total in collection response',
@@ -666,6 +653,11 @@ class BangumiApi {
       }
       final int total = rawTotal;
 
+      final firstPageReceivedCount = firstPageList.length;
+      final firstPageItems = parsePageItems(firstPageList);
+      bangumiCollection.addAll(firstPageItems);
+      progressCurrent += firstPageList.length;
+
       progressTotal = total;
       onProgress?.call(
         '正在拉取 Bangumi 收藏',
@@ -673,8 +665,10 @@ class BangumiApi {
         progressTotal,
       );
 
-      // 3. 单页全量数据直接返回（无需启动并发 Worker）
-      if (total <= effectiveLimit ||
+      // 2. 空收藏或单页全量数据直接返回（无需启动并发 Worker）
+      if (total == 0 ||
+          firstPageReceivedCount == 0 ||
+          total <= effectiveLimit ||
           firstPageReceivedCount < serverLimit ||
           firstPageReceivedCount >= total) {
         KazumiLogger()

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -637,27 +637,44 @@ class BangumiApi {
 
       // 阶段 1：探测首页，获取 total 及第一页数据
       final firstPageJson = await fetchPageData(0, limit);
-      final int? total = firstPageJson['total'] as int?;
+      final int? rawTotal = firstPageJson['total'] as int?;
       final serverLimit = (firstPageJson['limit'] as int?) ?? limit;
       final effectiveLimit = (serverLimit > 0) ? serverLimit : limit;
       final List<dynamic> firstPageList =
           firstPageJson['data'] as List<dynamic>;
 
-      progressTotal = total ?? firstPageList.length;
+      final firstPageReceivedCount = firstPageList.length;
       final firstPageItems = parsePageItems(firstPageList);
       bangumiCollection.addAll(firstPageItems);
       progressCurrent += firstPageList.length;
+
+      // 1. 空收藏直接返回
+      if (firstPageReceivedCount == 0) {
+        KazumiLogger()
+            .d('get Bangumi collection count: ${bangumiCollection.length}');
+        KazumiLogger().d('get item failed count: $failedItemCount');
+        return bangumiCollection;
+      }
+
+      // 2. 校验 total：缺失时抛出 FormatException，防止因镜像站/异常响应导致静默返回残缺数据
+      if (rawTotal == null) {
+        KazumiLogger().e(
+          'BangumiApi: missing or invalid total in collection response',
+        );
+        throw const FormatException(
+            'BangumiApi: missing total in collection response');
+      }
+      final int total = rawTotal;
+
+      progressTotal = total;
       onProgress?.call(
         '正在拉取 Bangumi 收藏',
         progressCurrent,
         progressTotal,
       );
 
-      final firstPageReceivedCount = firstPageList.length;
-      // 尾页判断：如果数据已在第一页完全获取，直接返回无需并发
-      if (firstPageReceivedCount == 0 ||
-          total == null ||
-          total <= effectiveLimit ||
+      // 3. 单页全量数据直接返回（无需启动并发 Worker）
+      if (total <= effectiveLimit ||
           firstPageReceivedCount < serverLimit ||
           firstPageReceivedCount >= total) {
         KazumiLogger()

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -15,6 +15,7 @@ import 'package:kazumi/modules/collect/collect_type_mapper.dart';
 import 'package:kazumi/modules/bangumi/bangumi_collection_type.dart';
 import 'package:kazumi/modules/comments/comment_item.dart';
 import 'package:kazumi/utils/search_parser.dart';
+import 'package:kazumi/utils/async_rate_limiter.dart';
 
 class BangumiSearchPage {
   const BangumiSearchPage({
@@ -28,6 +29,8 @@ class BangumiSearchPage {
 
 class BangumiApi {
   static final BangumiClient _client = BangumiClient.instance;
+  static final AsyncRateLimiter _writeRateLimiter =
+      AsyncRateLimiter(const Duration(milliseconds: 250));
 
   static Future<List<List<BangumiItem>>> getCalendar() async {
     List<List<BangumiItem>> bangumiCalendar = [];
@@ -549,9 +552,6 @@ class BangumiApi {
   }
 
   /// Get the Bangumi collection of the current user
-  ///
-  /// 采用 3 并发分片结合全局速率调度器（任意请求发起间隔严格 >= 200ms，即 <= 5 QPS 上限），
-  /// 既严格遵循 Bangumi API 的请求频控安全要求，又利用网络在途 RTT 窗口显著降低全量同步耗时。
   static Future<List<BangumiCollection>> getBangumiCollectibles({
     List<BangumiCollectionType> includeBangumiTypes = const [
       BangumiCollectionType.planToWatch,
@@ -577,25 +577,12 @@ class BangumiApi {
     }
 
     try {
-      const Duration minRequestInterval = Duration(milliseconds: 200);
+      final rateLimiter =
+          AsyncRateLimiter(const Duration(milliseconds: 200));
       const int concurrency = 3;
-      DateTime nextAllowedLaunchTime = DateTime.now();
-
-      // 全局速率控制器：确保任意两次请求发起的间距不小于 minRequestInterval (200ms)
-      Future<void> acquireRateLimitSlot() async {
-        final now = DateTime.now();
-        final scheduledTime = nextAllowedLaunchTime.isAfter(now)
-            ? nextAllowedLaunchTime
-            : now;
-        nextAllowedLaunchTime = scheduledTime.add(minRequestInterval);
-        final waitDuration = scheduledTime.difference(now);
-        if (waitDuration > Duration.zero) {
-          await Future.delayed(waitDuration);
-        }
-      }
 
       Future<Map> fetchPageData(int offset, int pageLimit) async {
-        await acquireRateLimitSlot();
+        await rateLimiter.acquire();
         final url = ApiEndpoints.formatUrl(
             ApiEndpoints.bangumiAuthAPIMirrorDomain +
                 ApiEndpoints.bangumiGetAllCollections,
@@ -635,7 +622,6 @@ class BangumiApi {
         return items;
       }
 
-      // 阶段 1：探测首页，获取 total 及第一页数据
       final firstPageJson = await fetchPageData(0, limit);
       final int? rawTotal = firstPageJson['total'] as int?;
       final serverLimit = (firstPageJson['limit'] as int?) ?? limit;
@@ -643,7 +629,6 @@ class BangumiApi {
       final List<dynamic> firstPageList =
           firstPageJson['data'] as List<dynamic>;
 
-      // 1. 优先校验 total：缺失时抛出 FormatException，防止因镜像站/网关返回残缺 body（如丢失 total 的空 data）导致静默返回空快照而误覆盖云端
       if (rawTotal == null) {
         KazumiLogger().e(
           'BangumiApi: missing or invalid total in collection response',
@@ -658,7 +643,6 @@ class BangumiApi {
       bangumiCollection.addAll(firstPageItems);
       progressCurrent += firstPageList.length;
 
-      // 2. 校验首包一致性：若声明 total > 0 但首包数据却为空，说明响应异常损坏，显式报错中止
       if (total > 0 && firstPageReceivedCount == 0) {
         KazumiLogger().e(
           'BangumiApi: received empty data on first page while total > 0 (total=$total)',
@@ -673,9 +657,6 @@ class BangumiApi {
         progressTotal,
       );
 
-      // 3. 空收藏或单页全量数据直接返回（无需启动并发 Worker）
-      //    严格仅在 total == 0 或首包实际条数已完整覆盖 total 时短路返回，
-      //    防止异常响应（如 total 很大但首包异常为空或短缺）产生残缺快照误覆盖云端
       if (total == 0 || firstPageReceivedCount >= total) {
         KazumiLogger()
             .d('get Bangumi collection count: ${bangumiCollection.length}');
@@ -683,7 +664,6 @@ class BangumiApi {
         return bangumiCollection;
       }
 
-      // 阶段 2：构建剩余分页 offset 队列并启动 3 并发 Worker
       final remainingOffsets = <int>[];
       for (int off = effectiveLimit; off < total; off += effectiveLimit) {
         remainingOffsets.add(off);
@@ -707,7 +687,6 @@ class BangumiApi {
             progressTotal,
           );
 
-          // 尾页提前截断优化：当返回条数不足一页且累计条目已达到或超过 total 时，说明已到尾页
           if (jsonList.length < serverLimit && offset + jsonList.length >= total) {
             offsetsQueue.clear();
             break;
@@ -720,7 +699,6 @@ class BangumiApi {
           : concurrency;
       await Future.wait(List.generate(workerCount, (_) => worker()));
 
-      // 阶段 3：按 offset 顺序合并所有分片，并按 bangumiId 去重（防御网络并发期间服务端数据位移）
       final Set<int> seenBangumiIds =
           bangumiCollection.map((e) => e.bangumiId).toSet();
       for (final offset in remainingOffsets) {
@@ -746,7 +724,7 @@ class BangumiApi {
   /// Update the Bangumi collection by ID
   static Future<bool> updateBangumiById(
       int id, Map<String, dynamic> data) async {
-    const Duration requestInterval = Duration(milliseconds: 250);
+    await _writeRateLimiter.acquire();
     try {
       await _client.post(
         ApiEndpoints.formatUrl(
@@ -778,8 +756,6 @@ class BangumiApi {
     } catch (e) {
       KazumiLogger().e('Network: update bangumi collection failed', error: e);
       rethrow;
-    } finally {
-      await Future.delayed(requestInterval);
     }
   }
 

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -666,11 +666,9 @@ class BangumiApi {
       );
 
       // 2. 空收藏或单页全量数据直接返回（无需启动并发 Worker）
-      if (total == 0 ||
-          firstPageReceivedCount == 0 ||
-          total <= effectiveLimit ||
-          firstPageReceivedCount < serverLimit ||
-          firstPageReceivedCount >= total) {
+      //    严格仅在 total == 0 或首包实际条数已完整覆盖 total 时短路返回，
+      //    防止异常响应（如 total 很大但首包异常为空或短缺）产生残缺快照误覆盖云端
+      if (total == 0 || firstPageReceivedCount >= total) {
         KazumiLogger()
             .d('get Bangumi collection count: ${bangumiCollection.length}');
         KazumiLogger().d('get item failed count: $failedItemCount');
@@ -701,8 +699,8 @@ class BangumiApi {
             progressTotal,
           );
 
-          // 尾页提前截断优化：如果返回条数小于 serverLimit，说明后续已无数据
-          if (jsonList.length < serverLimit) {
+          // 尾页提前截断优化：当返回条数不足一页且累计条目已达到或超过 total 时，说明已到尾页
+          if (jsonList.length < serverLimit && offset + jsonList.length >= total) {
             offsetsQueue.clear();
             break;
           }

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -549,6 +549,9 @@ class BangumiApi {
   }
 
   /// Get the Bangumi collection of the current user
+  ///
+  /// 采用 3 并发分片结合全局速率调度器（任意请求发起间隔严格 >= 200ms，即 <= 5 QPS 上限），
+  /// 既严格遵循 Bangumi API 的请求频控安全要求，又利用网络在途 RTT 窗口显著降低全量同步耗时。
   static Future<List<BangumiCollection>> getBangumiCollectibles({
     List<BangumiCollectionType> includeBangumiTypes = const [
       BangumiCollectionType.planToWatch,
@@ -575,39 +578,32 @@ class BangumiApi {
 
     try {
       const Duration minRequestInterval = Duration(milliseconds: 200);
-      DateTime? lastRequestStartTime;
-      int offset = 0;
-      int? total;
-      bool totalInitialized = false;
+      const int concurrency = 3;
+      DateTime nextAllowedLaunchTime = DateTime.now();
 
-      while (true) {
-        // 动态时延补偿：确保两次请求发出的时间间隔不小于 minRequestInterval
-        if (lastRequestStartTime != null) {
-          final elapsed = DateTime.now().difference(lastRequestStartTime);
-          if (elapsed < minRequestInterval) {
-            await Future.delayed(minRequestInterval - elapsed);
-          }
+      // 全局速率控制器：确保任意两次请求发起的间距不小于 minRequestInterval (200ms)
+      Future<void> acquireRateLimitSlot() async {
+        final now = DateTime.now();
+        final scheduledTime = nextAllowedLaunchTime.isAfter(now)
+            ? nextAllowedLaunchTime
+            : now;
+        nextAllowedLaunchTime = scheduledTime.add(minRequestInterval);
+        final waitDuration = scheduledTime.difference(now);
+        if (waitDuration > Duration.zero) {
+          await Future.delayed(waitDuration);
         }
-        lastRequestStartTime = DateTime.now();
+      }
 
-        dynamic jsonData;
-        try {
-          final url = ApiEndpoints.formatUrl(
-              ApiEndpoints.bangumiAuthAPIMirrorDomain +
-                  ApiEndpoints.bangumiGetAllCollections,
-              [resolvedUsername, limit, offset]);
-          jsonData = await _client.get(
-            url,
-            requiresAuth: true,
-          );
-        } catch (e) {
-          KazumiLogger().e(
-            'BangumiApi: fetch collection failed. offset=$offset',
-            error: e,
-          );
-          rethrow;
-        }
-
+      Future<Map> fetchPageData(int offset) async {
+        await acquireRateLimitSlot();
+        final url = ApiEndpoints.formatUrl(
+            ApiEndpoints.bangumiAuthAPIMirrorDomain +
+                ApiEndpoints.bangumiGetAllCollections,
+            [resolvedUsername, limit, offset]);
+        final jsonData = await _client.get(
+          url,
+          requiresAuth: true,
+        );
         if (jsonData is! Map || jsonData['data'] is! List) {
           KazumiLogger().e(
             'BangumiApi: invalid collection response format at offset=$offset',
@@ -615,29 +611,18 @@ class BangumiApi {
           throw const FormatException(
               'BangumiApi: Invalid collection response format');
         }
+        return jsonData;
+      }
 
-        final Map jsonMap = jsonData;
-        final List<dynamic> jsonList = jsonMap['data'] as List<dynamic>;
-        total ??= jsonMap['total'] as int?;
-        final serverLimit = (jsonMap['limit'] as int?) ?? limit;
-        if (!totalInitialized && total != null) {
-          progressTotal = total;
-          totalInitialized = true;
-        }
-
+      List<BangumiCollection> parsePageItems(List<dynamic> jsonList) {
+        final List<BangumiCollection> items = [];
         for (dynamic jsonItem in jsonList) {
           if (jsonItem is Map) {
             try {
               final collection = BangumiCollection.fromJson(jsonItem);
               if (includeBangumiTypes.contains(collection.type)) {
-                bangumiCollection.add(collection);
+                items.add(collection);
               }
-              progressCurrent++;
-              onProgress?.call(
-                '正在拉取 Bangumi 收藏',
-                progressCurrent,
-                progressTotal,
-              );
             } catch (e) {
               KazumiLogger().e(
                 'BangumiApi: parse collection item failed: ${e.toString()}',
@@ -647,20 +632,88 @@ class BangumiApi {
             }
           }
         }
+        return items;
+      }
 
-        final receivedCount = jsonList.length;
-        // 终止条件：
-        // 1. 收到空列表
-        // 2. 累计获取条目数达到或超过总数 total
-        // 3. 当前页返回条数小于分页 limit（说明已经是最后一页，无需多发一次空请求）
-        if (receivedCount == 0 ||
-            (total != null && offset + receivedCount >= total) ||
-            receivedCount < serverLimit) {
-          break;
+      // 阶段 1：探测首页，获取 total 及第一页数据
+      final firstPageJson = await fetchPageData(0);
+      final int? total = firstPageJson['total'] as int?;
+      final serverLimit = (firstPageJson['limit'] as int?) ?? limit;
+      final List<dynamic> firstPageList =
+          firstPageJson['data'] as List<dynamic>;
+
+      progressTotal = total ?? firstPageList.length;
+      final firstPageItems = parsePageItems(firstPageList);
+      bangumiCollection.addAll(firstPageItems);
+      progressCurrent += firstPageList.length;
+      onProgress?.call(
+        '正在拉取 Bangumi 收藏',
+        progressCurrent,
+        progressTotal,
+      );
+
+      final firstPageReceivedCount = firstPageList.length;
+      // 尾页判断：如果数据已在第一页完全获取，直接返回无需并发
+      if (firstPageReceivedCount == 0 ||
+          total == null ||
+          total <= limit ||
+          firstPageReceivedCount < serverLimit ||
+          firstPageReceivedCount >= total) {
+        KazumiLogger()
+            .d('get Bangumi collection count: ${bangumiCollection.length}');
+        KazumiLogger().d('get item failed count: $failedItemCount');
+        return bangumiCollection;
+      }
+
+      // 阶段 2：构建剩余分页 offset 队列并启动 3 并发 Worker
+      final remainingOffsets = <int>[];
+      for (int off = limit; off < total; off += limit) {
+        remainingOffsets.add(off);
+      }
+
+      final Map<int, List<BangumiCollection>> pageResults = {};
+      final offsetsQueue = List<int>.from(remainingOffsets);
+
+      Future<void> worker() async {
+        while (offsetsQueue.isNotEmpty) {
+          final offset = offsetsQueue.removeAt(0);
+          final pageJson = await fetchPageData(offset);
+          final List<dynamic> jsonList = pageJson['data'] as List<dynamic>;
+          final items = parsePageItems(jsonList);
+          pageResults[offset] = items;
+
+          progressCurrent += jsonList.length;
+          onProgress?.call(
+            '正在拉取 Bangumi 收藏',
+            progressCurrent > progressTotal ? progressTotal : progressCurrent,
+            progressTotal,
+          );
+
+          // 尾页提前截断优化：如果返回条数小于 serverLimit，说明后续已无数据
+          if (jsonList.length < serverLimit) {
+            offsetsQueue.clear();
+            break;
+          }
         }
+      }
 
-        // 自适应推进 offset：按实际接收到的条数推进
-        offset += receivedCount;
+      final workerCount = remainingOffsets.length < concurrency
+          ? remainingOffsets.length
+          : concurrency;
+      await Future.wait(List.generate(workerCount, (_) => worker()));
+
+      // 阶段 3：按 offset 顺序合并所有分片，并按 bangumiId 去重（防御网络并发期间服务端数据位移）
+      final Set<int> seenBangumiIds =
+          bangumiCollection.map((e) => e.bangumiId).toSet();
+      for (final offset in remainingOffsets) {
+        final items = pageResults[offset];
+        if (items != null) {
+          for (final item in items) {
+            if (seenBangumiIds.add(item.bangumiId)) {
+              bangumiCollection.add(item);
+            }
+          }
+        }
       }
     } catch (e) {
       KazumiLogger().e('Network: get bangumi collection failed', error: e);

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -658,6 +658,14 @@ class BangumiApi {
       bangumiCollection.addAll(firstPageItems);
       progressCurrent += firstPageList.length;
 
+      // 2. 校验首包一致性：若声明 total > 0 但首包数据却为空，说明响应异常损坏，显式报错中止
+      if (total > 0 && firstPageReceivedCount == 0) {
+        KazumiLogger().e(
+          'BangumiApi: received empty data on first page while total > 0 (total=$total)',
+        );
+        throw const FormatException(
+            'BangumiApi: received empty data on first page while total > 0');
+      }
       progressTotal = total;
       onProgress?.call(
         '正在拉取 Bangumi 收藏',
@@ -665,7 +673,7 @@ class BangumiApi {
         progressTotal,
       );
 
-      // 2. 空收藏或单页全量数据直接返回（无需启动并发 Worker）
+      // 3. 空收藏或单页全量数据直接返回（无需启动并发 Worker）
       //    严格仅在 total == 0 或首包实际条数已完整覆盖 total 时短路返回，
       //    防止异常响应（如 total 很大但首包异常为空或短缺）产生残缺快照误覆盖云端
       if (total == 0 || firstPageReceivedCount >= total) {

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -574,69 +574,67 @@ class BangumiApi {
     }
 
     try {
-      const Duration requestInterval = Duration(milliseconds: 250);
+      const Duration requestInterval = Duration(milliseconds: 200);
+      int offset = 0;
+      int? total;
+      bool totalInitialized = false;
 
-      for (final collectionType in includeBangumiTypes) {
-        if (collectionType == BangumiCollectionType.unknown) {
-          continue;
+      while (true) {
+        dynamic jsonData;
+        try {
+          final url = ApiEndpoints.formatUrl(
+              ApiEndpoints.bangumiAuthAPIMirrorDomain +
+                  ApiEndpoints.bangumiGetAllCollections,
+              [resolvedUsername, limit, offset]);
+          jsonData = await _client.get(
+            url,
+            requiresAuth: true,
+          );
+        } catch (e) {
+          KazumiLogger().e(
+            'BangumiApi: fetch collection failed. offset=$offset',
+            error: e,
+          );
+          rethrow;
         }
-        int offset = 0;
-        int? total;
-        bool totalInitialized = false;
-        while (true) {
-          dynamic jsonData;
-          try {
-            final url = ApiEndpoints.formatUrl(
-                ApiEndpoints.bangumiAuthAPIMirrorDomain +
-                    ApiEndpoints.bangumiGetCollection,
-                [resolvedUsername, limit, offset, collectionType.value]);
-            jsonData = await _client.get(
-              url,
-              requiresAuth: true,
-            );
-          } catch (e) {
-            KazumiLogger().e(
-              'BangumiApi: fetch collection failed. type=${collectionType.value}, offset=$offset',
-              error: e,
-            );
-            rethrow;
-          }
 
-          final Map jsonMap = jsonData;
-          final List<dynamic> jsonList = jsonMap['data'];
-          total ??= jsonMap['total'];
-          if (!totalInitialized && total != null) {
-            progressTotal += total;
-            totalInitialized = true;
-          }
+        final Map jsonMap = jsonData;
+        final List<dynamic> jsonList = jsonMap['data'] ?? [];
+        total ??= jsonMap['total'];
+        if (!totalInitialized && total != null) {
+          progressTotal = total;
+          totalInitialized = true;
+        }
 
-          for (dynamic jsonItem in jsonList) {
-            if (jsonItem is Map<String, dynamic>) {
-              try {
-                bangumiCollection.add(BangumiCollection.fromJson(jsonItem));
-                progressCurrent++;
-                onProgress?.call(
-                  '正在拉取${collectionType.label}收藏',
-                  progressCurrent,
-                  progressTotal,
-                );
-              } catch (e) {
-                KazumiLogger().e(
-                  'BangumiApi: parse collection item failed: ${e.toString()}',
-                  error: e,
-                );
-                failedItemCount++;
+        for (dynamic jsonItem in jsonList) {
+          if (jsonItem is Map) {
+            try {
+              final collection = BangumiCollection.fromJson(jsonItem);
+              if (includeBangumiTypes.contains(collection.type)) {
+                bangumiCollection.add(collection);
               }
+              progressCurrent++;
+              onProgress?.call(
+                '正在拉取 Bangumi 收藏',
+                progressCurrent,
+                progressTotal,
+              );
+            } catch (e) {
+              KazumiLogger().e(
+                'BangumiApi: parse collection item failed: ${e.toString()}',
+                error: e,
+              );
+              failedItemCount++;
             }
           }
-
-          if (jsonList.isEmpty || (total != null && offset + limit >= total)) {
-            break;
-          }
-
-          offset += limit;
-          await Future.delayed(requestInterval);
         }
+
+        if (jsonList.isEmpty || (total != null && offset + limit >= total)) {
+          break;
+        }
+
+        offset += limit;
+        await Future.delayed(requestInterval);
       }
     } catch (e) {
       KazumiLogger().e('Network: get bangumi collection failed', error: e);

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -558,7 +558,7 @@ class BangumiApi {
       BangumiCollectionType.abandoned,
     ],
     String? username,
-    required int limit,
+    int limit = 50,
     void Function(String message, int current, int total)? onProgress,
   }) async {
     final List<BangumiCollection> bangumiCollection = [];
@@ -574,12 +574,22 @@ class BangumiApi {
     }
 
     try {
-      const Duration requestInterval = Duration(milliseconds: 200);
+      const Duration minRequestInterval = Duration(milliseconds: 200);
+      DateTime? lastRequestStartTime;
       int offset = 0;
       int? total;
       bool totalInitialized = false;
 
       while (true) {
+        // 动态时延补偿：确保两次请求发出的时间间隔不小于 minRequestInterval
+        if (lastRequestStartTime != null) {
+          final elapsed = DateTime.now().difference(lastRequestStartTime);
+          if (elapsed < minRequestInterval) {
+            await Future.delayed(minRequestInterval - elapsed);
+          }
+        }
+        lastRequestStartTime = DateTime.now();
+
         dynamic jsonData;
         try {
           final url = ApiEndpoints.formatUrl(
@@ -609,6 +619,7 @@ class BangumiApi {
         final Map jsonMap = jsonData;
         final List<dynamic> jsonList = jsonMap['data'] as List<dynamic>;
         total ??= jsonMap['total'] as int?;
+        final serverLimit = (jsonMap['limit'] as int?) ?? limit;
         if (!totalInitialized && total != null) {
           progressTotal = total;
           totalInitialized = true;
@@ -637,12 +648,19 @@ class BangumiApi {
           }
         }
 
-        if (jsonList.isEmpty || (total != null && offset + limit >= total)) {
+        final receivedCount = jsonList.length;
+        // 终止条件：
+        // 1. 收到空列表
+        // 2. 累计获取条目数达到或超过总数 total
+        // 3. 当前页返回条数小于分页 limit（说明已经是最后一页，无需多发一次空请求）
+        if (receivedCount == 0 ||
+            (total != null && offset + receivedCount >= total) ||
+            receivedCount < serverLimit) {
           break;
         }
 
-        offset += limit;
-        await Future.delayed(requestInterval);
+        // 自适应推进 offset：按实际接收到的条数推进
+        offset += receivedCount;
       }
     } catch (e) {
       KazumiLogger().e('Network: get bangumi collection failed', error: e);

--- a/lib/request/apis/bangumi_api.dart
+++ b/lib/request/apis/bangumi_api.dart
@@ -594,12 +594,12 @@ class BangumiApi {
         }
       }
 
-      Future<Map> fetchPageData(int offset) async {
+      Future<Map> fetchPageData(int offset, int pageLimit) async {
         await acquireRateLimitSlot();
         final url = ApiEndpoints.formatUrl(
             ApiEndpoints.bangumiAuthAPIMirrorDomain +
                 ApiEndpoints.bangumiGetAllCollections,
-            [resolvedUsername, limit, offset]);
+            [resolvedUsername, pageLimit, offset]);
         final jsonData = await _client.get(
           url,
           requiresAuth: true,
@@ -636,9 +636,10 @@ class BangumiApi {
       }
 
       // 阶段 1：探测首页，获取 total 及第一页数据
-      final firstPageJson = await fetchPageData(0);
+      final firstPageJson = await fetchPageData(0, limit);
       final int? total = firstPageJson['total'] as int?;
       final serverLimit = (firstPageJson['limit'] as int?) ?? limit;
+      final effectiveLimit = (serverLimit > 0) ? serverLimit : limit;
       final List<dynamic> firstPageList =
           firstPageJson['data'] as List<dynamic>;
 
@@ -656,7 +657,7 @@ class BangumiApi {
       // 尾页判断：如果数据已在第一页完全获取，直接返回无需并发
       if (firstPageReceivedCount == 0 ||
           total == null ||
-          total <= limit ||
+          total <= effectiveLimit ||
           firstPageReceivedCount < serverLimit ||
           firstPageReceivedCount >= total) {
         KazumiLogger()
@@ -667,7 +668,7 @@ class BangumiApi {
 
       // 阶段 2：构建剩余分页 offset 队列并启动 3 并发 Worker
       final remainingOffsets = <int>[];
-      for (int off = limit; off < total; off += limit) {
+      for (int off = effectiveLimit; off < total; off += effectiveLimit) {
         remainingOffsets.add(off);
       }
 
@@ -677,7 +678,7 @@ class BangumiApi {
       Future<void> worker() async {
         while (offsetsQueue.isNotEmpty) {
           final offset = offsetsQueue.removeAt(0);
-          final pageJson = await fetchPageData(offset);
+          final pageJson = await fetchPageData(offset, effectiveLimit);
           final List<dynamic> jsonList = pageJson['data'] as List<dynamic>;
           final items = parsePageItems(jsonList);
           pageResults[offset] = items;

--- a/lib/request/config/api_endpoints.dart
+++ b/lib/request/config/api_endpoints.dart
@@ -75,10 +75,6 @@ class ApiEndpoints {
   /// 新增或修改用户单个条目收藏
   static const String bangumiSetCollection = '/v0/users/-/collections/{0}';
 
-  /// 获取用户收藏。用户名，分页参数1，分页参数2
-  static const String bangumiGetCollection =
-      '/v0/users/{0}/collections?subject_type=2&limit={1}&offset={2}&type={3}';
-
   /// 获取用户全部收藏（不限类型）。用户名，分页参数1(limit)，分页参数2(offset)
   static const String bangumiGetAllCollections =
       '/v0/users/{0}/collections?subject_type=2&limit={1}&offset={2}';

--- a/lib/request/config/api_endpoints.dart
+++ b/lib/request/config/api_endpoints.dart
@@ -79,6 +79,10 @@ class ApiEndpoints {
   static const String bangumiGetCollection =
       '/v0/users/{0}/collections?subject_type=2&limit={1}&offset={2}&type={3}';
 
+  /// 获取用户全部收藏（不限类型）。用户名，分页参数1(limit)，分页参数2(offset)
+  static const String bangumiGetAllCollections =
+      '/v0/users/{0}/collections?subject_type=2&limit={1}&offset={2}';
+
   /// Bangumi Next API Domain
   static const String bangumiAPINextDomain = 'https://next.bgm.tv';
 

--- a/lib/services/sync/bangumi_sync_service.dart
+++ b/lib/services/sync/bangumi_sync_service.dart
@@ -197,7 +197,7 @@ class BangumiSyncService {
           }
         }
 
-        // 5. 双方都有但不一致：按计划处理冲突
+        // 5. 双方都有但不一致：按优先级处理
         if (mergePlan.conflictUploads.isNotEmpty) {
           onProgress?.call(
               '${priority.label}：正在上传冲突状态', syncedCount, totalOperations);
@@ -206,7 +206,7 @@ class BangumiSyncService {
               upload.bangumiId,
               upload.type,
             );
-            if (updated != true) {
+            if (!updated) {
               throw Exception('同步失败：条目 ${upload.bangumiId} 上传到 Bangumi 失败');
             }
             syncedCount++;

--- a/lib/services/sync/bangumi_sync_service.dart
+++ b/lib/services/sync/bangumi_sync_service.dart
@@ -147,7 +147,7 @@ class BangumiSyncService {
         // 1. 全量拉取远程收藏
         final remoteCollection = await BangumiApi.getBangumiCollectibles(
           username: username,
-          limit: 100,
+          limit: 50,
           onProgress: onProgress,
         );
 

--- a/lib/services/sync/bangumi_sync_service.dart
+++ b/lib/services/sync/bangumi_sync_service.dart
@@ -197,9 +197,10 @@ class BangumiSyncService {
           }
         }
 
-        // 5. 双方都有但不一致：按优先级处理
-        if (priority == BangumiSyncPriority.localFirst) {
-          onProgress?.call('本地优先：正在处理冲突状态', syncedCount, totalOperations);
+        // 5. 双方都有但不一致：按计划处理冲突
+        if (mergePlan.conflictUploads.isNotEmpty) {
+          onProgress?.call(
+              '${priority.label}：正在上传冲突状态', syncedCount, totalOperations);
           for (final upload in mergePlan.conflictUploads) {
             final updated = await BangumiApi.updateBangumiByType(
               upload.bangumiId,
@@ -209,10 +210,13 @@ class BangumiSyncService {
               throw Exception('同步失败：条目 ${upload.bangumiId} 上传到 Bangumi 失败');
             }
             syncedCount++;
-            onProgress?.call('本地优先：正在处理冲突状态', syncedCount, totalOperations);
+            onProgress?.call(
+                '${priority.label}：正在上传冲突状态', syncedCount, totalOperations);
           }
-        } else {
-          onProgress?.call('Bangumi优先：正在处理冲突状态', syncedCount, totalOperations);
+        }
+        if (mergePlan.conflictLocalUpdates.isNotEmpty) {
+          onProgress?.call(
+              '${priority.label}：正在更新本地冲突状态', syncedCount, totalOperations);
           for (final mutation in mergePlan.conflictLocalUpdates) {
             await GStorage.putCollectible(mutation.collectible);
             await _recordCollectibleChange(
@@ -222,7 +226,7 @@ class BangumiSyncService {
             );
             syncedCount++;
             onProgress?.call(
-                'Bangumi优先：正在处理冲突状态', syncedCount, totalOperations);
+                '${priority.label}：正在更新本地冲突状态', syncedCount, totalOperations);
           }
         }
         onProgress?.call('Bangumi 状态同步完成', 1, 1);

--- a/lib/utils/async_rate_limiter.dart
+++ b/lib/utils/async_rate_limiter.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+/// Ensures asynchronous operations are spaced apart by at least a minimum interval.
+class AsyncRateLimiter {
+  AsyncRateLimiter(this.period);
+
+  final Duration period;
+  DateTime _nextAllowedTime = DateTime.now();
+
+  /// Waits until the next allowed time slot and reserves the following slot.
+  Future<void> acquire() async {
+    final now = DateTime.now();
+    final scheduledTime =
+        _nextAllowedTime.isAfter(now) ? _nextAllowedTime : now;
+    _nextAllowedTime = scheduledTime.add(period);
+    final waitDuration = scheduledTime.difference(now);
+    if (waitDuration > Duration.zero) {
+      await Future.delayed(waitDuration);
+    }
+  }
+
+  /// Runs [action] after acquiring a rate-limited time slot.
+  Future<T> run<T>(Future<T> Function() action) async {
+    await acquire();
+    return await action();
+  }
+}

--- a/test/async_rate_limiter_test.dart
+++ b/test/async_rate_limiter_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/utils/async_rate_limiter.dart';
+
+void main() {
+  group('AsyncRateLimiter', () {
+    test('first acquire completes immediately without unnecessary delay', () async {
+      final limiter = AsyncRateLimiter(const Duration(milliseconds: 50));
+      final stopwatch = Stopwatch()..start();
+      await limiter.acquire();
+      stopwatch.stop();
+
+      expect(stopwatch.elapsedMilliseconds, lessThan(30));
+    });
+
+    test('serial sequential calls maintain at least period spacing', () async {
+      const period = Duration(milliseconds: 40);
+      final limiter = AsyncRateLimiter(period);
+
+      final timestamps = <int>[];
+      final stopwatch = Stopwatch()..start();
+
+      for (var i = 0; i < 3; i++) {
+        await limiter.acquire();
+        timestamps.add(stopwatch.elapsedMilliseconds);
+      }
+
+      expect(timestamps.length, 3);
+      for (var i = 1; i < timestamps.length; i++) {
+        final diff = timestamps[i] - timestamps[i - 1];
+        expect(diff, greaterThanOrEqualTo(35));
+      }
+    });
+
+    test('concurrent callers are spaced apart into sequential time slots', () async {
+      const period = Duration(milliseconds: 40);
+      final limiter = AsyncRateLimiter(period);
+
+      final completionTimes = <int>[];
+      final stopwatch = Stopwatch()..start();
+
+      await Future.wait(
+        List.generate(4, (index) async {
+          await limiter.acquire();
+          completionTimes.add(stopwatch.elapsedMilliseconds);
+        }),
+      );
+
+      expect(completionTimes.length, 4);
+      for (var i = 1; i < completionTimes.length; i++) {
+        final diff = completionTimes[i] - completionTimes[i - 1];
+        expect(diff, greaterThanOrEqualTo(35));
+      }
+    });
+
+    test('run passes return value and preserves rate limit on failure', () async {
+      const period = Duration(milliseconds: 40);
+      final limiter = AsyncRateLimiter(period);
+
+      final stopwatch = Stopwatch()..start();
+
+      final firstResult = await limiter.run(() async => 'success');
+      expect(firstResult, 'success');
+
+      await expectLater(
+        limiter.run(() async => throw StateError('action error')),
+        throwsStateError,
+      );
+
+      final secondResult = await limiter.run(() async => 'recovered');
+      expect(secondResult, 'recovered');
+
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(70));
+    });
+  });
+}

--- a/test/collect_sync_test.dart
+++ b/test/collect_sync_test.dart
@@ -177,7 +177,7 @@ void main() {
       expect(plan.conflictLocalUpdates, isEmpty);
     });
 
-    test('resolves conflicts with timeFirst (local newer, remote newer, same moment)', () {
+    test('resolves conflicts with timeFirst (local newer, remote newer, same moment, remote null)', () {
       final plan = CollectSyncMerger.planBangumi(
         localCollectibles: [
           // id 1: local newer (timestamp 50 vs remote 10)
@@ -188,6 +188,8 @@ void main() {
           _collect(3, CollectType.onHold, 30),
           // id 4: local only
           _collect(4, CollectType.watched, 20),
+          // id 6: remote updatedAt is null -> fallback to local (conflictUploads)
+          _collect(6, CollectType.watching, 10),
         ],
         remoteCollections: [
           _remote(1, BangumiCollectionType.watched, 10),
@@ -195,24 +197,44 @@ void main() {
           _remote(3, BangumiCollectionType.abandoned, 30),
           // id 5: remote only
           _remote(5, BangumiCollectionType.planToWatch, 40),
+          // id 6: remote updatedAt is null
+          _remote(6, BangumiCollectionType.watched, null),
         ],
         priority: BangumiSyncPriority.timeFirst,
       );
 
-      expect(plan.totalOperations, 5);
+      expect(plan.totalOperations, 6);
       // local only upload
       expect(plan.localOnlyUploads.map((u) => u.bangumiId), [4]);
       expect(plan.localOnlyUploads.single.type, CollectType.watched.value);
       // remote only put
       expect(plan.remoteOnlyPuts.map((p) => p.collectible.bangumiItem.id), [5]);
       expect(plan.remoteOnlyPuts.single.collectible.type, CollectType.planToWatch.value);
-      // conflict uploads: id 1 (local newer) and id 3 (same moment default to local)
-      expect(plan.conflictUploads.map((u) => u.bangumiId), [1, 3]);
+      // conflict uploads: id 1 (local newer), id 3 (same moment), id 6 (remote null -> local prioritized)
+      expect(plan.conflictUploads.map((u) => u.bangumiId), [1, 3, 6]);
       expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 1).type, CollectType.watching.value);
       expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 3).type, CollectType.onHold.value);
+      expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 6).type, CollectType.watching.value);
       // conflict local updates: id 2 (remote newer)
       expect(plan.conflictLocalUpdates.map((u) => u.collectible.bangumiItem.id), [2]);
       expect(plan.conflictLocalUpdates.single.collectible.type, CollectType.watched.value);
+    });
+
+    test('remote-only put with null updatedAt defaults to current time for local storage', () {
+      final before = DateTime.now().subtract(const Duration(seconds: 1));
+      final plan = CollectSyncMerger.planBangumi(
+        localCollectibles: [],
+        remoteCollections: [
+          _remote(10, BangumiCollectionType.watching, null),
+        ],
+        priority: BangumiSyncPriority.bangumiFirst,
+      );
+
+      expect(plan.remoteOnlyPuts.length, 1);
+      final put = plan.remoteOnlyPuts.single;
+      expect(put.collectible.bangumiItem.id, 10);
+      expect(put.collectible.type, CollectType.watching.value);
+      expect(put.collectible.time.isAfter(before), isTrue);
     });
   });
 
@@ -264,7 +286,6 @@ void main() {
     });
 
     test('handles missing or malformed fields defensively', () {
-      final before = DateTime.now().subtract(const Duration(seconds: 1));
       final collection = BangumiCollection.fromJson({
         'updated_at': 'invalid-date-string',
         'type': 1,
@@ -274,17 +295,34 @@ void main() {
           // missing short_summary, eps, rank, images, tags
         },
       });
-      final after = DateTime.now().add(const Duration(seconds: 1));
 
       expect(collection.bangumiId, 999);
       expect(collection.score, 7.0);
       expect(collection.shortSummary, '');
       expect(collection.eps, 0);
       expect(collection.rank, 0);
-      expect(collection.updatedAt.isAfter(before), isTrue);
-      expect(collection.updatedAt.isBefore(after), isTrue);
+      expect(collection.updatedAt, isNull);
       expect(collection.images['large'], '');
       expect(collection.tags, isEmpty);
+    });
+
+    test('handles missing or empty updated_at as null', () {
+      final collection = BangumiCollection.fromJson({
+        'type': 1,
+        'subject': {
+          'id': 999,
+        },
+      });
+      expect(collection.updatedAt, isNull);
+
+      final emptyCollection = BangumiCollection.fromJson({
+        'updated_at': '',
+        'type': 1,
+        'subject': {
+          'id': 999,
+        },
+      });
+      expect(emptyCollection.updatedAt, isNull);
     });
 
     test('falls back to subject_id when subject.id is missing', () {
@@ -353,12 +391,14 @@ CollectedBangumiChange _change(
 BangumiCollection _remote(
   int id,
   BangumiCollectionType type,
-  int timestamp,
+  int? timestamp,
 ) {
   return BangumiCollection(
     id,
     '2026-01-01',
-    DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
+    timestamp == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
     type,
     'subject $id',
     '条目 $id',

--- a/test/collect_sync_test.dart
+++ b/test/collect_sync_test.dart
@@ -264,6 +264,7 @@ void main() {
     });
 
     test('handles missing or malformed fields defensively', () {
+      final before = DateTime.now().subtract(const Duration(seconds: 1));
       final collection = BangumiCollection.fromJson({
         'updated_at': 'invalid-date-string',
         'type': 1,
@@ -273,15 +274,54 @@ void main() {
           // missing short_summary, eps, rank, images, tags
         },
       });
+      final after = DateTime.now().add(const Duration(seconds: 1));
 
       expect(collection.bangumiId, 999);
       expect(collection.score, 7.0);
       expect(collection.shortSummary, '');
       expect(collection.eps, 0);
       expect(collection.rank, 0);
-      expect(collection.updatedAt, DateTime.fromMillisecondsSinceEpoch(0));
+      expect(collection.updatedAt.isAfter(before), isTrue);
+      expect(collection.updatedAt.isBefore(after), isTrue);
       expect(collection.images['large'], '');
       expect(collection.tags, isEmpty);
+    });
+
+    test('falls back to subject_id when subject.id is missing', () {
+      final collection = BangumiCollection.fromJson({
+        'subject_id': 888,
+        'type': 1,
+        'subject': {
+          'name': 'Fallback Name',
+        },
+      });
+
+      expect(collection.bangumiId, 888);
+      expect(collection.name, 'Fallback Name');
+    });
+
+    test('throws FormatException when subject id is missing or invalid', () {
+      expect(
+        () => BangumiCollection.fromJson({
+          'type': 1,
+          'subject': {
+            'name': 'No ID',
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
+
+      expect(
+        () => BangumiCollection.fromJson({
+          'subject_id': 0,
+          'type': 1,
+          'subject': {
+            'id': 0,
+            'name': 'Zero ID',
+          },
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 }

--- a/test/collect_sync_test.dart
+++ b/test/collect_sync_test.dart
@@ -176,6 +176,113 @@ void main() {
       expect(plan.remoteOnlyPuts, isEmpty);
       expect(plan.conflictLocalUpdates, isEmpty);
     });
+
+    test('resolves conflicts with timeFirst (local newer, remote newer, same moment)', () {
+      final plan = CollectSyncMerger.planBangumi(
+        localCollectibles: [
+          // id 1: local newer (timestamp 50 vs remote 10)
+          _collect(1, CollectType.watching, 50),
+          // id 2: remote newer (timestamp 10 vs remote 50)
+          _collect(2, CollectType.planToWatch, 10),
+          // id 3: same moment (timestamp 30 vs remote 30) -> default to local (conflictUploads)
+          _collect(3, CollectType.onHold, 30),
+          // id 4: local only
+          _collect(4, CollectType.watched, 20),
+        ],
+        remoteCollections: [
+          _remote(1, BangumiCollectionType.watched, 10),
+          _remote(2, BangumiCollectionType.watched, 50),
+          _remote(3, BangumiCollectionType.abandoned, 30),
+          // id 5: remote only
+          _remote(5, BangumiCollectionType.planToWatch, 40),
+        ],
+        priority: BangumiSyncPriority.timeFirst,
+      );
+
+      expect(plan.totalOperations, 5);
+      // local only upload
+      expect(plan.localOnlyUploads.map((u) => u.bangumiId), [4]);
+      expect(plan.localOnlyUploads.single.type, CollectType.watched.value);
+      // remote only put
+      expect(plan.remoteOnlyPuts.map((p) => p.collectible.bangumiItem.id), [5]);
+      expect(plan.remoteOnlyPuts.single.collectible.type, CollectType.planToWatch.value);
+      // conflict uploads: id 1 (local newer) and id 3 (same moment default to local)
+      expect(plan.conflictUploads.map((u) => u.bangumiId), [1, 3]);
+      expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 1).type, CollectType.watching.value);
+      expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 3).type, CollectType.onHold.value);
+      // conflict local updates: id 2 (remote newer)
+      expect(plan.conflictLocalUpdates.map((u) => u.collectible.bangumiItem.id), [2]);
+      expect(plan.conflictLocalUpdates.single.collectible.type, CollectType.watched.value);
+    });
+  });
+
+  group('BangumiSyncPriority', () {
+    test('fromValue maps correctly including timeFirst and fallback', () {
+      expect(BangumiSyncPriority.fromValue(0), BangumiSyncPriority.localFirst);
+      expect(BangumiSyncPriority.fromValue(1), BangumiSyncPriority.bangumiFirst);
+      expect(BangumiSyncPriority.fromValue(2), BangumiSyncPriority.timeFirst);
+      expect(BangumiSyncPriority.fromValue(999), BangumiSyncPriority.localFirst);
+      expect(BangumiSyncPriority.timeFirst.value, 2);
+      expect(BangumiSyncPriority.timeFirst.label, '最新优先');
+    });
+  });
+
+  group('BangumiCollection.fromJson', () {
+    test('parses normal JSON correctly', () {
+      final collection = BangumiCollection.fromJson({
+        'updated_at': '2026-08-30T14:00:00Z',
+        'type': 2,
+        'subject': {
+          'id': 12345,
+          'date': '2026-04-01',
+          'name': 'Original Name',
+          'name_cn': '中文名',
+          'short_summary': '这是一部动画',
+          'score': 8.5,
+          'eps': 24,
+          'rank': 42,
+          'images': {
+            'large': 'https://example.com/large.jpg',
+          },
+          'tags': [
+            {'name': '科幻', 'count': 100},
+          ],
+        },
+      });
+
+      expect(collection.bangumiId, 12345);
+      expect(collection.name, 'Original Name');
+      expect(collection.nameCn, '中文名');
+      expect(collection.shortSummary, '这是一部动画');
+      expect(collection.score, 8.5);
+      expect(collection.eps, 24);
+      expect(collection.rank, 42);
+      expect(collection.type, BangumiCollectionType.watched);
+      expect(collection.updatedAt, DateTime.parse('2026-08-30T14:00:00Z'));
+      expect(collection.images['large'], 'https://example.com/large.jpg');
+      expect(collection.tags.length, 1);
+    });
+
+    test('handles missing or malformed fields defensively', () {
+      final collection = BangumiCollection.fromJson({
+        'updated_at': 'invalid-date-string',
+        'type': 1,
+        'subject': {
+          'id': 999,
+          'score': 7, // integer instead of double
+          // missing short_summary, eps, rank, images, tags
+        },
+      });
+
+      expect(collection.bangumiId, 999);
+      expect(collection.score, 7.0);
+      expect(collection.shortSummary, '');
+      expect(collection.eps, 0);
+      expect(collection.rank, 0);
+      expect(collection.updatedAt, DateTime.fromMillisecondsSinceEpoch(0));
+      expect(collection.images['large'], '');
+      expect(collection.tags, isEmpty);
+    });
   });
 }
 

--- a/test/collect_sync_test.dart
+++ b/test/collect_sync_test.dart
@@ -177,7 +177,7 @@ void main() {
       expect(plan.conflictLocalUpdates, isEmpty);
     });
 
-    test('resolves conflicts with timeFirst (local newer, remote newer, same moment, remote null)', () {
+    test('resolves conflicts with timeFirst (local newer, remote newer, same moment)', () {
       final plan = CollectSyncMerger.planBangumi(
         localCollectibles: [
           // id 1: local newer (timestamp 50 vs remote 10)
@@ -188,8 +188,6 @@ void main() {
           _collect(3, CollectType.onHold, 30),
           // id 4: local only
           _collect(4, CollectType.watched, 20),
-          // id 6: remote updatedAt is null -> fallback to local (conflictUploads)
-          _collect(6, CollectType.watching, 10),
         ],
         remoteCollections: [
           _remote(1, BangumiCollectionType.watched, 10),
@@ -197,44 +195,24 @@ void main() {
           _remote(3, BangumiCollectionType.abandoned, 30),
           // id 5: remote only
           _remote(5, BangumiCollectionType.planToWatch, 40),
-          // id 6: remote updatedAt is null
-          _remote(6, BangumiCollectionType.watched, null),
         ],
         priority: BangumiSyncPriority.timeFirst,
       );
 
-      expect(plan.totalOperations, 6);
+      expect(plan.totalOperations, 5);
       // local only upload
       expect(plan.localOnlyUploads.map((u) => u.bangumiId), [4]);
       expect(plan.localOnlyUploads.single.type, CollectType.watched.value);
       // remote only put
       expect(plan.remoteOnlyPuts.map((p) => p.collectible.bangumiItem.id), [5]);
       expect(plan.remoteOnlyPuts.single.collectible.type, CollectType.planToWatch.value);
-      // conflict uploads: id 1 (local newer), id 3 (same moment), id 6 (remote null -> local prioritized)
-      expect(plan.conflictUploads.map((u) => u.bangumiId), [1, 3, 6]);
+      // conflict uploads: id 1 (local newer), id 3 (same moment)
+      expect(plan.conflictUploads.map((u) => u.bangumiId), [1, 3]);
       expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 1).type, CollectType.watching.value);
       expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 3).type, CollectType.onHold.value);
-      expect(plan.conflictUploads.firstWhere((u) => u.bangumiId == 6).type, CollectType.watching.value);
       // conflict local updates: id 2 (remote newer)
       expect(plan.conflictLocalUpdates.map((u) => u.collectible.bangumiItem.id), [2]);
       expect(plan.conflictLocalUpdates.single.collectible.type, CollectType.watched.value);
-    });
-
-    test('remote-only put with null updatedAt defaults to current time for local storage', () {
-      final before = DateTime.now().subtract(const Duration(seconds: 1));
-      final plan = CollectSyncMerger.planBangumi(
-        localCollectibles: [],
-        remoteCollections: [
-          _remote(10, BangumiCollectionType.watching, null),
-        ],
-        priority: BangumiSyncPriority.bangumiFirst,
-      );
-
-      expect(plan.remoteOnlyPuts.length, 1);
-      final put = plan.remoteOnlyPuts.single;
-      expect(put.collectible.bangumiItem.id, 10);
-      expect(put.collectible.type, CollectType.watching.value);
-      expect(put.collectible.time.isAfter(before), isTrue);
     });
   });
 
@@ -285,9 +263,9 @@ void main() {
       expect(collection.tags.length, 1);
     });
 
-    test('handles missing or malformed fields defensively', () {
+    test('handles missing or malformed fields defensively while requiring valid updated_at', () {
       final collection = BangumiCollection.fromJson({
-        'updated_at': 'invalid-date-string',
+        'updated_at': '2026-08-30T14:00:00Z',
         'type': 1,
         'subject': {
           'id': 999,
@@ -301,39 +279,48 @@ void main() {
       expect(collection.shortSummary, '');
       expect(collection.eps, 0);
       expect(collection.rank, 0);
-      expect(collection.updatedAt, isNull);
+      expect(collection.updatedAt, DateTime.parse('2026-08-30T14:00:00Z'));
       expect(collection.images['large'], '');
       expect(collection.tags, isEmpty);
     });
 
-    test('handles missing or empty updated_at as null', () {
-      final collection = BangumiCollection.fromJson({
-        'type': 1,
-        'subject': {
-          'id': 999,
-        },
-      });
-      expect(collection.updatedAt, isNull);
+    test('throws FormatException on missing, empty, or invalid updated_at', () {
+      expect(
+        () => BangumiCollection.fromJson({
+          'type': 1,
+          'subject': {'id': 999},
+        }),
+        throwsA(isA<FormatException>()),
+      );
 
-      final emptyCollection = BangumiCollection.fromJson({
-        'updated_at': '',
-        'type': 1,
-        'subject': {
-          'id': 999,
-        },
-      });
-      expect(emptyCollection.updatedAt, isNull);
+      expect(
+        () => BangumiCollection.fromJson({
+          'updated_at': '',
+          'type': 1,
+          'subject': {'id': 999},
+        }),
+        throwsA(isA<FormatException>()),
+      );
+
+      expect(
+        () => BangumiCollection.fromJson({
+          'updated_at': 'invalid-date-string',
+          'type': 1,
+          'subject': {'id': 999},
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
 
     test('falls back to subject_id when subject.id is missing', () {
       final collection = BangumiCollection.fromJson({
+        'updated_at': '2026-08-30T14:00:00Z',
         'subject_id': 888,
         'type': 1,
         'subject': {
           'name': 'Fallback Name',
         },
       });
-
       expect(collection.bangumiId, 888);
       expect(collection.name, 'Fallback Name');
     });
@@ -391,14 +378,12 @@ CollectedBangumiChange _change(
 BangumiCollection _remote(
   int id,
   BangumiCollectionType type,
-  int? timestamp,
+  int timestamp,
 ) {
   return BangumiCollection(
     id,
     '2026-01-01',
-    timestamp == null
-        ? null
-        : DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
+    DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
     type,
     'subject $id',
     '条目 $id',


### PR DESCRIPTION
优化了 Bangumi 收藏同步逻辑：

1. **单流分页拉取**：调用收藏接口时省略 `type` 参数，从原本的 5次状态循环改为单次全量分页获取，并补充了异常字段的容错解析。
2. **新增最新优先策略**：两端状态不一致时，比对本地 `time`与远端`updated_at`时间戳，自动保留较新的修改；若时间相同则以本地为准。原有本地优先与云端优先逻辑保持不变。
3. **单元测试**：在 `test/collect_sync_test.dart`中补充了时间戳裁决和解析容错测试，现有 153 项测试均已通过。

Closes #2522