### PR TITLE
feat(input): 为win掌机、steamdeck等掌上游戏机的摇杆和触屏输入添加了初步的适配

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -12,7 +13,9 @@ import 'package:window_manager/window_manager.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/dialog/exit_confirmation_dialog.dart';
 import 'package:kazumi/bean/settings/theme_provider.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
 import 'package:kazumi/navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
 import 'package:kazumi/utils/constants.dart';
 import 'package:kazumi/utils/device.dart';
 import 'package:kazumi/utils/theme.dart';
@@ -30,6 +33,7 @@ class _AppWidgetState extends State<AppWidget>
   bool _isHandlingWindowClose = false;
   bool _didApplyStoredThemeSettings = false;
   Brightness? _lastTitleBarBrightness;
+  late final GamepadInputService _gamepadInputService;
 
   @override
   void initState() {
@@ -37,6 +41,13 @@ class _AppWidgetState extends State<AppWidget>
     trayManager.addListener(this);
     windowManager.addListener(this);
     WidgetsBinding.instance.addObserver(this);
+    _gamepadInputService = GamepadInputService(
+      enabled: GStorage.getSetting(SettingsKeys.gamepadEnabled),
+      stickDeadZone: GStorage.getSetting(SettingsKeys.gamepadStickDeadZone),
+      initialRepeatDelay: Duration(
+        milliseconds: GStorage.getSetting(SettingsKeys.gamepadRepeatDelay),
+      ),
+    );
     _initializePlatformIntegrations();
   }
 
@@ -76,6 +87,7 @@ class _AppWidgetState extends State<AppWidget>
     trayManager.removeListener(this);
     windowManager.removeListener(this);
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_gamepadInputService.dispose());
     super.dispose();
   }
 
@@ -141,12 +153,38 @@ class _AppWidgetState extends State<AppWidget>
     Color? color,
     ColorScheme? colorScheme,
   }) {
+    final effectiveColorScheme = colorScheme ??
+        ColorScheme.fromSeed(
+          seedColor: color ?? Colors.green,
+          brightness: brightness,
+        );
+    // A controller-driven focus needs to be unmistakable: give every focused
+    // button a solid outline in addition to the overlay tint.
+    WidgetStateProperty<BorderSide?> focusedOutline() =>
+        WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.focused)) {
+            return BorderSide(color: effectiveColorScheme.primary, width: 2);
+          }
+          return BorderSide.none;
+        });
     return ThemeData(
       useMaterial3: true,
       fontFamily: fontFamily,
       brightness: brightness,
-      colorSchemeSeed: color,
-      colorScheme: colorScheme,
+      colorScheme: effectiveColorScheme,
+      focusColor: effectiveColorScheme.primary.withValues(alpha: 0.32),
+      iconButtonTheme: IconButtonThemeData(
+        style: ButtonStyle(side: focusedOutline()),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: ButtonStyle(side: focusedOutline()),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: ButtonStyle(side: focusedOutline()),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: ButtonStyle(side: focusedOutline()),
+      ),
       progressIndicatorTheme: progressIndicatorTheme2024,
       sliderTheme: sliderTheme2024,
       pageTransitionsTheme: pageTransitionsTheme2024,
@@ -303,6 +341,7 @@ class _AppWidgetState extends State<AppWidget>
 
         return MaterialApp.router(
           title: "Kazumi",
+          debugShowCheckedModeBanner: false,
           localizationsDelegates: GlobalMaterialLocalizations.delegates,
           supportedLocales: const [
             Locale.fromSubtags(
@@ -315,6 +354,10 @@ class _AppWidgetState extends State<AppWidget>
           themeMode: themeProvider.themeMode,
           scaffoldMessengerKey: rootScaffoldMessengerKey,
           routerConfig: ModularApp.routerConfigOf(context),
+          builder: (context, child) => GamepadNavigationScope(
+            service: _gamepadInputService,
+            child: child ?? const SizedBox.shrink(),
+          ),
         );
       },
     );

--- a/lib/bean/appbar/sys_app_bar.dart
+++ b/lib/bean/appbar/sys_app_bar.dart
@@ -58,55 +58,64 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
       }
       acs.add(const SizedBox(width: 8));
     }
-    return GestureDetector(
-      onPanStart: (_) => (isDesktop()) ? windowManager.startDragging() : null,
-      child: AppBar(
-        toolbarHeight: preferredSize.height,
-        scrolledUnderElevation: 0.0,
-        title: title != null
-            ? EmbeddedNativeControlArea(
-                requireOffset: needTopOffset,
-                child: title!,
-              )
-            : null,
-        centerTitle: Platform.isIOS ? true : false,
-        actions: acs.map((e) {
-          return EmbeddedNativeControlArea(
-            requireOffset: needTopOffset,
-            child: e,
-          );
-        }).toList(),
-        leading: leading != null
-            ? EmbeddedNativeControlArea(
-                requireOffset: needTopOffset,
-                child: leading!,
-              )
-            : (ModalRoute.of(context)?.impliesAppBarDismissal ?? false)
-                ? EmbeddedNativeControlArea(
-                    requireOffset: needTopOffset,
-                    child: IconButton(
-                      onPressed: () {
-                        context.maybePop();
-                      },
-                      icon: Icon(Icons.arrow_back),
-                    ),
-                  )
-                : null,
-        leadingWidth: leadingWidth,
-        backgroundColor: backgroundColor,
-        elevation: elevation,
-        shape: shape,
-        bottom: bottom,
-        automaticallyImplyLeading: false,
-        systemOverlayStyle: SystemUiOverlayStyle(
-          statusBarColor: Colors.transparent,
-          statusBarIconBrightness:
-              Theme.of(context).brightness == Brightness.light
-                  ? Brightness.dark
-                  : Brightness.light,
-          systemNavigationBarColor: Colors.transparent,
-          systemNavigationBarDividerColor: Colors.transparent,
-        ),
+    // When the native title bar is hidden the app bar is the window's drag
+    // surface. It must stay draggable, but a bar-wide drag recognizer would
+    // race the leading/actions buttons in the gesture arena: a touch or a
+    // slightly-moving mouse press over the back button starts a drag (and can
+    // leave the pointer grabbed), so the button intermittently becomes
+    // unclickable. Put the drag surface in flexibleSpace so it sits behind the
+    // toolbar. Buttons win the hit test (AppBar stacks the toolbar above
+    // flexibleSpace) and always keep their taps; only the empty bar area
+    // actually starts a window drag.
+    final Widget? dragSurface =
+        isDesktop() && !showWindowButton() ? const _DragToMoveSurface() : null;
+    return AppBar(
+      toolbarHeight: preferredSize.height,
+      scrolledUnderElevation: 0.0,
+      title: title != null
+          ? EmbeddedNativeControlArea(
+              requireOffset: needTopOffset,
+              child: title!,
+            )
+          : null,
+      centerTitle: Platform.isIOS ? true : false,
+      flexibleSpace: dragSurface,
+      actions: acs.map((e) {
+        return EmbeddedNativeControlArea(
+          requireOffset: needTopOffset,
+          child: e,
+        );
+      }).toList(),
+      leading: leading != null
+          ? EmbeddedNativeControlArea(
+              requireOffset: needTopOffset,
+              child: leading!,
+            )
+          : (ModalRoute.of(context)?.impliesAppBarDismissal ?? false)
+              ? EmbeddedNativeControlArea(
+                  requireOffset: needTopOffset,
+                  child: IconButton(
+                    onPressed: () {
+                      context.maybePop();
+                    },
+                    icon: Icon(Icons.arrow_back),
+                  ),
+                )
+              : null,
+      leadingWidth: leadingWidth,
+      backgroundColor: backgroundColor,
+      elevation: elevation,
+      shape: shape,
+      bottom: bottom,
+      automaticallyImplyLeading: false,
+      systemOverlayStyle: SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness:
+            Theme.of(context).brightness == Brightness.light
+                ? Brightness.dark
+                : Brightness.light,
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarDividerColor: Colors.transparent,
       ),
     );
   }
@@ -124,5 +133,23 @@ class SysAppBar extends StatelessWidget implements PreferredSizeWidget {
     } else {
       return Size.fromHeight(toolbarHeight ?? kToolbarHeight);
     }
+  }
+}
+
+/// Full-toolbar window-drag surface placed in [AppBar.flexibleSpace].
+///
+/// It is the topmost hittable widget only where no other app bar widget
+/// (leading / actions / title) claims the pointer, so those buttons stay
+/// clickable while the remaining bar area drags the window.
+class _DragToMoveSurface extends StatelessWidget {
+  const _DragToMoveSurface();
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onPanStart: (_) => windowManager.startDragging(),
+      child: const SizedBox.expand(),
+    );
   }
 }

--- a/lib/bean/dialog/exit_confirmation_dialog.dart
+++ b/lib/bean/dialog/exit_confirmation_dialog.dart
@@ -27,6 +27,26 @@ class _ExitConfirmationDialogState extends State<ExitConfirmationDialog> {
       ? Duration.zero
       : const Duration(milliseconds: 200);
 
+  // ListTile-based controls own focus but do not translate ActivateIntent
+  // into onChanged, so map it explicitly. Without this a gamepad A press on
+  // an option does nothing.
+  Widget _activateOnIntent({
+    required VoidCallback onActivate,
+    required Widget child,
+  }) {
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (_) {
+            onActivate();
+            return null;
+          },
+        ),
+      },
+      child: child,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -118,21 +138,25 @@ class _ExitConfirmationDialogState extends State<ExitConfirmationDialog> {
               ),
             ),
             const SizedBox(height: 16),
-            CheckboxListTile(
-              value: _rememberChoice,
-              onChanged: (value) {
-                setState(() => _rememberChoice = value ?? false);
-              },
-              controlAffinity: ListTileControlAffinity.leading,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 4),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              title: Text('记住我的选择', style: theme.textTheme.bodyMedium),
-              subtitle: Text(
-                '下次关闭窗口时不再询问',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: colors.onSurfaceVariant,
+            _activateOnIntent(
+              onActivate: () =>
+                  setState(() => _rememberChoice = !_rememberChoice),
+              child: CheckboxListTile(
+                value: _rememberChoice,
+                onChanged: (value) {
+                  setState(() => _rememberChoice = value ?? false);
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                title: Text('记住我的选择', style: theme.textTheme.bodyMedium),
+                subtitle: Text(
+                  '下次关闭窗口时不再询问',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
@@ -185,29 +209,38 @@ class _ExitConfirmationDialogState extends State<ExitConfirmationDialog> {
     final foreground =
         selected ? colors.onSecondaryContainer : colors.onSurface;
 
-    return Material(
-      color: selected ? colors.secondaryContainer : colors.surfaceContainerLow,
-      borderRadius: borderRadius,
-      clipBehavior: Clip.antiAlias,
-      animationDuration: _animationDuration,
-      child: RadioListTile<ExitDialogAction>(
-        value: action,
-        selected: selected,
-        activeColor: colors.onSecondaryContainer,
-        controlAffinity: ListTileControlAffinity.trailing,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        shape: RoundedRectangleBorder(borderRadius: borderRadius),
-        secondary: Icon(icon, color: foreground),
-        title: Text(
-          title,
-          style: theme.textTheme.titleSmall?.copyWith(color: foreground),
-        ),
-        subtitle: Text(
-          description,
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: selected
-                ? colors.onSecondaryContainer
-                : colors.onSurfaceVariant,
+    return _activateOnIntent(
+      onActivate: () {
+        if (_action != action) {
+          setState(() => _action = action);
+        }
+      },
+      child: Material(
+        color:
+            selected ? colors.secondaryContainer : colors.surfaceContainerLow,
+        borderRadius: borderRadius,
+        clipBehavior: Clip.antiAlias,
+        animationDuration: _animationDuration,
+        child: RadioListTile<ExitDialogAction>(
+          value: action,
+          selected: selected,
+          activeColor: colors.onSecondaryContainer,
+          controlAffinity: ListTileControlAffinity.trailing,
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          shape: RoundedRectangleBorder(borderRadius: borderRadius),
+          secondary: Icon(icon, color: foreground),
+          title: Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(color: foreground),
+          ),
+          subtitle: Text(
+            description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: selected
+                  ? colors.onSecondaryContainer
+                  : colors.onSurfaceVariant,
+            ),
           ),
         ),
       ),

--- a/lib/bean/settings/settings_list.dart
+++ b/lib/bean/settings/settings_list.dart
@@ -160,18 +160,24 @@ class SettingsCategoryTile extends StatelessWidget {
     required this.title,
     required this.description,
     required this.onTap,
+    this.focusNode,
+    this.autofocus = false,
   });
 
   final IconData icon;
   final String title;
   final String description;
   final VoidCallback onTap;
+  final FocusNode? focusNode;
+  final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     return InkWell(
+      focusNode: focusNode,
+      autofocus: autofocus,
       onTap: onTap,
       onHighlightChanged: SplitListRow.pressReporterOf(context),
       child: Padding(

--- a/lib/bean/widget/gamepad_navigation.dart
+++ b/lib/bean/widget/gamepad_navigation.dart
@@ -1,0 +1,719 @@
+import 'dart:async';
+import 'dart:ui' show ViewFocusEvent, ViewFocusState;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:kazumi/navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+
+class GamepadActivateIntent extends Intent {
+  const GamepadActivateIntent();
+}
+
+class GamepadNavigateIntent extends Intent {
+  const GamepadNavigateIntent(this.direction);
+
+  final TraversalDirection direction;
+}
+
+class GamepadBackIntent extends Intent {
+  const GamepadBackIntent();
+}
+
+class GamepadSecondaryActionIntent extends Intent {
+  const GamepadSecondaryActionIntent();
+}
+
+class GamepadContextActionIntent extends Intent {
+  const GamepadContextActionIntent();
+}
+
+class GamepadPreviousSectionIntent extends Intent {
+  const GamepadPreviousSectionIntent();
+}
+
+class GamepadNextSectionIntent extends Intent {
+  const GamepadNextSectionIntent();
+}
+
+class GamepadPreviousSecondarySectionIntent extends Intent {
+  const GamepadPreviousSecondarySectionIntent();
+}
+
+class GamepadNextSecondarySectionIntent extends Intent {
+  const GamepadNextSecondarySectionIntent();
+}
+
+class GamepadMenuIntent extends Intent {
+  const GamepadMenuIntent();
+}
+
+class GamepadViewIntent extends Intent {
+  const GamepadViewIntent();
+}
+
+class GamepadLeftStickClickIntent extends Intent {
+  const GamepadLeftStickClickIntent();
+}
+
+class GamepadRightStickClickIntent extends Intent {
+  const GamepadRightStickClickIntent();
+}
+
+class _GamepadServiceScope extends InheritedWidget {
+  const _GamepadServiceScope({
+    required this.service,
+    required super.child,
+  });
+
+  final GamepadInputService service;
+
+  @override
+  bool updateShouldNotify(_GamepadServiceScope oldWidget) =>
+      oldWidget.service != service;
+}
+
+/// Dispatches normalized gamepad commands from the current primary focus.
+///
+/// Feature widgets may override a command by registering its intent in an
+/// [Actions] ancestor. Commands without a local action use standard Flutter
+/// activation, spatial focus traversal, scrolling, and navigator dismissal.
+class GamepadNavigationScope extends StatefulWidget {
+  const GamepadNavigationScope({
+    super.key,
+    required this.service,
+    required this.child,
+  });
+
+  final GamepadInputService service;
+  final Widget child;
+
+  /// Optional global fallback that switches the persistent menu/sidebar
+  /// destination when no local action claims a shoulder-button press.
+  ///
+  /// The menu shell registers this so LB/RB keep controlling the sidebar even
+  /// while a covering page (settings, player, ...) owns the focus. The player
+  /// overloads the shoulder buttons for seeking, but its own action is found
+  /// first from the player focus, so the fallback only fires where nothing
+  /// else claims the command.
+  static void Function(int offset)? onSectionFallback;
+
+  static GamepadInputService? maybeServiceOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_GamepadServiceScope>()
+        ?.service;
+  }
+
+  @override
+  State<GamepadNavigationScope> createState() => _GamepadNavigationScopeState();
+}
+
+class _GamepadNavigationScopeState extends State<GamepadNavigationScope>
+    with WidgetsBindingObserver {
+  StreamSubscription<GamepadCommandEvent>? _subscription;
+  bool _focusRecoveryScheduled = false;
+  bool _appActive = true;
+  bool _viewFocused = true;
+
+  final Set<LogicalKeyboardKey> _handledNavigationKeys = <LogicalKeyboardKey>{};
+  final Map<LogicalKeyboardKey, Timer> _keyboardActionTimers =
+      <LogicalKeyboardKey, Timer>{};
+  final Map<LogicalKeyboardKey, GamepadCommand> _keyboardActions =
+      <LogicalKeyboardKey, GamepadCommand>{};
+  final Set<LogicalKeyboardKey> _pressedKeyboardActionKeys =
+      <LogicalKeyboardKey>{};
+  final Map<GamepadCommand, Timer> _nativeFaceButtonSuppression =
+      <GamepadCommand, Timer>{};
+
+  static const Duration _keyboardActionGrace = Duration(milliseconds: 90);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    widget.service.setSuspended(!_appActive || !_viewFocused);
+    widget.service.start();
+    _subscription = widget.service.commands.listen(_dispatch);
+    HardwareKeyboard.instance.addHandler(_observeKeyRelease);
+    FocusManager.instance.addListener(_scheduleFocusRecovery);
+    topRouteRevision.addListener(_retargetFocusAfterRouteChange);
+  }
+
+  @override
+  void didUpdateWidget(GamepadNavigationScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.service == widget.service) {
+      return;
+    }
+    _clearPendingInput(oldWidget.service);
+    unawaited(_subscription?.cancel());
+    widget.service.setSuspended(!_appActive || !_viewFocused);
+    widget.service.start();
+    _subscription = widget.service.commands.listen(_dispatch);
+  }
+
+  void _clearPendingInput(GamepadInputService service) {
+    service.reset();
+    _handledNavigationKeys.clear();
+    for (final timer in _keyboardActionTimers.values) {
+      timer.cancel();
+    }
+    for (final timer in _nativeFaceButtonSuppression.values) {
+      timer.cancel();
+    }
+    _keyboardActionTimers.clear();
+    _nativeFaceButtonSuppression.clear();
+    _keyboardActions.clear();
+    _pressedKeyboardActionKeys.clear();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _appActive = state == AppLifecycleState.resumed;
+    _updateSuspension();
+  }
+
+  @override
+  void didChangeViewFocus(ViewFocusEvent event) {
+    if (event.viewId != View.of(context).viewId) return;
+    _viewFocused = event.state == ViewFocusState.focused;
+    _updateSuspension();
+  }
+
+  void _updateSuspension() {
+    _clearPendingInput(widget.service);
+    widget.service.setSuspended(!_appActive || !_viewFocused);
+  }
+
+  // Observe releases even when the new focused widget consumes the event.
+  bool _observeKeyRelease(KeyEvent event) {
+    if (event is KeyUpEvent &&
+        _handledNavigationKeys.remove(event.logicalKey)) {
+      final command = _navigationCommandForKey(event.logicalKey);
+      if (command != null) {
+        widget.service.handleKeyboardNavigation(command, false);
+      }
+    }
+    return false;
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    HardwareKeyboard.instance.removeHandler(_observeKeyRelease);
+    FocusManager.instance.removeListener(_scheduleFocusRecovery);
+    topRouteRevision.removeListener(_retargetFocusAfterRouteChange);
+    _clearPendingInput(widget.service);
+    unawaited(_subscription?.cancel());
+    super.dispose();
+  }
+
+  void _dispatch(GamepadCommandEvent event) {
+    if (!mounted) {
+      return;
+    }
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    _suppressKeyboardFaceAction(event.command);
+    final primary = FocusManager.instance.primaryFocus;
+    if ((primary == null || !isGamepadFocusUsable(primary)) &&
+        event.command != GamepadCommand.back) {
+      _focusTopRoute(currentTopRoute.value);
+      return;
+    }
+    final direction = switch (event.command) {
+      GamepadCommand.navigateUp => TraversalDirection.up,
+      GamepadCommand.navigateDown => TraversalDirection.down,
+      GamepadCommand.navigateLeft => TraversalDirection.left,
+      GamepadCommand.navigateRight => TraversalDirection.right,
+      _ => null,
+    };
+    if (direction != null) {
+      final intent = GamepadNavigateIntent(direction);
+      if (!_invokeLocal(intent) && !invokeGamepadControlDirection(direction)) {
+        final focus = FocusManager.instance.primaryFocus;
+        if (focus == null || focus is FocusScopeNode) {
+          _focusTopRoute(currentTopRoute.value);
+        } else {
+          focus.focusInDirection(direction);
+        }
+      }
+      _ensurePrimaryFocusVisible();
+      return;
+    }
+
+    switch (event.command) {
+      case GamepadCommand.activate:
+        if (!_invokeLocal(const GamepadActivateIntent())) {
+          _invokeStandard(const ActivateIntent());
+        }
+      case GamepadCommand.back:
+        final focusContext = FocusManager.instance.primaryFocus?.context;
+        final menuController =
+            focusContext == null ? null : MenuController.maybeOf(focusContext);
+        if (menuController?.isOpen ?? false) {
+          menuController!.close();
+        } else if (!_invokeLocal(const GamepadBackIntent())) {
+          unawaited(_popFromFocusedNavigator(focusContext));
+        }
+      case GamepadCommand.secondaryAction:
+        _invokeLocal(const GamepadSecondaryActionIntent());
+      case GamepadCommand.contextAction:
+        _invokeLocal(const GamepadContextActionIntent());
+      case GamepadCommand.previousSection:
+        if (!_invokeLocal(const GamepadPreviousSectionIntent())) {
+          _switchSectionFallback(-1);
+        }
+      case GamepadCommand.nextSection:
+        if (!_invokeLocal(const GamepadNextSectionIntent())) {
+          _switchSectionFallback(1);
+        }
+      case GamepadCommand.previousSecondarySection:
+        _invokeLocal(const GamepadPreviousSecondarySectionIntent());
+      case GamepadCommand.nextSecondarySection:
+        _invokeLocal(const GamepadNextSecondarySectionIntent());
+      case GamepadCommand.menu:
+        _invokeLocal(const GamepadMenuIntent());
+      case GamepadCommand.view:
+        _invokeLocal(const GamepadViewIntent());
+      case GamepadCommand.leftStickClick:
+        _invokeLocal(const GamepadLeftStickClickIntent());
+      case GamepadCommand.rightStickClick:
+        _invokeLocal(const GamepadRightStickClickIntent());
+      case GamepadCommand.scrollUp:
+        _invokeStandard(const ScrollIntent(direction: AxisDirection.up));
+      case GamepadCommand.scrollDown:
+        _invokeStandard(const ScrollIntent(direction: AxisDirection.down));
+      case GamepadCommand.scrollLeft:
+        _invokeStandard(const ScrollIntent(direction: AxisDirection.left));
+      case GamepadCommand.scrollRight:
+        _invokeStandard(const ScrollIntent(direction: AxisDirection.right));
+      case GamepadCommand.navigateUp:
+      case GamepadCommand.navigateDown:
+      case GamepadCommand.navigateLeft:
+      case GamepadCommand.navigateRight:
+        break;
+    }
+  }
+
+  /// Handheld middleware can report a face-button press through both the
+  /// gamepad event channel and a virtual keyboard. Native face-button events
+  /// are authoritative, so suppress the matching keyboard fallback briefly.
+  /// In particular, a virtual Enter generated by B must never activate focus.
+  void _suppressKeyboardFaceAction(GamepadCommand command) {
+    final commands = switch (command) {
+      GamepadCommand.back => const <GamepadCommand>[
+          GamepadCommand.activate,
+          GamepadCommand.back,
+        ],
+      GamepadCommand.activate => const <GamepadCommand>[
+          GamepadCommand.activate,
+        ],
+      _ => const <GamepadCommand>[],
+    };
+    for (final suppressed in commands) {
+      _cancelKeyboardAction(suppressed);
+      _nativeFaceButtonSuppression.remove(suppressed)?.cancel();
+      _nativeFaceButtonSuppression[suppressed] = Timer(
+        _keyboardActionGrace,
+        () => _nativeFaceButtonSuppression.remove(suppressed)?.cancel(),
+      );
+    }
+  }
+
+  void _cancelKeyboardAction(GamepadCommand command) {
+    final keys = _keyboardActions.entries
+        .where((entry) => entry.value == command)
+        .map((entry) => entry.key)
+        .toList();
+    for (final key in keys) {
+      _keyboardActionTimers.remove(key)?.cancel();
+      _keyboardActions.remove(key);
+    }
+  }
+
+  bool _isNativeFaceActionSuppressed(GamepadCommand command) =>
+      _nativeFaceButtonSuppression[command] != null;
+
+  Future<void> _popFromFocusedNavigator(BuildContext? focusContext) async {
+    final focusedNavigator =
+        focusContext == null ? null : Navigator.maybeOf(focusContext);
+    final rootNavigator = rootNavigatorKey.currentState;
+    if (focusedNavigator != null && focusedNavigator != rootNavigator) {
+      if (await focusedNavigator.maybePop()) {
+        return;
+      }
+    }
+    await rootNavigator?.maybePop();
+  }
+
+  bool _invokeLocal<T extends Intent>(T intent) {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    if (focusContext == null) return false;
+    final action = Actions.maybeFind<T>(focusContext);
+    if (action == null || !action.isEnabled(intent)) return false;
+    Actions.invoke(focusContext, intent);
+    return true;
+  }
+
+  void _invokeStandard<T extends Intent>(T intent) {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    if (focusContext != null) {
+      Actions.maybeInvoke(focusContext, intent);
+    }
+  }
+
+  /// Shoulder-button fallback: nothing in the current page claimed the
+  /// command, so the persistent sidebar takes over, matching wiliwili where
+  /// L1/R1 always switch the top-level destinations.
+  ///
+  /// Gated on the top route being a full page: inside a dialog or bottom
+  /// sheet the buttons must not yank the underlying page around.
+  void _switchSectionFallback(int offset) {
+    final fallback = GamepadNavigationScope.onSectionFallback;
+    if (fallback == null) {
+      return;
+    }
+    if (currentTopRoute.value is! PageRoute) {
+      return;
+    }
+    fallback(offset);
+  }
+
+  void _scheduleFocusRecovery() {
+    if (!mounted ||
+        _focusRecoveryScheduled ||
+        !widget.service.usingGamepad.value) {
+      return;
+    }
+    final primary = FocusManager.instance.primaryFocus;
+    if (primary != null && isGamepadFocusUsable(primary)) return;
+    _focusRecoveryScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusRecoveryScheduled = false;
+      if (!mounted || !widget.service.usingGamepad.value) return;
+      final primary = FocusManager.instance.primaryFocus;
+      if (primary != null && isGamepadFocusUsable(primary)) return;
+      if (primary is FocusScopeNode && focusFirstGamepadControl(primary)) {
+        return;
+      }
+      _focusTopRoute(currentTopRoute.value);
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  void _retargetFocusAfterRouteChange() {
+    if (!mounted) return;
+    _clearPendingInput(widget.service);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final primary = FocusManager.instance.primaryFocus;
+      // A nested route is valid when its ancestors are current too; comparing
+      // its identity with the root route incorrectly steals settings focus.
+      if (primary == null || !isGamepadFocusUsable(primary)) {
+        _focusTopRoute(currentTopRoute.value);
+      }
+    });
+  }
+
+  bool _focusTopRoute(Route<dynamic>? route) {
+    final routeContext = route is ModalRoute ? route.subtreeContext : null;
+    final focusContext =
+        routeContext?.mounted == true ? routeContext! : context;
+    return focusFirstGamepadControl(FocusScope.of(focusContext));
+  }
+
+  void _ensurePrimaryFocusVisible() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final focusContext = FocusManager.instance.primaryFocus?.context;
+      if (!mounted || focusContext == null) {
+        return;
+      }
+      Scrollable.ensureVisible(
+        focusContext,
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOutCubic,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+      );
+    });
+  }
+
+  void _markPointerInput() {
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.automatic;
+    _clearPendingInput(widget.service);
+    widget.service.markPointerInput();
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    final command = _navigationCommandForKey(event.logicalKey);
+    if (command != null && widget.service.enabled) {
+      if (event is KeyUpEvent) {
+        if (!_handledNavigationKeys.remove(event.logicalKey)) {
+          return KeyEventResult.ignored;
+        }
+        widget.service.handleKeyboardNavigation(command, false);
+        return KeyEventResult.handled;
+      }
+      if (_focusedEditable() != null) {
+        return KeyEventResult.ignored;
+      }
+      if (event is KeyRepeatEvent &&
+          !_handledNavigationKeys.contains(event.logicalKey)) {
+        return KeyEventResult.handled;
+      }
+      _handledNavigationKeys.add(event.logicalKey);
+      widget.service.handleKeyboardNavigation(command, true);
+      return KeyEventResult.handled;
+    }
+    if (!widget.service.enabled) {
+      return KeyEventResult.ignored;
+    }
+
+    if (_focusedEditable() != null &&
+        (event.logicalKey == LogicalKeyboardKey.enter ||
+            event.logicalKey == LogicalKeyboardKey.numpadEnter ||
+            event.logicalKey == LogicalKeyboardKey.space)) {
+      return KeyEventResult.ignored;
+    }
+
+    final keyboardCommand = _keyboardCommandForKey(event.logicalKey);
+    if (keyboardCommand == null) {
+      return KeyEventResult.ignored;
+    }
+    if (event is KeyUpEvent) {
+      final wasPressed = _pressedKeyboardActionKeys.remove(event.logicalKey);
+      return wasPressed || _isNativeFaceActionSuppressed(keyboardCommand)
+          ? KeyEventResult.handled
+          : KeyEventResult.ignored;
+    }
+    if (_isNativeFaceActionSuppressed(keyboardCommand)) {
+      return KeyEventResult.handled;
+    }
+    if (event is KeyRepeatEvent ||
+        _pressedKeyboardActionKeys.contains(event.logicalKey)) {
+      return KeyEventResult.handled;
+    }
+
+    _pressedKeyboardActionKeys.add(event.logicalKey);
+    _keyboardActions[event.logicalKey] = keyboardCommand;
+    _keyboardActionTimers[event.logicalKey] = Timer(_keyboardActionGrace, () {
+      _keyboardActionTimers.remove(event.logicalKey);
+      final pending = _keyboardActions.remove(event.logicalKey);
+      if (pending == null || _isNativeFaceActionSuppressed(pending)) {
+        return;
+      }
+      switch (event.logicalKey) {
+        case LogicalKeyboardKey.enter:
+        case LogicalKeyboardKey.numpadEnter:
+        case LogicalKeyboardKey.space:
+          _invokeStandard(const ActivateIntent());
+        case LogicalKeyboardKey.escape:
+          _invokeStandard(const DismissIntent());
+        case LogicalKeyboardKey.gameButtonA:
+        case LogicalKeyboardKey.gameButtonB:
+          _dispatch(GamepadCommandEvent(command: pending, gamepadId: -1));
+      }
+    });
+    return KeyEventResult.handled;
+  }
+
+  GamepadCommand? _navigationCommandForKey(LogicalKeyboardKey key) {
+    return switch (key) {
+      LogicalKeyboardKey.arrowUp => GamepadCommand.navigateUp,
+      LogicalKeyboardKey.arrowDown => GamepadCommand.navigateDown,
+      LogicalKeyboardKey.arrowLeft => GamepadCommand.navigateLeft,
+      LogicalKeyboardKey.arrowRight => GamepadCommand.navigateRight,
+      _ => null,
+    };
+  }
+
+  GamepadCommand? _keyboardCommandForKey(LogicalKeyboardKey key) {
+    return switch (key) {
+      LogicalKeyboardKey.enter => GamepadCommand.activate,
+      LogicalKeyboardKey.numpadEnter => GamepadCommand.activate,
+      LogicalKeyboardKey.space => GamepadCommand.activate,
+      LogicalKeyboardKey.escape => GamepadCommand.back,
+      LogicalKeyboardKey.gameButtonA => GamepadCommand.activate,
+      LogicalKeyboardKey.gameButtonB => GamepadCommand.back,
+      _ => null,
+    };
+  }
+
+  // Keep text editing keys in Flutter's input pipeline.
+  EditableTextState? _focusedEditable() {
+    final context = FocusManager.instance.primaryFocus?.context;
+    if (context == null) {
+      return null;
+    }
+    EditableTextState? found;
+    bool inspect(Element element) {
+      if (element is StatefulElement && element.state is EditableTextState) {
+        found = element.state as EditableTextState;
+        return true;
+      }
+      return false;
+    }
+
+    void visit(Element element) {
+      if (found != null) {
+        return;
+      }
+      if (inspect(element)) {
+        return;
+      }
+      element.visitChildren(visit);
+    }
+
+    if (context is Element) {
+      inspect(context);
+      context.visitAncestorElements((element) => !inspect(element));
+      if (found == null) {
+        // Some custom editable widgets attach their FocusNode above the
+        // EditableText rather than inside it.
+        context.visitChildren(visit);
+      }
+    }
+    return found;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _GamepadServiceScope(
+      service: widget.service,
+      child: Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: _handleKeyEvent,
+        child: Listener(
+          behavior: HitTestBehavior.translucent,
+          onPointerDown: (_) => _markPointerInput(),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              ValueListenableBuilder<bool>(
+                valueListenable: widget.service.usingGamepad,
+                child: widget.child,
+                builder: (context, usingGamepad, child) => MediaQuery(
+                  data: MediaQuery.of(context).copyWith(
+                    navigationMode: usingGamepad
+                        ? NavigationMode.directional
+                        : NavigationMode.traditional,
+                  ),
+                  child: child!,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Flutter's offstage routes can retain nodes; only navigate visible routes.
+bool isGamepadFocusUsable(FocusNode node) {
+  final context = node.context;
+  if (context == null ||
+      !node.canRequestFocus ||
+      node is FocusScopeNode ||
+      node.skipTraversal) {
+    return false;
+  }
+  bool visible = ModalRoute.of(context)?.isCurrent ?? true;
+  context.visitAncestorElements((element) {
+    if (element.widget is Offstage && (element.widget as Offstage).offstage) {
+      visible = false;
+    }
+    return visible;
+  });
+  for (final ancestor in node.ancestors) {
+    final ancestorContext = ancestor.context;
+    if (ancestorContext != null &&
+        ModalRoute.of(ancestorContext)?.isCurrent == false) {
+      return false;
+    }
+  }
+  return visible;
+}
+
+bool focusFirstGamepadControl(FocusNode scope) {
+  final remembered = scope is FocusScopeNode ? scope.focusedChild : null;
+  if (remembered != null && isGamepadFocusUsable(remembered)) {
+    remembered.requestFocus();
+    return true;
+  }
+  for (final node in scope.traversalDescendants) {
+    if (isGamepadFocusUsable(node)) {
+      node.requestFocus();
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Whether the current primary focus is inside an editable text field.
+///
+/// Directional traversal must not be swallowed by text-editing shortcuts or a
+/// focused text field becomes a dead end for the joystick.
+bool primaryFocusIsEditable() {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return false;
+  if (context.widget is EditableText) return true;
+  if (context.findAncestorWidgetOfExactType<EditableText>() != null) {
+    return true;
+  }
+  if (context is! Element) return false;
+  bool found = false;
+  void visit(Element element) {
+    if (found) return;
+    if (element is StatefulElement && element.state is EditableTextState) {
+      found = true;
+      return;
+    }
+    element.visitChildren(visit);
+  }
+
+  context.visitChildren(visit);
+  return found;
+}
+
+/// Reuse the focused control's arrow action (slider, text field, etc.) without
+/// synthesizing key events or accidentally invoking default focus traversal.
+bool invokeGamepadControlDirection(TraversalDirection direction) {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return false;
+  // Text fields own the arrow keys for cursor movement; let the caller fall
+  // back to focus traversal so the stick can always leave the field.
+  if (primaryFocusIsEditable()) return false;
+  final key = switch (direction) {
+    TraversalDirection.up => LogicalKeyboardKey.arrowUp,
+    TraversalDirection.down => LogicalKeyboardKey.arrowDown,
+    TraversalDirection.left => LogicalKeyboardKey.arrowLeft,
+    TraversalDirection.right => LogicalKeyboardKey.arrowRight,
+  };
+  bool handled = false;
+  context.visitAncestorElements((element) {
+    final widget = element.widget;
+    if (widget is! Shortcuts) return true;
+    for (final entry in widget.shortcuts.entries) {
+      final activator = entry.key;
+      final matches = activator is SingleActivator &&
+          activator.trigger == key &&
+          !activator.control &&
+          !activator.shift &&
+          !activator.alt &&
+          !activator.meta;
+      if (!matches) continue;
+      final intent = entry.value;
+      if (intent is DirectionalFocusIntent) return false;
+      final action = Actions.maybeFind<Intent>(context, intent: intent);
+      if (action != null && action.isEnabled(intent)) {
+        Actions.invoke(context, intent);
+        handled = true;
+      }
+      return false;
+    }
+    return true;
+  });
+  return handled;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,7 +97,11 @@ void main() async {
     ModularApp(
       module: appModule,
       navigatorKey: rootNavigatorKey,
-      navigatorObservers: [KazumiDialog.observer, rootRouteObserver],
+      navigatorObservers: [
+        KazumiDialog.observer,
+        rootRouteObserver,
+        topRouteObserver,
+      ],
       defaultTransition: TransitionType.material,
       provide: (scoped) {
         scoped.addChangeNotifier<ThemeProvider>(ThemeProvider.new);

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -8,3 +8,25 @@ final rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 /// Restricted to [PageRoute] on purpose: dialogs and bottom sheets are
 /// PopupRoutes, and sitting under one does not make a page hidden.
 final rootRouteObserver = RouteObserver<PageRoute<void>>();
+
+/// The top route of the root navigator, kept current by [topRouteObserver].
+final currentTopRoute = ValueNotifier<Route<dynamic>?>(null);
+
+/// Bumped whenever the top route of the root navigator changes.
+///
+/// The global gamepad scope lives above the [Navigator], so it cannot observe
+/// route changes itself; it listens to this revision and re-targets primary
+/// focus into the new top route afterwards.
+final topRouteRevision = ValueNotifier<int>(0);
+
+/// Keeps [currentTopRoute] and [topRouteRevision] in sync with the root
+/// navigator.
+final NavigatorObserver topRouteObserver = _TopRouteObserver();
+
+class _TopRouteObserver extends NavigatorObserver {
+  @override
+  void didChangeTop(Route<dynamic> topRoute, Route<dynamic>? previousTopRoute) {
+    currentTopRoute.value = topRoute;
+    topRouteRevision.value++;
+  }
+}

--- a/lib/pages/menu/menu.dart
+++ b/lib/pages/menu/menu.dart
@@ -6,6 +6,7 @@ import 'package:kazumi/bean/widget/embedded_native_control_area.dart';
 import 'package:kazumi/navigation.dart';
 import 'package:kazumi/pages/menu/route_visibility.dart';
 import 'package:kazumi/pages/router.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
 
 class ScaffoldMenu extends StatefulWidget {
   const ScaffoldMenu({super.key, required this.location});
@@ -26,6 +27,12 @@ class _ScaffoldMenu extends State<ScaffoldMenu> with RouteAware {
   bool _isCovered = false;
 
   @override
+  void initState() {
+    super.initState();
+    GamepadNavigationScope.onSectionFallback = _handleGlobalSectionSwitch;
+  }
+
+  @override
   void didUpdateWidget(covariant ScaffoldMenu oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.location != widget.location) {
@@ -44,6 +51,7 @@ class _ScaffoldMenu extends State<ScaffoldMenu> with RouteAware {
 
   @override
   void dispose() {
+    GamepadNavigationScope.onSectionFallback = null;
     rootRouteObserver.unsubscribe(this);
     super.dispose();
   }
@@ -72,6 +80,11 @@ class _ScaffoldMenu extends State<ScaffoldMenu> with RouteAware {
     setState(() => _selectedIndex = index);
   }
 
+  // The shell owns its selection even while another page covers it.
+  void _handleGlobalSectionSwitch(int offset) {
+    _selectDestination((_selectedIndex + offset) % menu.menuList.length);
+  }
+
   void _handleSystemBack(BuildContext context) {
     if (_outletKey.currentState?.maybePop() ?? false) {
       _lastExitPromptAt = null;
@@ -98,21 +111,84 @@ class _ScaffoldMenu extends State<ScaffoldMenu> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
-    return RouteVisibility(
-      isCovered: _isCovered,
-      child: PopScope(
-        canPop: false,
-        onPopInvokedWithResult: (didPop, _) {
-          if (!didPop) {
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        GamepadBackIntent: CallbackAction<GamepadBackIntent>(
+          onInvoke: (_) {
             _handleSystemBack(context);
-          }
-        },
-        child: OrientationBuilder(
-          builder: (context, orientation) {
-            return orientation == Orientation.portrait
-                ? _bottomMenu(context, _selectedIndex)
-                : _sideMenu(context, _selectedIndex);
+            return null;
           },
+        ),
+        GamepadPreviousSectionIntent:
+            CallbackAction<GamepadPreviousSectionIntent>(
+          onInvoke: (_) {
+            _handleGlobalSectionSwitch(-1);
+            return null;
+          },
+        ),
+        GamepadNextSectionIntent: CallbackAction<GamepadNextSectionIntent>(
+          onInvoke: (_) {
+            _handleGlobalSectionSwitch(1);
+            return null;
+          },
+        ),
+        GamepadContextActionIntent: CallbackAction<GamepadContextActionIntent>(
+          onInvoke: (_) {
+            // The search page owns Y while its input is focused. The shell's
+            // action is still in the ancestor tree, so inspect both the
+            // focused route and the root route state before opening another
+            // search route. This also covers nested tab paths such as
+            // /tab/my/search, which are not equal to /search.
+            final focusedContext = FocusManager.instance.primaryFocus?.context;
+            final navigationContext = rootNavigatorKey.currentContext;
+            final paths = <String>[];
+            for (final candidate in [
+              focusedContext,
+              navigationContext,
+              context
+            ]) {
+              if (candidate == null) continue;
+              try {
+                paths.add(candidate.routeState(listen: false).uri.path);
+              } catch (_) {
+                // A focused platform view can sit outside Modular's route
+                // scope; the other candidates still provide the route.
+              }
+            }
+            bool isSearchPath(String path) =>
+                path == '/search' ||
+                path.endsWith('/search') ||
+                path.contains('/search/');
+            if (paths.any(isSearchPath)) {
+              return null;
+            }
+            context.pushNamed('/search/');
+            return null;
+          },
+        ),
+        GamepadMenuIntent: CallbackAction<GamepadMenuIntent>(
+          onInvoke: (_) {
+            context.pushNamed('/settings/');
+            return null;
+          },
+        ),
+      },
+      child: RouteVisibility(
+        isCovered: _isCovered,
+        child: PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (!didPop) {
+              _handleSystemBack(context);
+            }
+          },
+          child: OrientationBuilder(
+            builder: (context, orientation) {
+              return orientation == Orientation.portrait
+                  ? _bottomMenu(context, _selectedIndex)
+                  : _sideMenu(context, _selectedIndex);
+            },
+          ),
         ),
       ),
     );

--- a/lib/pages/player/controller/interactive_seek_lifecycle.dart
+++ b/lib/pages/player/controller/interactive_seek_lifecycle.dart
@@ -1,0 +1,147 @@
+typedef InteractiveSeekPositionReader = Duration Function();
+typedef InteractiveSeekPlayingReader = bool Function();
+typedef InteractiveSeekPreviewWriter = void Function(Duration position);
+typedef InteractiveSeekAction = Future<void> Function();
+typedef InteractiveSeekTargetAction = Future<void> Function(Duration target);
+typedef InteractiveSeekNormalizer = Duration Function(Duration target);
+
+class _InteractiveSeekSession {
+  _InteractiveSeekSession({
+    required this.initialPosition,
+    required this.wasPlaying,
+    required this.pauseCompleted,
+  }) : target = initialPosition;
+
+  final Duration initialPosition;
+  final bool wasPlaying;
+  final Future<void> pauseCompleted;
+  Duration target;
+  Future<bool>? completion;
+}
+
+/// Owns the pause/preview/commit lifecycle of one interactive seek gesture.
+///
+/// Preview updates only change the displayed position. The media player is
+/// sought once, when the gesture commits. Cancelling restores the original
+/// preview position and the playback state captured at gesture start.
+class InteractiveSeekLifecycle {
+  InteractiveSeekLifecycle({
+    required InteractiveSeekPositionReader readPosition,
+    required InteractiveSeekPlayingReader isPlaying,
+    required InteractiveSeekPreviewWriter writePreview,
+    required InteractiveSeekNormalizer normalize,
+    required InteractiveSeekAction pause,
+    required InteractiveSeekTargetAction seek,
+    required InteractiveSeekAction play,
+    this.operationTimeout = const Duration(seconds: 3),
+  })  : _readPosition = readPosition,
+        _isPlaying = isPlaying,
+        _writePreview = writePreview,
+        _normalize = normalize,
+        _pause = pause,
+        _seek = seek,
+        _play = play;
+
+  final InteractiveSeekPositionReader _readPosition;
+  final InteractiveSeekPlayingReader _isPlaying;
+  final InteractiveSeekPreviewWriter _writePreview;
+  final InteractiveSeekNormalizer _normalize;
+  final InteractiveSeekAction _pause;
+  final InteractiveSeekTargetAction _seek;
+  final InteractiveSeekAction _play;
+  final Duration operationTimeout;
+
+  _InteractiveSeekSession? _session;
+
+  bool get hasActiveSession => _session != null;
+
+  void begin() {
+    if (_session != null) {
+      return;
+    }
+    final initialPosition = _normalize(_readPosition());
+    final wasPlaying = _isPlaying();
+    _session = _InteractiveSeekSession(
+      initialPosition: initialPosition,
+      wasPlaying: wasPlaying,
+      pauseCompleted:
+          wasPlaying ? Future<void>.sync(_pause) : Future<void>.value(),
+    );
+  }
+
+  bool update(Duration target) {
+    final session = _session;
+    if (session == null || session.completion != null) {
+      return false;
+    }
+    session.target = _normalize(target);
+    _writePreview(session.target);
+    return true;
+  }
+
+  Future<bool> commit() {
+    final session = _session;
+    if (session == null) {
+      return Future<bool>.value(false);
+    }
+    return session.completion ??= _commit(session);
+  }
+
+  Future<bool> cancel() {
+    final session = _session;
+    if (session == null) {
+      return Future<bool>.value(false);
+    }
+    return session.completion ??= _cancel(session);
+  }
+
+  void invalidate() {
+    _session = null;
+  }
+
+  Future<bool> _commit(_InteractiveSeekSession session) async {
+    try {
+      await session.pauseCompleted.timeout(operationTimeout);
+      if (!_isCurrent(session)) {
+        return false;
+      }
+
+      await _seek(session.target).timeout(operationTimeout);
+      if (!_isCurrent(session)) {
+        return false;
+      }
+
+      if (session.wasPlaying) {
+        await _play().timeout(operationTimeout);
+      }
+      return _isCurrent(session);
+    } finally {
+      if (_isCurrent(session)) {
+        _session = null;
+      }
+    }
+  }
+
+  Future<bool> _cancel(_InteractiveSeekSession session) async {
+    try {
+      _writePreview(session.initialPosition);
+      await session.pauseCompleted.timeout(operationTimeout);
+      if (!_isCurrent(session)) {
+        return false;
+      }
+
+      _writePreview(session.initialPosition);
+      if (session.wasPlaying) {
+        await _play().timeout(operationTimeout);
+      }
+      return _isCurrent(session);
+    } finally {
+      if (_isCurrent(session)) {
+        _session = null;
+      }
+    }
+  }
+
+  bool _isCurrent(_InteractiveSeekSession session) =>
+      identical(_session, session);
+}

--- a/lib/pages/player/controller/player_seek_controller.dart
+++ b/lib/pages/player/controller/player_seek_controller.dart
@@ -1,13 +1,6 @@
+import 'package:kazumi/pages/player/controller/interactive_seek_lifecycle.dart';
 import 'package:kazumi/pages/player/controller/player_danmaku_controller.dart';
 import 'package:kazumi/pages/player/controller/player_playback_controller.dart';
-
-class _InteractiveSeekSession {
-  _InteractiveSeekSession(this.pauseCompleted, this.target);
-
-  final Future<void> pauseCompleted;
-  Duration target;
-  Future<bool>? commit;
-}
 
 class PlayerSeekController {
   PlayerSeekController({
@@ -29,9 +22,18 @@ class PlayerSeekController {
   final Future<void> Function(bool enableSync) _onSeekCompleted;
 
   Future<void> _seekTail = Future<void>.value();
-  _InteractiveSeekSession? _interactiveSession;
+  late final InteractiveSeekLifecycle _interactiveSeek =
+      InteractiveSeekLifecycle(
+    readPosition: () => _playback.currentPosition,
+    isPlaying: () => _playback.playing,
+    writePreview: (position) => _playback.currentPosition = position,
+    normalize: _normalize,
+    pause: () => _pause(enableSync: false),
+    seek: seekTo,
+    play: () => _play(enableSync: false),
+  );
 
-  bool get hasActiveInteractiveSeek => _interactiveSession != null;
+  bool get hasActiveInteractiveSeek => _interactiveSeek.hasActiveSession;
 
   Future<void> seekTo(
     Duration target, {
@@ -73,55 +75,23 @@ class PlayerSeekController {
       );
 
   void beginInteractiveSeek() {
-    _interactiveSession = _InteractiveSeekSession(
-      _pause(enableSync: false),
-      _playback.currentPosition,
-    );
+    _interactiveSeek.begin();
   }
 
   bool updateInteractiveSeek(Duration target) {
-    final session = _interactiveSession;
-    if (session == null) {
-      return false;
-    }
-    session.target = _normalize(target);
-    _playback.currentPosition = session.target;
-    return true;
+    return _interactiveSeek.update(target);
   }
 
   Future<bool> commitInteractiveSeek() {
-    final session = _interactiveSession;
-    if (session == null) {
-      return Future<bool>.value(false);
-    }
-    return session.commit ??= _commitInteractiveSeek(session);
+    return _interactiveSeek.commit();
+  }
+
+  Future<bool> cancelInteractiveSeek() {
+    return _interactiveSeek.cancel();
   }
 
   void invalidateInteractiveSeek() {
-    _interactiveSession = null;
-  }
-
-  Future<bool> _commitInteractiveSeek(
-    _InteractiveSeekSession session,
-  ) async {
-    try {
-      await session.pauseCompleted;
-      if (!_isCurrent(session)) {
-        return false;
-      }
-
-      await seekTo(session.target);
-      if (!_isCurrent(session)) {
-        return false;
-      }
-
-      await _play(enableSync: false);
-      return _isCurrent(session);
-    } finally {
-      if (_isCurrent(session)) {
-        _interactiveSession = null;
-      }
-    }
+    _interactiveSeek.invalidate();
   }
 
   Duration _normalize(Duration target) {
@@ -135,9 +105,6 @@ class PlayerSeekController {
     }
     return Duration(milliseconds: milliseconds);
   }
-
-  bool _isCurrent(_InteractiveSeekSession session) =>
-      identical(_interactiveSession, session);
 
   Future<void> _settle(Future<void> operation) async {
     try {

--- a/lib/pages/player/player_item.dart
+++ b/lib/pages/player/player_item.dart
@@ -39,6 +39,9 @@ import 'package:kazumi/services/player/audio_controller.dart';
 import 'package:kazumi/utils/device.dart';
 import 'package:kazumi/services/platform/display_mode_service.dart';
 import 'package:kazumi/services/platform/player_menu_service.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+
+enum _InteractiveSeekSource { progressBar, surface }
 
 class PlayerItem extends StatefulWidget {
   const PlayerItem({
@@ -51,6 +54,11 @@ class PlayerItem extends StatefulWidget {
     required this.changeEpisode,
     required this.onBackPressed,
     required this.keyboardFocus,
+    required this.playerPanelScopeNode,
+    required this.topBarScopeNode,
+    required this.sideTabScopeNode,
+    required this.isSideTabOpen,
+    required this.onCloseSideTab,
     required this.pauseForTimedShutdown,
     this.disableAnimations = false,
   });
@@ -64,6 +72,14 @@ class PlayerItem extends StatefulWidget {
       changeEpisode;
   final void Function(BuildContext) onBackPressed;
   final FocusNode keyboardFocus;
+  // Traversal scopes owned by the video page. The panel scope keeps panel
+  // navigation contained; the top bar scope is the explicit exit target
+  // when navigation leaves the top edge of the panel.
+  final FocusScopeNode playerPanelScopeNode;
+  final FocusScopeNode topBarScopeNode;
+  final FocusScopeNode sideTabScopeNode;
+  final bool Function() isSideTabOpen;
+  final VoidCallback onCloseSideTab;
   final bool disableAnimations;
   final VoidCallback pauseForTimedShutdown;
 
@@ -77,6 +93,8 @@ class _PlayerItemState extends State<PlayerItem>
         WidgetsBindingObserver,
         TickerProviderStateMixin,
         KazumiDialogOwner {
+  static const Duration _interactiveSeekRecoveryTimeout = Duration(seconds: 5);
+
   late final PlayerController playerController;
   late final VideoPageController videoPageController =
       widget.videoPageController;
@@ -124,8 +142,16 @@ class _PlayerItemState extends State<PlayerItem>
   final Set<PlayerPanelHold> _playerPanelHolds = <PlayerPanelHold>{};
   int _openPlayerMenuCount = 0;
   PlayerPanelHold? _progressBarDragHold;
+  Timer? _interactiveSeekRecoveryTimer;
+  int? _progressBarPointer;
   PointerDeviceKind? _lastTapPointerKind;
   PointerDeviceKind? _lastDoubleTapPointerKind;
+  Duration _surfaceSeekStartPosition = Duration.zero;
+  double _surfaceSeekCumulativeDx = 0;
+  _InteractiveSeekSource? _interactiveSeekSource;
+  int _interactiveSeekGeneration = 0;
+  bool _interactiveSeekWasPlaying = false;
+  bool _playerPanelHasFocus = false;
 
   late final AnimationController _panelVisibilityController;
   late final AnimationController _screenshotFeedbackController;
@@ -151,6 +177,12 @@ class _PlayerItemState extends State<PlayerItem>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) async {
     super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.paused ||
+        state == AppLifecycleState.detached) {
+      _abortInteractiveSeek(resumePlayback: false);
+    }
     if (state == AppLifecycleState.paused && !backgroundPlayback) {
       // Suspend before awaiting pause so a later resume wins; pause alone keeps prefetching.
       final suspend = playerController.playback.setPrefetchSuspended(true);
@@ -667,6 +699,7 @@ class _PlayerItemState extends State<PlayerItem>
   }
 
   void _handleFullscreenChange(BuildContext context) async {
+    _abortInteractiveSeek();
     playerController.panel.lockPanel = false;
     _releasePlayerPanelHolds();
     playerController.danmaku.canvasController.clear();
@@ -676,43 +709,242 @@ class _PlayerItemState extends State<PlayerItem>
   }
 
   void handleProgressBarDragStart() {
-    _beginInteractiveSeek();
+    if (!_beginInteractiveSeek(_InteractiveSeekSource.progressBar)) {
+      return;
+    }
     _syncAudioServiceState();
     _progressBarDragHold = acquirePlayerPanelHold();
   }
 
-  Future<void> handleProgressBarSeek(Duration duration) async {
-    if (!playerController.seeking.updateInteractiveSeek(duration)) {
-      await playerController.seek(duration);
+  void handleProgressBarDragUpdate(Duration duration) {
+    if (_interactiveSeekSource != _InteractiveSeekSource.progressBar) {
       return;
     }
-    await _commitInteractiveSeek();
+    if (playerController.seeking.updateInteractiveSeek(duration)) {
+      _armInteractiveSeekRecovery();
+    }
   }
 
-  void _beginInteractiveSeek() {
-    _progressBarDragHold?.release();
-    _progressBarDragHold = null;
+  Future<void> handleProgressBarSeek(Duration duration) async {
+    if (_interactiveSeekSource == _InteractiveSeekSource.surface) {
+      return;
+    }
+    if (playerController.seeking.hasActiveInteractiveSeek) {
+      // An onSeek arriving again while commit is pending must not seek twice.
+      if (playerController.seeking.updateInteractiveSeek(duration)) {
+        await _commitInteractiveSeek();
+      }
+      return;
+    }
+    final generation = _interactiveSeekGeneration;
+    try {
+      await playerController.seek(duration);
+    } finally {
+      if (mounted && generation == _interactiveSeekGeneration) {
+        _clearInteractiveSeekUi();
+      }
+    }
+  }
+
+  bool _beginInteractiveSeek(_InteractiveSeekSource source) {
+    if (playerController.seeking.hasActiveInteractiveSeek) {
+      return false;
+    }
     playerTimer?.cancel();
+    _interactiveSeekGeneration++;
+    _interactiveSeekSource = source;
+    _interactiveSeekWasPlaying = playerController.playback.playing;
     playerController.seeking.beginInteractiveSeek();
+    if (!playerController.seeking.hasActiveInteractiveSeek) {
+      _interactiveSeekSource = null;
+      return false;
+    }
+    _armInteractiveSeekRecovery();
+    return true;
+  }
+
+  void _armInteractiveSeekRecovery() {
+    _interactiveSeekRecoveryTimer?.cancel();
+    _interactiveSeekRecoveryTimer = Timer(
+      _interactiveSeekRecoveryTimeout,
+      _abortInteractiveSeek,
+    );
   }
 
   Future<void> _commitInteractiveSeek() async {
+    final generation = _interactiveSeekGeneration;
     var completed = false;
     try {
       completed = await playerController.seeking.commitInteractiveSeek();
     } catch (e) {
       KazumiLogger().e('PlayerController: interactive seek failed', error: e);
+    } finally {
+      if (mounted && generation == _interactiveSeekGeneration) {
+        _clearInteractiveSeekUi(syncAudioService: completed);
+      }
     }
-    if (!mounted ||
-        (!completed && playerController.seeking.hasActiveInteractiveSeek)) {
+  }
+
+  Future<void> _cancelInteractiveSeek() async {
+    final generation = _interactiveSeekGeneration;
+    var completed = false;
+    try {
+      completed = await playerController.seeking.cancelInteractiveSeek();
+    } catch (e) {
+      KazumiLogger().e(
+        'PlayerController: interactive seek cancellation failed',
+        error: e,
+      );
+    } finally {
+      if (mounted && generation == _interactiveSeekGeneration) {
+        _clearInteractiveSeekUi(syncAudioService: completed);
+      }
+    }
+  }
+
+  void _beginSurfaceInteractiveSeek() {
+    if (!_beginInteractiveSeek(_InteractiveSeekSource.surface)) {
       return;
     }
+    _surfaceSeekStartPosition = playerController.playback.currentPosition;
+    _surfaceSeekCumulativeDx = 0;
+    playerController.panel.seekDirection = 0;
+    playerController.panel.showSeekTime = true;
+  }
+
+  void _updateSurfaceInteractiveSeek(
+    BuildContext context,
+    DragUpdateDetails details,
+  ) {
+    if (!playerController.seeking.hasActiveInteractiveSeek) {
+      return;
+    }
+    _surfaceSeekCumulativeDx += details.delta.dx;
+    final target = horizontalDragSeekTarget(
+      initialPosition: _surfaceSeekStartPosition,
+      videoDuration: playerController.playback.duration,
+      cumulativeDeltaX: _surfaceSeekCumulativeDx,
+      surfaceWidth: MediaQuery.sizeOf(context).width,
+    );
+    playerController.panel.seekDirection = interactiveSeekDirection(
+      initialPosition: _surfaceSeekStartPosition,
+      target: target,
+    );
+    if (playerController.seeking.updateInteractiveSeek(target)) {
+      _armInteractiveSeekRecovery();
+    }
+  }
+
+  void _finishSurfaceSeekHud() {
+    playerController.panel.showSeekTime = false;
+    playerController.panel.seekDirection = 0;
+    _surfaceSeekCumulativeDx = 0;
+  }
+
+  void _commitSurfaceInteractiveSeek() {
+    _finishSurfaceSeekHud();
+    if (_interactiveSeekSource == _InteractiveSeekSource.surface &&
+        playerController.seeking.hasActiveInteractiveSeek) {
+      unawaited(_commitInteractiveSeek());
+    }
+  }
+
+  void _cancelSurfaceInteractiveSeek() {
+    _finishSurfaceSeekHud();
+    if (_interactiveSeekSource == _InteractiveSeekSource.surface &&
+        playerController.seeking.hasActiveInteractiveSeek) {
+      unawaited(_cancelInteractiveSeek());
+    }
+  }
+
+  void _handleProgressBarPointerDown(int pointer) {
+    _progressBarPointer ??= pointer;
+  }
+
+  void _handleProgressBarPointerUp(int pointer) {
+    if (_progressBarPointer == pointer) {
+      _progressBarPointer = null;
+    }
+  }
+
+  void _handleProgressBarPointerCancel(int pointer) {
+    if (_progressBarPointer != pointer) {
+      return;
+    }
+    _progressBarPointer = null;
+    if (_interactiveSeekSource == _InteractiveSeekSource.progressBar) {
+      unawaited(_cancelInteractiveSeek());
+    }
+  }
+
+  void _clearInteractiveSeekUi({bool syncAudioService = false}) {
+    _interactiveSeekGeneration++;
+    _interactiveSeekRecoveryTimer?.cancel();
+    _interactiveSeekRecoveryTimer = null;
+    _progressBarPointer = null;
     _progressBarDragHold?.release();
     _progressBarDragHold = null;
-    if (completed) {
+    _interactiveSeekSource = null;
+    _interactiveSeekWasPlaying = false;
+    _finishSurfaceSeekHud();
+    if (syncAudioService) {
       _syncAudioServiceState();
     }
     _restartPlayerTimer();
+  }
+
+  void _abortInteractiveSeek({bool resumePlayback = true}) {
+    if (!playerController.seeking.hasActiveInteractiveSeek &&
+        _interactiveSeekSource == null) {
+      return;
+    }
+    final shouldResume = _interactiveSeekWasPlaying;
+    playerController.seeking.invalidateInteractiveSeek();
+    if (mounted) {
+      _clearInteractiveSeekUi();
+    }
+    if (shouldResume && resumePlayback) {
+      unawaited(
+        playerController.play(enableSync: false).catchError((_) {}),
+      );
+    }
+  }
+
+  void _updateSurfaceVerticalDrag(
+    BuildContext context,
+    DragUpdateDetails details,
+  ) {
+    if (!brightnessVolumeGesture) {
+      return;
+    }
+    final double totalWidth = MediaQuery.sizeOf(context).width;
+    final double totalHeight = MediaQuery.sizeOf(context).height;
+    final double tapPosition = details.localPosition.dx;
+    final double sectionWidth = totalWidth / 2;
+    final double delta = details.delta.dy;
+
+    if (tapPosition < sectionWidth) {
+      playerController.panel.brightnessSeeking = true;
+      _showBrightnessAdjustmentHud();
+      final double level = totalHeight * 2;
+      final double brightness =
+          playerController.panel.brightness - delta / level;
+      final double result = brightness.clamp(0.0, 1.0);
+      setBrightness(result);
+      playerController.panel.brightness = result;
+    } else {
+      _showVolumeAdjustmentHud();
+      if (!playerController.panel.volumeSeeking) {
+        playerController.panel.volumeSeeking = true;
+        playerController.playback.invalidatePreciseVolume();
+      }
+      final double baseVolume = playerController.playback.preciseVolume >= 0
+          ? playerController.playback.preciseVolume
+          : playerController.playback.volume;
+      final double level = totalHeight * 0.03;
+      final double volume = baseVolume - delta / level;
+      playerController.setVolumeDuringGesture(volume);
+    }
   }
 
   void _restartPlayerTimer() {
@@ -1283,6 +1515,11 @@ class _PlayerItemState extends State<PlayerItem>
   }
 
   @override
+  void onWindowBlur() {
+    _abortInteractiveSeek();
+  }
+
+  @override
   void onWindowRestore() {
     playerController.danmaku.canvasController.clear();
   }
@@ -1400,6 +1637,7 @@ class _PlayerItemState extends State<PlayerItem>
     hideTimer?.cancel();
     mouseScrollerTimer?.cancel();
     _adjustmentHudHideTimer?.cancel();
+    _interactiveSeekRecoveryTimer?.cancel();
     _panelVisibilityController.dispose();
     _screenshotFeedbackController.dispose();
     _disposePlayerMenu();
@@ -1411,322 +1649,508 @@ class _PlayerItemState extends State<PlayerItem>
     super.dispose();
   }
 
+  Map<Type, Action<Intent>> get _gamepadActions => <Type, Action<Intent>>{
+        GamepadActivateIntent: CallbackAction<GamepadActivateIntent>(
+          onInvoke: (_) {
+            _handleGamepadActivate();
+            return null;
+          },
+        ),
+        GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+          onInvoke: (intent) {
+            _handleGamepadNavigate(intent.direction);
+            return null;
+          },
+        ),
+        GamepadBackIntent: CallbackAction<GamepadBackIntent>(
+          onInvoke: (_) {
+            _handleGamepadBack();
+            return null;
+          },
+        ),
+        GamepadSecondaryActionIntent:
+            CallbackAction<GamepadSecondaryActionIntent>(
+          onInvoke: (_) {
+            handleDanmaku();
+            return null;
+          },
+        ),
+        GamepadContextActionIntent: CallbackAction<GamepadContextActionIntent>(
+          onInvoke: (_) {
+            if (playerController.panel.showVideoController) {
+              hideVideoController();
+            } else {
+              showVideoController();
+            }
+            return null;
+          },
+        ),
+        GamepadPreviousSectionIntent:
+            CallbackAction<GamepadPreviousSectionIntent>(
+          onInvoke: (_) {
+            _handleGamepadSeek(-1);
+            return null;
+          },
+        ),
+        GamepadNextSectionIntent: CallbackAction<GamepadNextSectionIntent>(
+          onInvoke: (_) {
+            _handleGamepadSeek(1);
+            return null;
+          },
+        ),
+        GamepadPreviousSecondarySectionIntent:
+            CallbackAction<GamepadPreviousSecondarySectionIntent>(
+          onInvoke: (_) {
+            handlePreNextEpisode('prev');
+            return null;
+          },
+        ),
+        GamepadNextSecondarySectionIntent:
+            CallbackAction<GamepadNextSecondarySectionIntent>(
+          onInvoke: (_) {
+            handlePreNextEpisode('next');
+            return null;
+          },
+        ),
+        GamepadMenuIntent: CallbackAction<GamepadMenuIntent>(
+          onInvoke: (_) {
+            unawaited(playerController.playOrPause());
+            showVideoController();
+            return null;
+          },
+        ),
+        GamepadViewIntent: CallbackAction<GamepadViewIntent>(
+          onInvoke: (_) {
+            widget.toggleMenu();
+            return null;
+          },
+        ),
+        GamepadLeftStickClickIntent:
+            CallbackAction<GamepadLeftStickClickIntent>(
+          onInvoke: (_) {
+            unawaited(handleShortcutVolumeChange('mute'));
+            return null;
+          },
+        ),
+        GamepadRightStickClickIntent:
+            CallbackAction<GamepadRightStickClickIntent>(
+          onInvoke: (_) {
+            _toggleGamepadPlaybackSpeed();
+            return null;
+          },
+        ),
+      };
+
+  // A confirms the control the stick selected. It is never bound to a media
+  // action directly (no fullscreen or play/pause shortcut); when nothing is
+  // selected yet it reveals the controls so the next press can confirm.
+  void _handleGamepadActivate() {
+    if (_playerPanelHasFocus) {
+      final focusContext = FocusManager.instance.primaryFocus?.context;
+      if (focusContext != null) {
+        Actions.maybeInvoke(focusContext, const ActivateIntent());
+      }
+      return;
+    }
+    _focusPlayerPanel();
+  }
+
+  void _handleGamepadNavigate(TraversalDirection direction) {
+    if (playerController.panel.lockPanel) {
+      return;
+    }
+    // The episode side tab sits in its own focus scope on the right. A right
+    // press moves into it before the panel claims the direction, so the list
+    // is reachable without cycling through every player control first.
+    if (widget.isSideTabOpen() &&
+        direction == TraversalDirection.right &&
+        !_playerPanelHasFocus) {
+      focusFirstGamepadControl(widget.sideTabScopeNode);
+      return;
+    }
+    // Navigation only moves between on-screen buttons. When the controls are
+    // hidden the stick reveals them and focuses the first button instead of
+    // seeking or changing the volume.
+    if (!playerController.panel.showVideoController || !_playerPanelHasFocus) {
+      _focusPlayerPanel();
+      return;
+    }
+    if (!invokeGamepadControlDirection(direction)) {
+      final focused = FocusManager.instance.primaryFocus;
+      final moved = focused?.focusInDirection(direction) ?? false;
+      if (!moved && direction == TraversalDirection.up) {
+        // Directional traversal is confined to the nearest focus scope,
+        // so focus at the top edge of the panel can never reach the top
+        // bar on its own; hand it over explicitly.
+        focusFirstGamepadControl(widget.topBarScopeNode);
+      } else if (!moved &&
+          direction == TraversalDirection.right &&
+          widget.isSideTabOpen()) {
+        focusFirstGamepadControl(widget.sideTabScopeNode);
+      }
+    }
+  }
+
+  void _focusPlayerPanel() {
+    showVideoController(restartHideTimer: false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // Validate the remembered child instead of blindly calling nextFocus,
+      // which can silently do nothing after a control was rebuilt away.
+      if (!focusFirstGamepadControl(widget.playerPanelScopeNode)) {
+        widget.keyboardFocus.requestFocus();
+      }
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  void _handleGamepadBack() {
+    // The episode side tab is an overlay: dismiss it first, then the player
+    // controls, then leave the page. This mirrors the video page level B.
+    if (widget.isSideTabOpen()) {
+      widget.onCloseSideTab();
+      return;
+    }
+    if (_playerPanelHasFocus || playerController.panel.showVideoController) {
+      widget.keyboardFocus.requestFocus();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          hideVideoController();
+        }
+      });
+      return;
+    }
+    widget.onBackPressed(context);
+  }
+
+  void _handleGamepadSeek(int direction) {
+    final seconds = playerController.playback.arrowKeySkipTime * direction;
+    unawaited(_seekWithPlayerTimer(
+      () => playerController.seekBy(Duration(seconds: seconds)),
+    ));
+  }
+
+  void _toggleGamepadPlaybackSpeed() {
+    final current = playerController.playback.playerSpeed;
+    final target =
+        (current - longPressPlaySpeed).abs() < 0.01 ? 1.0 : longPressPlaySpeed;
+    unawaited(setPlaybackSpeed(target));
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Observer(
-      builder: (context) {
-        return ClipRect(
-          child: Container(
-            color: Colors.black,
-            child: MouseRegion(
-              cursor: (videoPageController.isFullscreen &&
-                      !playerController.panel.showVideoController)
-                  ? SystemMouseCursors.none
-                  : SystemMouseCursors.basic,
-              onHover: (PointerEvent pointerEvent) {
-                // Android taps can emit hover events.
-                if (isDesktop()) {
-                  if (pointerEvent.position.dy > 50 &&
-                      pointerEvent.position.dy <
-                          MediaQuery.of(context).size.height - 70) {
-                    showVideoController();
-                  } else {
-                    if (!playerController.panel.showVideoController) {
-                      _panelVisibilityController.forward();
-                      playerController.panel.showVideoController = true;
+    return Actions(
+      actions: _gamepadActions,
+      child: Focus(
+        focusNode: widget.keyboardFocus,
+        autofocus: true,
+        child: Observer(
+          builder: (context) {
+            final enableSurfaceVerticalDrag =
+                shouldEnablePlayerSurfaceVerticalDrag(isDesktop: isDesktop());
+            return ClipRect(
+              child: Container(
+                color: Colors.black,
+                child: MouseRegion(
+                  cursor: (videoPageController.isFullscreen &&
+                          !playerController.panel.showVideoController)
+                      ? SystemMouseCursors.none
+                      : SystemMouseCursors.basic,
+                  onHover: (PointerEvent pointerEvent) {
+                    // Android taps can emit hover events.
+                    if (isDesktop()) {
+                      if (pointerEvent.position.dy > 50 &&
+                          pointerEvent.position.dy <
+                              MediaQuery.of(context).size.height - 70) {
+                        showVideoController();
+                      } else {
+                        if (!playerController.panel.showVideoController) {
+                          _panelVisibilityController.forward();
+                          playerController.panel.showVideoController = true;
+                        }
+                      }
                     }
-                  }
-                }
-              },
-              child: Listener(
-                onPointerSignal: (pointerSignal) {
-                  if (pointerSignal is PointerScrollEvent) {
-                    _handleMouseScroller();
-                    final scrollDelta = pointerSignal.scrollDelta;
-                    final double volume =
-                        playerController.playback.volume - scrollDelta.dy / 60;
-                    playerController.setVolume(volume);
-                  }
-                },
-                child: SizedBox(
-                  height: videoPageController.isFullscreen ||
-                          videoPageController.isPip
-                      ? (MediaQuery.of(context).size.height)
-                      : (MediaQuery.of(context).size.width * 9.0 / (16.0)),
-                  width: MediaQuery.of(context).size.width,
-                  child: Stack(alignment: Alignment.center, children: [
-                    PlayerKeyboardShortcuts(
-                      focusScopeNode: widget.keyboardFocus,
-                      actions: keyboardActions,
-                      longPressActions: keyboardLongPressActions,
-                      isBlocked: () => _openPlayerMenuCount > 0,
-                    ),
-                    Center(
-                      key: _videoSurfaceKey,
-                      child: PlayerItemSurface(
-                        playerController: playerController,
-                      ),
-                    ),
-                    (playerController.playback.isBuffering ||
-                            videoPageController.loading)
-                        ? const Positioned.fill(
-                            child: Center(
-                              child: CircularProgressIndicator(),
-                            ),
-                          )
-                        : Container(),
-                    GestureDetector(
-                      onTapDown: (details) {
-                        _lastTapPointerKind = details.kind;
-                      },
-                      onTap: () {
-                        _handleTap(_lastTapPointerKind);
-                        _lastTapPointerKind = null;
-                      },
-                      onTapCancel: () {
-                        _lastTapPointerKind = null;
-                      },
-                      onDoubleTapDown: (playerController.panel.lockPanel)
-                          ? null
-                          : (details) {
-                              _lastDoubleTapPointerKind = details.kind;
-                            },
-                      onDoubleTap: (playerController.panel.lockPanel)
-                          ? null
-                          : () {
-                              _handleDoubleTap(
-                                _lastDoubleTapPointerKind ??
-                                    _lastTapPointerKind,
-                              );
-                              _lastDoubleTapPointerKind = null;
-                              _lastTapPointerKind = null;
-                            },
-                      onLongPressStart: (_) {
-                        if (playerController.panel.lockPanel) {
-                          return;
-                        }
-                        setState(() {
-                          playerController.panel.showPlaySpeed = true;
-                        });
-                        lastPlayerSpeed = playerController.playback.playerSpeed;
-                        setPlaybackSpeed(longPressPlaySpeed);
-                      },
-                      onLongPressEnd: (_) {
-                        if (playerController.panel.lockPanel) {
-                          return;
-                        }
-                        setState(() {
-                          playerController.panel.showPlaySpeed = false;
-                        });
-                        setPlaybackSpeed(lastPlayerSpeed);
-                      },
-                      child: Container(
-                        color: Colors.transparent,
-                        width: double.infinity,
-                        height: double.infinity,
-                      ),
-                    ),
-                    Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
+                  },
+                  child: Listener(
+                    onPointerSignal: (pointerSignal) {
+                      if (pointerSignal is PointerScrollEvent) {
+                        _handleMouseScroller();
+                        final scrollDelta = pointerSignal.scrollDelta;
+                        final double volume = playerController.playback.volume -
+                            scrollDelta.dy / 60;
+                        playerController.setVolume(volume);
+                      }
+                    },
+                    child: SizedBox(
                       height: videoPageController.isFullscreen ||
                               videoPageController.isPip
-                          ? MediaQuery.sizeOf(context).height
-                          : (MediaQuery.sizeOf(context).width * 9 / 16),
-                      child: DanmakuScreen(
-                        key: _danmuKey,
-                        createdController: (DanmakuController e) {
-                          playerController.danmaku.canvasController = e;
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
-                            playerController.updateDanmakuSpeed();
-                          });
-                        },
-                        option: DanmakuOption(
-                          hideTop: _hideTop,
-                          hideScroll: _hideScroll,
-                          hideBottom: _hideBottom,
-                          area: _danmakuArea,
-                          opacity: _opacity,
-                          fontSize: _fontSize,
-                          // Speed scaling is applied after canvas creation.
-                          duration: _danmakuDuration,
-                          lineHeight: _danmakuLineHeight,
-                          strokeWidth: _border ? _danmakuBorderSize : 0.0,
-                          fontWeight: _danmakuFontWeight,
-                          massiveMode: _massiveMode,
-                          fontFamily: _danmakuUseSystemFont
-                              ? null
-                              : customAppFontFamily,
+                          ? (MediaQuery.of(context).size.height)
+                          : (MediaQuery.of(context).size.width * 9.0 / (16.0)),
+                      width: MediaQuery.of(context).size.width,
+                      child: Stack(alignment: Alignment.center, children: [
+                        PlayerKeyboardShortcuts(
+                          focusScopeNode: widget.keyboardFocus,
+                          actions: keyboardActions,
+                          longPressActions: keyboardLongPressActions,
+                          isBlocked: () =>
+                              _openPlayerMenuCount > 0 || _playerPanelHasFocus,
                         ),
-                      ),
-                    ),
-                    Positioned.fill(
-                      child: PlayerScreenshotFeedbackOverlay(
-                        animation: _screenshotFeedbackAnimation,
-                      ),
-                    ),
-                    (Platform.isAndroid &&
-                            (videoPageController.isPip || _pipEnterRequested))
-                        ? const SizedBox.shrink()
-                        : (_needsFullPanel(context))
-                            ? PlayerItemPanel(
-                                playerController: playerController,
-                                videoPageController: videoPageController,
-                                onBackPressed: widget.onBackPressed,
-                                setPlaybackSpeed: setPlaybackSpeed,
-                                showDanmakuSwitch: showDanmakuSwitch,
-                                toggleMenu: widget.toggleMenu,
-                                handleFullscreen: handleFullscreen,
-                                enterAndroidPictureInPicture:
-                                    enterAndroidPictureInPicture,
-                                handleProgressBarDragStart:
-                                    handleProgressBarDragStart,
-                                handleProgressBarSeek: handleProgressBarSeek,
-                                handleSuperResolutionChange:
-                                    handleSuperResolutionChange,
-                                handlePreNextEpisode: handlePreNextEpisode,
-                                panelVisibilityController:
-                                    _panelVisibilityController,
-                                keyboardFocus: widget.keyboardFocus,
-                                acquirePlayerPanelHold: acquirePlayerPanelHold,
-                                onMenuVisibilityChanged:
-                                    _handlePlayerMenuVisibilityChanged,
-                                handleDanmaku: handleDanmaku,
-                                showVideoInfo: showVideoInfo,
-                                showSyncPlayPanel: showSyncPlayPanel,
-                                pauseForTimedShutdown:
-                                    widget.pauseForTimedShutdown,
-                                disableAnimations: widget.disableAnimations,
-                                handleScreenShot: handleScreenshot,
-                                skipOP: skipOP,
+                        Center(
+                          key: _videoSurfaceKey,
+                          child: PlayerItemSurface(
+                            playerController: playerController,
+                          ),
+                        ),
+                        (playerController.playback.isBuffering ||
+                                videoPageController.loading)
+                            ? const Positioned.fill(
+                                child: Center(
+                                  child: CircularProgressIndicator(),
+                                ),
                               )
-                            : SmallestPlayerItemPanel(
-                                playerController: playerController,
-                                videoPageController: videoPageController,
-                                onBackPressed: widget.onBackPressed,
-                                setPlaybackSpeed: setPlaybackSpeed,
-                                showDanmakuSwitch: showDanmakuSwitch,
-                                handleFullscreen: handleFullscreen,
-                                enterAndroidPictureInPicture:
-                                    enterAndroidPictureInPicture,
-                                handleProgressBarDragStart:
-                                    handleProgressBarDragStart,
-                                handleProgressBarSeek: handleProgressBarSeek,
-                                handleSuperResolutionChange:
-                                    handleSuperResolutionChange,
-                                panelVisibilityController:
-                                    _panelVisibilityController,
-                                acquirePlayerPanelHold: acquirePlayerPanelHold,
-                                onMenuVisibilityChanged:
-                                    _handlePlayerMenuVisibilityChanged,
-                                handleDanmaku: handleDanmaku,
-                                showVideoInfo: showVideoInfo,
-                                showSyncPlayPanel: showSyncPlayPanel,
-                                pauseForTimedShutdown:
-                                    widget.pauseForTimedShutdown,
-                                disableAnimations: widget.disableAnimations,
-                                skipOP: skipOP,
-                              ),
-                    Positioned.fill(
-                      left: 16,
-                      top: 25,
-                      right: 15,
-                      bottom: 15,
-                      child: (isDesktop() || playerController.panel.lockPanel)
-                          ? Container()
-                          : GestureDetector(
-                              onHorizontalDragStart: (_) {
-                                playerController.panel.seekDirection = 0;
-                                _beginInteractiveSeek();
-                              },
-                              onHorizontalDragUpdate:
-                                  (DragUpdateDetails details) {
-                                playerController.panel.showSeekTime = true;
-                                if (details.delta.dx != 0) {
-                                  playerController.panel.seekDirection =
-                                      details.delta.dx > 0 ? 1 : -1;
-                                }
-                                final double scale =
-                                    180000 / MediaQuery.sizeOf(context).width;
-                                playerController.seeking.updateInteractiveSeek(
-                                  playerController.playback.currentPosition +
-                                      Duration(
-                                        milliseconds:
-                                            (details.delta.dx * scale).round(),
-                                      ),
-                                );
-                              },
-                              onHorizontalDragEnd: (_) {
-                                playerController.panel.showSeekTime = false;
-                                playerController.panel.seekDirection = 0;
-                                if (playerController
-                                    .seeking.hasActiveInteractiveSeek) {
-                                  unawaited(
-                                    _commitInteractiveSeek(),
+                            : Container(),
+                        GestureDetector(
+                          onTapDown: (details) {
+                            _lastTapPointerKind = details.kind;
+                          },
+                          onTap: () {
+                            _handleTap(_lastTapPointerKind);
+                            _lastTapPointerKind = null;
+                          },
+                          onTapCancel: () {
+                            _lastTapPointerKind = null;
+                          },
+                          onDoubleTapDown: (playerController.panel.lockPanel)
+                              ? null
+                              : (details) {
+                                  _lastDoubleTapPointerKind = details.kind;
+                                },
+                          onDoubleTap: (playerController.panel.lockPanel)
+                              ? null
+                              : () {
+                                  _handleDoubleTap(
+                                    _lastDoubleTapPointerKind ??
+                                        _lastTapPointerKind,
                                   );
-                                }
-                              },
-                              onVerticalDragUpdate:
-                                  (DragUpdateDetails details) async {
-                                if (!brightnessVolumeGesture) {
-                                  return;
-                                }
-                                final double totalWidth =
-                                    MediaQuery.sizeOf(context).width;
-                                final double totalHeight =
-                                    MediaQuery.sizeOf(context).height;
-                                final double tapPosition =
-                                    details.localPosition.dx;
-                                final double sectionWidth = totalWidth / 2;
-                                final double delta = details.delta.dy;
-
-                                if (tapPosition < sectionWidth) {
-                                  playerController.panel.brightnessSeeking =
-                                      true;
-                                  _showBrightnessAdjustmentHud();
-                                  final double level = (totalHeight) * 2;
-                                  final double brightness =
-                                      playerController.panel.brightness -
-                                          delta / level;
-                                  final double result =
-                                      brightness.clamp(0.0, 1.0);
-                                  setBrightness(result);
-                                  playerController.panel.brightness = result;
-                                } else {
-                                  _showVolumeAdjustmentHud();
-                                  if (!playerController.panel.volumeSeeking) {
-                                    playerController.panel.volumeSeeking = true;
-                                    playerController.playback
-                                        .invalidatePreciseVolume();
-                                  }
-                                  final double baseVolume = playerController
-                                              .playback.preciseVolume >=
-                                          0
-                                      ? playerController.playback.preciseVolume
-                                      : playerController.playback.volume;
-                                  final double level = (totalHeight) * 0.03;
-                                  final double volume =
-                                      baseVolume - delta / level;
-                                  playerController
-                                      .setVolumeDuringGesture(volume);
-                                }
-                              },
-                              onVerticalDragEnd: (_) {
-                                _finishAdjustmentGesture();
-                              },
-                              onVerticalDragCancel: () {
-                                _finishAdjustmentGesture();
-                              },
+                                  _lastDoubleTapPointerKind = null;
+                                  _lastTapPointerKind = null;
+                                },
+                          onLongPressStart: (_) {
+                            if (playerController.panel.lockPanel) {
+                              return;
+                            }
+                            setState(() {
+                              playerController.panel.showPlaySpeed = true;
+                            });
+                            lastPlayerSpeed =
+                                playerController.playback.playerSpeed;
+                            setPlaybackSpeed(longPressPlaySpeed);
+                          },
+                          onLongPressEnd: (_) {
+                            if (playerController.panel.lockPanel) {
+                              return;
+                            }
+                            setState(() {
+                              playerController.panel.showPlaySpeed = false;
+                            });
+                            setPlaybackSpeed(lastPlayerSpeed);
+                          },
+                          child: Container(
+                            color: Colors.transparent,
+                            width: double.infinity,
+                            height: double.infinity,
+                          ),
+                        ),
+                        Positioned(
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          height: videoPageController.isFullscreen ||
+                                  videoPageController.isPip
+                              ? MediaQuery.sizeOf(context).height
+                              : (MediaQuery.sizeOf(context).width * 9 / 16),
+                          child: DanmakuScreen(
+                            key: _danmuKey,
+                            createdController: (DanmakuController e) {
+                              playerController.danmaku.canvasController = e;
+                              WidgetsBinding.instance.addPostFrameCallback((_) {
+                                playerController.updateDanmakuSpeed();
+                              });
+                            },
+                            option: DanmakuOption(
+                              hideTop: _hideTop,
+                              hideScroll: _hideScroll,
+                              hideBottom: _hideBottom,
+                              area: _danmakuArea,
+                              opacity: _opacity,
+                              fontSize: _fontSize,
+                              // Speed scaling is applied after canvas creation.
+                              duration: _danmakuDuration,
+                              lineHeight: _danmakuLineHeight,
+                              strokeWidth: _border ? _danmakuBorderSize : 0.0,
+                              fontWeight: _danmakuFontWeight,
+                              massiveMode: _massiveMode,
+                              fontFamily: _danmakuUseSystemFont
+                                  ? null
+                                  : customAppFontFamily,
                             ),
+                          ),
+                        ),
+                        Positioned.fill(
+                          child: PlayerScreenshotFeedbackOverlay(
+                            animation: _screenshotFeedbackAnimation,
+                          ),
+                        ),
+                        Positioned.fill(
+                          left: 16,
+                          top: 25,
+                          right: 15,
+                          bottom: 15,
+                          child: !shouldEnablePlayerSurfaceSeek(
+                            isDesktop: isDesktop(),
+                            isLinux: Platform.isLinux,
+                            panelLocked: playerController.panel.lockPanel,
+                            videoDuration: playerController.playback.duration,
+                          )
+                              ? Container()
+                              : GestureDetector(
+                                  supportedDevices: playerSurfaceDragDevices(
+                                    isLinux: Platform.isLinux,
+                                  ),
+                                  onHorizontalDragStart: (_) =>
+                                      _beginSurfaceInteractiveSeek(),
+                                  onHorizontalDragUpdate:
+                                      (DragUpdateDetails details) {
+                                    _updateSurfaceInteractiveSeek(
+                                        context, details);
+                                  },
+                                  onHorizontalDragEnd: (_) =>
+                                      _commitSurfaceInteractiveSeek(),
+                                  onHorizontalDragCancel:
+                                      _cancelSurfaceInteractiveSeek,
+                                  onVerticalDragUpdate:
+                                      enableSurfaceVerticalDrag
+                                          ? (details) =>
+                                              _updateSurfaceVerticalDrag(
+                                                context,
+                                                details,
+                                              )
+                                          : null,
+                                  onVerticalDragEnd: enableSurfaceVerticalDrag
+                                      ? (_) => _finishAdjustmentGesture()
+                                      : null,
+                                  onVerticalDragCancel:
+                                      enableSurfaceVerticalDrag
+                                          ? _finishAdjustmentGesture
+                                          : null,
+                                ),
+                        ),
+                        (Platform.isAndroid &&
+                                (videoPageController.isPip ||
+                                    _pipEnterRequested))
+                            ? const SizedBox.shrink()
+                            : PlayerPanelHoldFocus(
+                                acquirePlayerPanelHold: acquirePlayerPanelHold,
+                                onFocusChanged: (hasFocus) {
+                                  _playerPanelHasFocus = hasFocus;
+                                },
+                                child: FocusScope(
+                                  node: widget.playerPanelScopeNode,
+                                  child: _needsFullPanel(context)
+                                      ? PlayerItemPanel(
+                                          playerController: playerController,
+                                          videoPageController:
+                                              videoPageController,
+                                          onBackPressed: widget.onBackPressed,
+                                          setPlaybackSpeed: setPlaybackSpeed,
+                                          showDanmakuSwitch: showDanmakuSwitch,
+                                          toggleMenu: widget.toggleMenu,
+                                          handleFullscreen: handleFullscreen,
+                                          enterAndroidPictureInPicture:
+                                              enterAndroidPictureInPicture,
+                                          handleProgressBarDragStart:
+                                              handleProgressBarDragStart,
+                                          handleProgressBarPointerDown:
+                                              _handleProgressBarPointerDown,
+                                          handleProgressBarPointerUp:
+                                              _handleProgressBarPointerUp,
+                                          handleProgressBarPointerCancel:
+                                              _handleProgressBarPointerCancel,
+                                          handleProgressBarDragUpdate:
+                                              handleProgressBarDragUpdate,
+                                          handleProgressBarSeek:
+                                              handleProgressBarSeek,
+                                          handleSuperResolutionChange:
+                                              handleSuperResolutionChange,
+                                          handlePreNextEpisode:
+                                              handlePreNextEpisode,
+                                          panelVisibilityController:
+                                              _panelVisibilityController,
+                                          keyboardFocus: widget.keyboardFocus,
+                                          acquirePlayerPanelHold:
+                                              acquirePlayerPanelHold,
+                                          onMenuVisibilityChanged:
+                                              _handlePlayerMenuVisibilityChanged,
+                                          handleDanmaku: handleDanmaku,
+                                          showVideoInfo: showVideoInfo,
+                                          showSyncPlayPanel: showSyncPlayPanel,
+                                          pauseForTimedShutdown:
+                                              widget.pauseForTimedShutdown,
+                                          disableAnimations:
+                                              widget.disableAnimations,
+                                          handleScreenShot: handleScreenshot,
+                                          skipOP: skipOP,
+                                        )
+                                      : SmallestPlayerItemPanel(
+                                          playerController: playerController,
+                                          videoPageController:
+                                              videoPageController,
+                                          onBackPressed: widget.onBackPressed,
+                                          setPlaybackSpeed: setPlaybackSpeed,
+                                          showDanmakuSwitch: showDanmakuSwitch,
+                                          handleFullscreen: handleFullscreen,
+                                          enterAndroidPictureInPicture:
+                                              enterAndroidPictureInPicture,
+                                          handleProgressBarDragStart:
+                                              handleProgressBarDragStart,
+                                          handleProgressBarPointerDown:
+                                              _handleProgressBarPointerDown,
+                                          handleProgressBarPointerUp:
+                                              _handleProgressBarPointerUp,
+                                          handleProgressBarPointerCancel:
+                                              _handleProgressBarPointerCancel,
+                                          handleProgressBarDragUpdate:
+                                              handleProgressBarDragUpdate,
+                                          handleProgressBarSeek:
+                                              handleProgressBarSeek,
+                                          handleSuperResolutionChange:
+                                              handleSuperResolutionChange,
+                                          panelVisibilityController:
+                                              _panelVisibilityController,
+                                          acquirePlayerPanelHold:
+                                              acquirePlayerPanelHold,
+                                          onMenuVisibilityChanged:
+                                              _handlePlayerMenuVisibilityChanged,
+                                          handleDanmaku: handleDanmaku,
+                                          showVideoInfo: showVideoInfo,
+                                          showSyncPlayPanel: showSyncPlayPanel,
+                                          pauseForTimedShutdown:
+                                              widget.pauseForTimedShutdown,
+                                          disableAnimations:
+                                              widget.disableAnimations,
+                                          skipOP: skipOP,
+                                        ),
+                                ),
+                              ),
+                      ]),
                     ),
-                  ]),
+                  ),
                 ),
               ),
-            ),
-          ),
-        );
-      },
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/player/player_item_panel.dart
+++ b/lib/pages/player/player_item_panel.dart
@@ -40,6 +40,10 @@ class PlayerItemPanel extends StatefulWidget {
     required this.handleScreenShot,
     required this.handlePreNextEpisode,
     required this.handleProgressBarDragStart,
+    required this.handleProgressBarPointerDown,
+    required this.handleProgressBarPointerUp,
+    required this.handleProgressBarPointerCancel,
+    required this.handleProgressBarDragUpdate,
     required this.handleProgressBarSeek,
     required this.handleSuperResolutionChange,
     required this.panelVisibilityController,
@@ -65,6 +69,10 @@ class PlayerItemPanel extends StatefulWidget {
   final Future<void> Function() enterAndroidPictureInPicture;
   final void Function() handleScreenShot;
   final VoidCallback handleProgressBarDragStart;
+  final ValueChanged<int> handleProgressBarPointerDown;
+  final ValueChanged<int> handleProgressBarPointerUp;
+  final ValueChanged<int> handleProgressBarPointerCancel;
+  final ValueChanged<Duration> handleProgressBarDragUpdate;
   final Future<void> Function(Duration duration) handleProgressBarSeek;
   final Future<void> Function(SuperResolutionMode mode)
       handleSuperResolutionChange;
@@ -93,7 +101,8 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
   late final PlayerController playerController;
   final DownloadController downloadController = inject<DownloadController>();
   final TextEditingController textController = TextEditingController();
-  final FocusNode textFieldFocus = FocusNode();
+  final FocusNode textFieldFocus =
+      FocusNode(skipTraversal: true, debugLabel: 'Danmaku text field');
   PlayerPanelHold? _danmakuTextFieldHold;
 
   String? cachedSvgString;
@@ -632,26 +641,34 @@ class _PlayerItemPanelState extends State<PlayerItemPanel> {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Observer(builder: (context) {
-                return ProgressBar(
-                  thumbRadius: 8,
-                  thumbGlowRadius: 18,
-                  timeLabelLocation: isTablet()
-                      ? TimeLabelLocation.sides
-                      : TimeLabelLocation.none,
-                  timeLabelTextStyle: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 12.0,
-                    fontFeatures: [
-                      FontFeature.tabularFigures(),
-                    ],
+                return Listener(
+                  onPointerDown: (event) =>
+                      widget.handleProgressBarPointerDown(event.pointer),
+                  onPointerUp: (event) =>
+                      widget.handleProgressBarPointerUp(event.pointer),
+                  onPointerCancel: (event) =>
+                      widget.handleProgressBarPointerCancel(event.pointer),
+                  child: ProgressBar(
+                    thumbRadius: 8,
+                    thumbGlowRadius: 18,
+                    timeLabelLocation: isTablet()
+                        ? TimeLabelLocation.sides
+                        : TimeLabelLocation.none,
+                    timeLabelTextStyle: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12.0,
+                      fontFeatures: [
+                        FontFeature.tabularFigures(),
+                      ],
+                    ),
+                    progress: playerController.playback.currentPosition,
+                    buffered: playerController.playback.buffer,
+                    total: playerController.playback.duration,
+                    onSeek: widget.handleProgressBarSeek,
+                    onDragStart: (_) => widget.handleProgressBarDragStart(),
+                    onDragUpdate: (details) =>
+                        widget.handleProgressBarDragUpdate(details.timeStamp),
                   ),
-                  progress: playerController.playback.currentPosition,
-                  buffered: playerController.playback.buffer,
-                  total: playerController.playback.duration,
-                  onSeek: widget.handleProgressBarSeek,
-                  onDragStart: (_) => widget.handleProgressBarDragStart(),
-                  onDragUpdate: (details) => playerController.seeking
-                      .updateInteractiveSeek(details.timeStamp),
                 );
               }),
             ),

--- a/lib/pages/player/player_panel_hold.dart
+++ b/lib/pages/player/player_panel_hold.dart
@@ -43,6 +43,59 @@ class PlayerPanelHoldMouseRegion extends StatefulWidget {
       _PlayerPanelHoldMouseRegionState();
 }
 
+/// Keeps the controls visible while a keyboard or gamepad focus is inside.
+class PlayerPanelHoldFocus extends StatefulWidget {
+  const PlayerPanelHoldFocus({
+    super.key,
+    required this.acquirePlayerPanelHold,
+    required this.onFocusChanged,
+    required this.child,
+  });
+
+  final PlayerPanelHold Function() acquirePlayerPanelHold;
+  final ValueChanged<bool> onFocusChanged;
+  final Widget child;
+
+  @override
+  State<PlayerPanelHoldFocus> createState() => _PlayerPanelHoldFocusState();
+}
+
+class _PlayerPanelHoldFocusState extends State<PlayerPanelHoldFocus> {
+  PlayerPanelHold? _hold;
+
+  @override
+  void dispose() {
+    _releaseHold();
+    super.dispose();
+  }
+
+  void _handleFocusChanged(bool hasFocus) {
+    widget.onFocusChanged(hasFocus);
+    if (hasFocus) {
+      if (_hold?.isReleased != false) {
+        _hold = widget.acquirePlayerPanelHold();
+      }
+      return;
+    }
+    _releaseHold();
+  }
+
+  void _releaseHold() {
+    _hold?.release();
+    _hold = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onFocusChange: _handleFocusChanged,
+      child: widget.child,
+    );
+  }
+}
+
 class _PlayerPanelHoldMouseRegionState
     extends State<PlayerPanelHoldMouseRegion> {
   PlayerPanelHold? _hold;

--- a/lib/pages/player/player_pointer_interaction.dart
+++ b/lib/pages/player/player_pointer_interaction.dart
@@ -1,9 +1,64 @@
 import 'package:flutter/gestures.dart';
 
+const Set<PointerDeviceKind> touchLikePointerKinds = <PointerDeviceKind>{
+  PointerDeviceKind.touch,
+  PointerDeviceKind.stylus,
+  PointerDeviceKind.invertedStylus,
+};
+
 bool isTouchLikePointer(PointerDeviceKind? pointerKind) {
-  return pointerKind == PointerDeviceKind.touch ||
-      pointerKind == PointerDeviceKind.stylus ||
-      pointerKind == PointerDeviceKind.invertedStylus;
+  return touchLikePointerKinds.contains(pointerKind);
+}
+
+Set<PointerDeviceKind>? playerSurfaceDragDevices({required bool isLinux}) {
+  return isLinux ? touchLikePointerKinds : null;
+}
+
+bool shouldEnablePlayerSurfaceSeek({
+  required bool isDesktop,
+  required bool isLinux,
+  required bool panelLocked,
+  required Duration videoDuration,
+}) {
+  return !panelLocked &&
+      videoDuration > Duration.zero &&
+      (!isDesktop || isLinux);
+}
+
+bool shouldEnablePlayerSurfaceVerticalDrag({required bool isDesktop}) {
+  return !isDesktop;
+}
+
+Duration horizontalDragSeekTarget({
+  required Duration initialPosition,
+  required Duration videoDuration,
+  required double cumulativeDeltaX,
+  required double surfaceWidth,
+  Duration maximumSpan = const Duration(seconds: 120),
+}) {
+  if (videoDuration <= Duration.zero ||
+      surfaceWidth <= 0 ||
+      !surfaceWidth.isFinite ||
+      !cumulativeDeltaX.isFinite) {
+    return initialPosition;
+  }
+
+  final span = videoDuration < maximumSpan ? videoDuration : maximumSpan;
+  final offsetMilliseconds =
+      (span.inMilliseconds * cumulativeDeltaX / surfaceWidth).round();
+  final targetMilliseconds =
+      initialPosition.inMilliseconds + offsetMilliseconds;
+  return Duration(
+    milliseconds:
+        targetMilliseconds.clamp(0, videoDuration.inMilliseconds).toInt(),
+  );
+}
+
+int interactiveSeekDirection({
+  required Duration initialPosition,
+  required Duration target,
+}) {
+  return target.compareTo(initialPosition);
 }
 
 bool shouldToggleControllerOnPrimaryTap({

--- a/lib/pages/player/smallest_player_item_panel.dart
+++ b/lib/pages/player/smallest_player_item_panel.dart
@@ -33,6 +33,10 @@ class SmallestPlayerItemPanel extends StatefulWidget {
     required this.handleFullscreen,
     required this.enterAndroidPictureInPicture,
     required this.handleProgressBarDragStart,
+    required this.handleProgressBarPointerDown,
+    required this.handleProgressBarPointerUp,
+    required this.handleProgressBarPointerCancel,
+    required this.handleProgressBarDragUpdate,
     required this.handleProgressBarSeek,
     required this.handleSuperResolutionChange,
     required this.panelVisibilityController,
@@ -56,6 +60,10 @@ class SmallestPlayerItemPanel extends StatefulWidget {
   final void Function() handleFullscreen;
   final Future<void> Function() enterAndroidPictureInPicture;
   final VoidCallback handleProgressBarDragStart;
+  final ValueChanged<int> handleProgressBarPointerDown;
+  final ValueChanged<int> handleProgressBarPointerUp;
+  final ValueChanged<int> handleProgressBarPointerCancel;
+  final ValueChanged<Duration> handleProgressBarDragUpdate;
   final Future<void> Function(Duration duration) handleProgressBarSeek;
   final Future<void> Function(SuperResolutionMode mode)
       handleSuperResolutionChange;
@@ -423,17 +431,25 @@ class _SmallestPlayerItemPanelState extends State<SmallestPlayerItemPanel> {
         // tick rebuilds only the bar and time text, not the whole bottom bar.
         Expanded(
           child: Observer(builder: (context) {
-            return ProgressBar(
-              thumbRadius: 8,
-              thumbGlowRadius: 18,
-              timeLabelLocation: TimeLabelLocation.none,
-              progress: playerController.playback.currentPosition,
-              buffered: playerController.playback.buffer,
-              total: playerController.playback.duration,
-              onSeek: widget.handleProgressBarSeek,
-              onDragStart: (_) => widget.handleProgressBarDragStart(),
-              onDragUpdate: (details) => playerController.seeking
-                  .updateInteractiveSeek(details.timeStamp),
+            return Listener(
+              onPointerDown: (event) =>
+                  widget.handleProgressBarPointerDown(event.pointer),
+              onPointerUp: (event) =>
+                  widget.handleProgressBarPointerUp(event.pointer),
+              onPointerCancel: (event) =>
+                  widget.handleProgressBarPointerCancel(event.pointer),
+              child: ProgressBar(
+                thumbRadius: 8,
+                thumbGlowRadius: 18,
+                timeLabelLocation: TimeLabelLocation.none,
+                progress: playerController.playback.currentPosition,
+                buffered: playerController.playback.buffer,
+                total: playerController.playback.duration,
+                onSeek: widget.handleProgressBarSeek,
+                onDragStart: (_) => widget.handleProgressBarDragStart(),
+                onDragUpdate: (details) =>
+                    widget.handleProgressBarDragUpdate(details.timeStamp),
+              ),
             );
           }),
         ),

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -138,6 +138,7 @@ class _SearchPageState extends State<SearchPage> {
       builder: (context, value, child) => SearchBar(
         controller: _input,
         focusNode: _inputFocus,
+        autoFocus: true,
         hintText: '搜索番剧名称',
         textInputAction: TextInputAction.search,
         constraints: const BoxConstraints(minHeight: 64),

--- a/lib/pages/settings/keyboard_settings.dart
+++ b/lib/pages/settings/keyboard_settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/settings/settings_detail_scaffold.dart';
 import 'package:kazumi/bean/widget/content_section.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
 import 'package:kazumi/services/storage/storage.dart';
 import 'package:kazumi/utils/constants.dart';
 
@@ -38,8 +39,12 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
   String originalValue = '';
 
   late Map<String, List<String>> shortcuts;
+  late bool gamepadEnabled;
+  late double gamepadStickDeadZone;
+  late int gamepadRepeatDelay;
 
   final FocusNode focusNode = FocusNode();
+  FocusNode? _focusBeforeListening;
 
   bool get isListening => listeningFunction != null && listeningIndex != null;
 
@@ -48,6 +53,10 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
     super.initState();
     // Repair persisted placeholders and keep at least one binding per action.
     shortcuts = {};
+    gamepadEnabled = GStorage.getSetting(SettingsKeys.gamepadEnabled);
+    gamepadStickDeadZone =
+        GStorage.getSetting(SettingsKeys.gamepadStickDeadZone);
+    gamepadRepeatDelay = GStorage.getSetting(SettingsKeys.gamepadRepeatDelay);
     for (final key in defaultShortcuts.keys) {
       final stored = GStorage.getStringListSettingByName(
         'shortcut_$key',
@@ -91,9 +100,14 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
     listeningFunction = null;
     listeningIndex = null;
     originalValue = '';
+    _restoreFocusAfterListening();
   }
 
   void beginListening(String func, int index) {
+    final currentFocus = FocusManager.instance.primaryFocus;
+    if (currentFocus != null && currentFocus != focusNode) {
+      _focusBeforeListening = currentFocus;
+    }
     originalValue = shortcuts[func]![index];
     shortcuts[func]![index] = '...';
     listeningFunction = func;
@@ -102,6 +116,19 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
     Future.delayed(const Duration(milliseconds: 50), () {
       if (!mounted) return;
       focusNode.requestFocus();
+    });
+  }
+
+  void _restoreFocusAfterListening() {
+    final previousFocus = _focusBeforeListening;
+    _focusBeforeListening = null;
+    if (!mounted || previousFocus == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted &&
+          previousFocus.context != null &&
+          previousFocus.canRequestFocus) {
+        previousFocus.requestFocus();
+      }
     });
   }
 
@@ -131,6 +158,7 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
       originalValue = '';
     });
     GStorage.putStringListSettingByName('shortcut_$func', shortcuts[func]!);
+    _restoreFocusAfterListening();
 
     return true;
   }
@@ -180,8 +208,76 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
         shortcuts[func] = defaultShortcuts[func]?.toList() ?? [];
         GStorage.putStringListSettingByName('shortcut_$func', shortcuts[func]!);
       }
+      gamepadEnabled = SettingsKeys.gamepadEnabled.defaultValue;
+      gamepadStickDeadZone = SettingsKeys.gamepadStickDeadZone.defaultValue;
+      gamepadRepeatDelay = SettingsKeys.gamepadRepeatDelay.defaultValue;
     });
-    KazumiDialog.showToast(message: '已恢复默认快捷键');
+    _restoreFocusAfterListening();
+    GStorage.putSetting(SettingsKeys.gamepadEnabled, gamepadEnabled);
+    GStorage.putSetting(
+      SettingsKeys.gamepadStickDeadZone,
+      gamepadStickDeadZone,
+    );
+    GStorage.putSetting(SettingsKeys.gamepadRepeatDelay, gamepadRepeatDelay);
+    _configureGamepadService();
+    KazumiDialog.showToast(message: '已恢复默认操作设置');
+  }
+
+  void _configureGamepadService() {
+    GamepadNavigationScope.maybeServiceOf(context)?.configure(
+      enabled: gamepadEnabled,
+      stickDeadZone: gamepadStickDeadZone,
+      initialRepeatDelay: Duration(milliseconds: gamepadRepeatDelay),
+    );
+  }
+
+  void _setGamepadEnabled(bool value) {
+    setState(() => gamepadEnabled = value);
+    GStorage.putSetting(SettingsKeys.gamepadEnabled, value);
+    _configureGamepadService();
+  }
+
+  void _setGamepadDeadZone(double value, {required bool persist}) {
+    setState(() => gamepadStickDeadZone = value);
+    if (persist) {
+      GStorage.putSetting(SettingsKeys.gamepadStickDeadZone, value);
+    }
+    _configureGamepadService();
+  }
+
+  void _setGamepadRepeatDelay(int value, {required bool persist}) {
+    setState(() => gamepadRepeatDelay = value);
+    if (persist) {
+      GStorage.putSetting(SettingsKeys.gamepadRepeatDelay, value);
+    }
+    _configureGamepadService();
+  }
+
+  Widget _withGamepadAdjustment({
+    required Widget child,
+    required VoidCallback decrease,
+    required VoidCallback increase,
+  }) {
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+          onInvoke: (intent) {
+            switch (intent.direction) {
+              case TraversalDirection.left:
+                decrease();
+              case TraversalDirection.right:
+                increase();
+              case TraversalDirection.up:
+              case TraversalDirection.down:
+                FocusManager.instance.primaryFocus
+                    ?.focusInDirection(intent.direction);
+            }
+            return null;
+          },
+        ),
+      },
+      child: child,
+    );
   }
 
   List<_ShortcutGroup> get displayGroups {
@@ -217,11 +313,16 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
         ),
       ],
       body: FocusScope(
-        autofocus: true,
+        // Keep the scope for shortcut-capture event bubbling, but do not let
+        // it claim primary focus from the settings rail on page entry.
+        autofocus: false,
         child: Focus(
           focusNode: focusNode,
-          autofocus: true,
-          canRequestFocus: true,
+          // This node only records a shortcut while the user is editing a
+          // binding. It must never win the page's initial focus: doing so
+          // hides the settings rail from spatial gamepad traversal.
+          autofocus: false,
+          canRequestFocus: false,
           skipTraversal: true,
           descendantsAreFocusable: true,
           onKeyEvent: (node, event) {
@@ -238,6 +339,12 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
           child: ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1000),
+                  child: _buildGamepadCard(),
+                ),
+              ),
               Center(
                 child: ConstrainedBox(
                   constraints: const BoxConstraints(maxWidth: 1000),
@@ -262,6 +369,131 @@ class _KeyboardSettingsPageState extends State<KeyboardSettingsPage> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildGamepadCard() {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    const bindings = <String>[
+      'A 确认',
+      'B 返回',
+      'X 弹幕',
+      'Y 控制栏 / 页面操作',
+      'LB / RB 快退快进',
+      'LT / RT 上下集',
+      'Start 播放暂停',
+      'View 侧栏',
+    ];
+
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.only(bottom: 24),
+      color: colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          SwitchListTile(
+            secondary: const Icon(Icons.sports_esports_rounded),
+            title: const Text('启用手柄操作'),
+            subtitle: const Text('支持方向键、摇杆、面键、肩键与扳机'),
+            value: gamepadEnabled,
+            onChanged: _setGamepadEnabled,
+          ),
+          const Divider(height: 1),
+          ListTile(
+            enabled: gamepadEnabled,
+            title: const Text('摇杆死区'),
+            subtitle: _withGamepadAdjustment(
+              decrease: () => _setGamepadDeadZone(
+                (gamepadStickDeadZone - 0.05).clamp(0.15, 0.75).toDouble(),
+                persist: true,
+              ),
+              increase: () => _setGamepadDeadZone(
+                (gamepadStickDeadZone + 0.05).clamp(0.15, 0.75).toDouble(),
+                persist: true,
+              ),
+              child: Slider(
+                value: gamepadStickDeadZone,
+                min: 0.15,
+                max: 0.75,
+                divisions: 12,
+                label: '${(gamepadStickDeadZone * 100).round()}%',
+                onChanged: gamepadEnabled
+                    ? (value) => _setGamepadDeadZone(value, persist: false)
+                    : null,
+                onChangeEnd: gamepadEnabled
+                    ? (value) => _setGamepadDeadZone(value, persist: true)
+                    : null,
+              ),
+            ),
+            trailing: Text('${(gamepadStickDeadZone * 100).round()}%'),
+          ),
+          ListTile(
+            enabled: gamepadEnabled,
+            title: const Text('长按重复延迟'),
+            subtitle: _withGamepadAdjustment(
+              decrease: () => _setGamepadRepeatDelay(
+                (gamepadRepeatDelay - 50).clamp(250, 800).toInt(),
+                persist: true,
+              ),
+              increase: () => _setGamepadRepeatDelay(
+                (gamepadRepeatDelay + 50).clamp(250, 800).toInt(),
+                persist: true,
+              ),
+              child: Slider(
+                value: gamepadRepeatDelay.toDouble(),
+                min: 250,
+                max: 800,
+                divisions: 11,
+                label: '$gamepadRepeatDelay ms',
+                onChanged: gamepadEnabled
+                    ? (value) => _setGamepadRepeatDelay(
+                          value.round(),
+                          persist: false,
+                        )
+                    : null,
+                onChangeEnd: gamepadEnabled
+                    ? (value) => _setGamepadRepeatDelay(
+                          value.round(),
+                          persist: true,
+                        )
+                    : null,
+              ),
+            ),
+            trailing: Text('$gamepadRepeatDelay ms'),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '默认映射',
+                    style: textTheme.labelLarge
+                        ?.copyWith(color: colorScheme.onSurfaceVariant),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      for (final binding in bindings)
+                        Chip(
+                          visualDensity: VisualDensity.compact,
+                          label: Text(binding),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -5,6 +7,7 @@ import 'package:kazumi/bean/appbar/sys_app_bar.dart';
 import 'package:kazumi/bean/settings/settings_detail_scaffold.dart';
 import 'package:kazumi/bean/settings/settings_list.dart';
 import 'package:kazumi/bean/widget/content_section.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
 import 'package:kazumi/pages/settings/player_settings.dart';
 import 'package:kazumi/utils/constants.dart';
 
@@ -47,8 +50,8 @@ const List<_SettingsGroup> _settingsGroups = [
       ),
       _SettingsCategory(
         label: '操作设置',
-        description: '播放器按键映射',
-        icon: Icons.keyboard_rounded,
+        description: '键盘与手柄映射',
+        icon: Icons.sports_esports_rounded,
         path: '/settings/keyboard',
       ),
     ],
@@ -165,6 +168,83 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   final _outletKey = GlobalKey<RouterOutletState>();
+  final _railScope = FocusScopeNode(debugLabel: 'settings categories');
+  final _detailScope = FocusScopeNode(debugLabel: 'settings detail');
+  late final _categoryNodes = <String, FocusNode>{
+    for (final group in _settingsGroups)
+      for (final category in group.categories)
+        category.path: FocusNode(debugLabel: category.path),
+  };
+  bool? _wide;
+
+  @override
+  void dispose() {
+    _railScope.dispose();
+    _detailScope.dispose();
+    for (final node in _categoryNodes.values) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  void _focusCategory() {
+    final node = _categoryNodes[_selectedCategoryPath];
+    if (node?.context == null || _wide != true) return;
+    _detailScope.canRequestFocus = false;
+    node!.requestFocus();
+    unawaited(Scrollable.ensureVisible(node.context!,
+        duration: const Duration(milliseconds: 100)));
+  }
+
+  void _navigate(TraversalDirection direction) {
+    if (_wide == true && _railScope.hasFocus) {
+      if (direction == TraversalDirection.right) {
+        _enterDetail();
+      } else if (direction == TraversalDirection.up ||
+          direction == TraversalDirection.down) {
+        final paths = _categoryNodes.keys.toList();
+        final current =
+            paths.indexWhere((path) => _categoryNodes[path]!.hasFocus);
+        final offset = direction == TraversalDirection.up ? -1 : 1;
+        final next = (current + offset).clamp(0, paths.length - 1);
+        _categoryNodes[paths[next]]!.requestFocus();
+      }
+      return;
+    }
+    if (invokeGamepadControlDirection(direction)) return;
+    final focus = FocusManager.instance.primaryFocus;
+    final moved = focus?.focusInDirection(direction) ?? false;
+    if (!moved && _wide == true && direction == TraversalDirection.left) {
+      _focusCategory();
+    }
+  }
+
+  void _previewCategory(String path) {
+    if (_wide != true) return;
+    _detailScope.canRequestFocus = false;
+    if (_location != path) _replaceCategory(path);
+    // The outlet creates a route focus scope when it replaces its contents.
+    // Keep selection on the rail until the user explicitly enters the pane.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _wide == true && _selectedCategoryPath == path) {
+        _focusCategory();
+      }
+    });
+  }
+
+  void _enterDetail() {
+    _detailScope.canRequestFocus = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) focusFirstGamepadControl(_detailScope);
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  void _activateCategory(String path) {
+    _replaceCategory(path);
+    _enterDetail();
+  }
+
   Object? _categoryNavigation;
   // Nested pushes do not update the root route state.
   late String _location = _normalizePath(widget.location);
@@ -184,6 +264,7 @@ class _SettingsPageState extends State<SettingsPage> {
 
   void _replaceCategory(String path) {
     _categoryNavigation = null;
+    if (_location == path) return;
     _outletKey.currentState!.navigate(path);
     setState(() => _location = _normalizePath(path));
   }
@@ -204,8 +285,16 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   void _goBack() {
+    if (_wide == true && _railScope.hasFocus) {
+      _exitSettings();
+      return;
+    }
     if (_outletKey.currentState?.maybePop() ?? false) return;
-    _exitSettings();
+    if (_wide == true) {
+      _focusCategory();
+    } else {
+      _exitSettings();
+    }
   }
 
   void _exitSettings() {
@@ -216,52 +305,95 @@ class _SettingsPageState extends State<SettingsPage> {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       final wide = constraints.maxWidth > LayoutBreakpoint.compact['width']!;
-      return NavigatorPopHandler<Object?>(
-        onPopWithResult: (_) => _goBack(),
-        child: Scaffold(
-          appBar: wide
-              ? SysAppBar(
-                  title: const Text('设置'),
-                  leading: BackButton(onPressed: _exitSettings),
-                )
-              : null,
-          body: SafeArea(
-            top: false,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Keep the outlet at the same tree position on resize.
-                SizedBox(
-                  width: wide ? 280 : 0,
-                  child: Offstage(
-                    offstage: !wide,
-                    child: _SettingsMenu(
-                      wide: true,
-                      selectedPath: _selectedCategoryPath,
-                      onSelect: _replaceCategory,
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: SettingsPaneScope(
-                    embedded: wide,
-                    showBackButton: _isSecondaryRoute,
-                    onBack: _goBack,
-                    child: NotificationListener<_SettingsCategorySelected>(
-                      onNotification: (notification) {
-                        _pushCategory(notification.path);
-                        return true;
-                      },
-                      child: Theme(
-                        data: Theme.of(context).copyWith(
-                          pageTransitionsTheme: settingsPageTransitionsTheme,
+      if (_wide != wide) {
+        _wide = wide;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          if (_wide == true) {
+            _focusCategory();
+          } else {
+            _enterDetail();
+          }
+        });
+      }
+      return Actions(
+        actions: <Type, Action<Intent>>{
+          GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+            onInvoke: (intent) {
+              _navigate(intent.direction);
+              return null;
+            },
+          ),
+          GamepadBackIntent: CallbackAction<GamepadBackIntent>(
+            onInvoke: (_) {
+              _goBack();
+              return null;
+            },
+          ),
+        },
+        child: NavigatorPopHandler<Object?>(
+          onPopWithResult: (_) => _goBack(),
+          child: Scaffold(
+            appBar: wide
+                ? SysAppBar(
+                    title: const Text('设置'),
+                    leading: BackButton(onPressed: _exitSettings),
+                  )
+                : null,
+            body: SafeArea(
+              top: false,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Keep the outlet at the same tree position on resize.
+                  SizedBox(
+                    width: wide ? 280 : 0,
+                    child: ExcludeFocus(
+                      excluding: !wide,
+                      child: Offstage(
+                        offstage: !wide,
+                        child: FocusScope(
+                          node: _railScope,
+                          child: _SettingsMenu(
+                            wide: true,
+                            selectedPath: _selectedCategoryPath,
+                            focusNodes: _categoryNodes,
+                            onFocusCategory: _previewCategory,
+                            onSelect: _activateCategory,
+                          ),
                         ),
-                        child: RouterOutlet(key: _outletKey),
                       ),
                     ),
                   ),
-                ),
-              ],
+                  Expanded(
+                    child: Listener(
+                      onPointerDown: (_) => _detailScope.canRequestFocus = true,
+                      child: FocusScope.withExternalFocusNode(
+                        focusScopeNode: _detailScope,
+                        child: SettingsPaneScope(
+                          embedded: wide,
+                          showBackButton: _isSecondaryRoute,
+                          onBack: _goBack,
+                          child:
+                              NotificationListener<_SettingsCategorySelected>(
+                            onNotification: (notification) {
+                              _pushCategory(notification.path);
+                              return true;
+                            },
+                            child: Theme(
+                              data: Theme.of(context).copyWith(
+                                pageTransitionsTheme:
+                                    settingsPageTransitionsTheme,
+                              ),
+                              child: RouterOutlet(key: _outletKey),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -297,51 +429,67 @@ class _SettingsMenu extends StatelessWidget {
   const _SettingsMenu({
     required this.wide,
     this.selectedPath,
+    this.focusNodes,
+    this.onFocusCategory,
     required this.onSelect,
   });
 
   final bool wide;
   final String? selectedPath;
   final ValueChanged<String> onSelect;
+  final Map<String, FocusNode>? focusNodes;
+  final ValueChanged<String>? onFocusCategory;
 
   @override
   Widget build(BuildContext context) {
+    final compactInitialPath = _settingsGroups.first.categories.first.path;
     return ScrollConfiguration(
       behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-      child: ListView(
+      child: SingleChildScrollView(
         padding: wide
             ? const EdgeInsets.fromLTRB(4, 0, 0, 12)
             : const EdgeInsets.fromLTRB(16, 8, 16, 24),
-        children: [
-          for (final group in _settingsGroups)
-            if (wide) ...[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(28, 16, 28, 8),
-                child: SectionHeader(title: Text(group.title)),
-              ),
-              for (final category in group.categories)
-                _RailDestination(
-                  category: category,
-                  selected: selectedPath == category.path,
-                  onTap: () => onSelect(category.path),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final group in _settingsGroups)
+              if (wide) ...[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(28, 16, 28, 8),
+                  child: SectionHeader(title: Text(group.title)),
                 ),
-            ] else
-              Padding(
-                padding: const EdgeInsets.only(top: 16),
-                child: ContentSection.group(
-                  title: group.title,
-                  children: [
-                    for (final category in group.categories)
-                      SettingsCategoryTile(
-                        icon: category.icon,
-                        title: category.label,
-                        description: category.description,
-                        onTap: () => onSelect(category.path),
-                      ),
-                  ],
+                for (final category in group.categories)
+                  _RailDestination(
+                    category: category,
+                    selected: selectedPath == category.path,
+                    focusNode: focusNodes?[category.path],
+                    onFocusChange: (focused) {
+                      if (focused) onFocusCategory?.call(category.path);
+                    },
+                    onTap: () => onSelect(category.path),
+                  ),
+              ] else
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: ContentSection.group(
+                    title: group.title,
+                    children: [
+                      for (final category in group.categories)
+                        SettingsCategoryTile(
+                          icon: category.icon,
+                          title: category.label,
+                          description: category.description,
+                          autofocus: selectedPath == category.path ||
+                              (!wide &&
+                                  selectedPath == null &&
+                                  category.path == compactInitialPath),
+                          onTap: () => onSelect(category.path),
+                        ),
+                    ],
+                  ),
                 ),
-              ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -352,11 +500,15 @@ class _RailDestination extends StatelessWidget {
     required this.category,
     required this.selected,
     required this.onTap,
+    this.focusNode,
+    this.onFocusChange,
   });
 
   final _SettingsCategory category;
   final bool selected;
   final VoidCallback onTap;
+  final FocusNode? focusNode;
+  final ValueChanged<bool>? onFocusChange;
 
   @override
   Widget build(BuildContext context) {
@@ -372,6 +524,8 @@ class _RailDestination extends StatelessWidget {
         borderRadius: BorderRadius.circular(28),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
+          focusNode: focusNode,
+          onFocusChange: onFocusChange,
           onTap: onTap,
           child: SizedBox(
             height: 56,

--- a/lib/pages/settings/theme_settings_page.dart
+++ b/lib/pages/settings/theme_settings_page.dart
@@ -266,26 +266,30 @@ class _ThemeSettingsPageState extends State<ThemeSettingsPage> {
                             ...colorThemes.map(
                               (e) {
                                 final index = colorThemes.indexOf(e);
-                                return GestureDetector(
+                                return InkWell(
+                                  borderRadius: BorderRadius.circular(12),
                                   onTap: () {
                                     index == 0
                                         ? resetTheme()
                                         : setTheme(e['color']);
                                     KazumiDialog.dismiss();
                                   },
-                                  child: Column(
-                                    children: [
-                                      PaletteCard(
-                                        color: e['color'],
-                                        selected: (e['color']
-                                                    .value
-                                                    .toRadixString(16) ==
-                                                defaultThemeColor ||
-                                            (defaultThemeColor == 'default' &&
-                                                index == 0)),
-                                      ),
-                                      Text(e['label']),
-                                    ],
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4),
+                                    child: Column(
+                                      children: [
+                                        PaletteCard(
+                                          color: e['color'],
+                                          selected: (e['color']
+                                                      .value
+                                                      .toRadixString(16) ==
+                                                  defaultThemeColor ||
+                                              (defaultThemeColor == 'default' &&
+                                                  index == 0)),
+                                        ),
+                                        Text(e['label']),
+                                      ],
+                                    ),
                                   ),
                                 );
                               },

--- a/lib/pages/video/episode_selection_panel.dart
+++ b/lib/pages/video/episode_selection_panel.dart
@@ -288,6 +288,7 @@ class _RoadSelectorState extends State<_RoadSelector> {
   final _focusNode = FocusNode(debugLabel: 'Playback road selector');
   FocusNode? _focusBeforeOpen;
   bool _pointerActivation = false;
+  bool _focused = false;
 
   String _name(int index) => index >= 0 && index < widget.roads.length
       ? (widget.roads[index].name.trim().isEmpty
@@ -451,54 +452,69 @@ class _RoadSelectorState extends State<_RoadSelector> {
             button: canSwitch,
             expanded: canSwitch ? open : null,
             label: canSwitch ? '切换播放线路' : null,
-            child: Material(
-              animationDuration: duration,
-              color:
-                  open ? colors.secondaryContainer : colors.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(open ? 16 : 20),
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                focusNode: _focusNode,
-                onTapUp: canSwitch ? (_) => _pointerActivation = true : null,
-                onTap: canSwitch ? () => _toggleMenu(controller) : null,
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              widget.isOffline ? '离线观看' : '播放线路',
-                              style: theme.textTheme.labelMedium
-                                  ?.copyWith(color: foreground),
-                            ),
-                            const SizedBox(height: 2),
-                            Text(
-                              _name(widget.visibleRoad),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w700,
-                                color: foreground,
+            child: DecoratedBox(
+              position: DecorationPosition.foreground,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(open ? 16 : 20),
+                border: _focused
+                    ? Border.all(color: colors.primary, width: 2)
+                    : null,
+              ),
+              child: Material(
+                animationDuration: duration,
+                color: open
+                    ? colors.secondaryContainer
+                    : colors.surfaceContainerLow,
+                borderRadius: BorderRadius.circular(open ? 16 : 20),
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  focusNode: _focusNode,
+                  onFocusChange: (focused) {
+                    if (_focused != focused) {
+                      setState(() => _focused = focused);
+                    }
+                  },
+                  onTapUp: canSwitch ? (_) => _pointerActivation = true : null,
+                  onTap: canSwitch ? () => _toggleMenu(controller) : null,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 12),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                widget.isOffline ? '离线观看' : '播放线路',
+                                style: theme.textTheme.labelMedium
+                                    ?.copyWith(color: foreground),
                               ),
-                            ),
-                          ],
+                              const SizedBox(height: 2),
+                              Text(
+                                _name(widget.visibleRoad),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.titleSmall?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                  color: foreground,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                      if (canSwitch) ...[
-                        const SizedBox(width: 8),
-                        AnimatedRotation(
-                          turns: open ? 0.5 : 0,
-                          duration: duration,
-                          curve: Curves.easeOutCubic,
-                          child: Icon(Icons.keyboard_arrow_down_rounded,
-                              color: foreground),
-                        ),
+                        if (canSwitch) ...[
+                          const SizedBox(width: 8),
+                          AnimatedRotation(
+                            turns: open ? 0.5 : 0,
+                            duration: duration,
+                            curve: Curves.easeOutCubic,
+                            child: Icon(Icons.keyboard_arrow_down_rounded,
+                                color: foreground),
+                          ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                 ),
               ),
@@ -541,6 +557,7 @@ class _EpisodeRow extends StatefulWidget {
 class _EpisodeRowState extends State<_EpisodeRow>
     with SingleTickerProviderStateMixin {
   late final _press = AnimationController.unbounded(vsync: this);
+  bool _focused = false;
 
   bool get _reduceMotion =>
       widget.disableAnimations || MediaQuery.disableAnimationsOf(context);
@@ -617,30 +634,47 @@ class _EpisodeRowState extends State<_EpisodeRow>
                     bottom: Radius.circular(widget.last ? 20 : 4),
                   );
             final press = _press.value.clamp(0.0, 1.0);
+            final radius =
+                BorderRadius.lerp(restShape, BorderRadius.circular(12), press);
+            final tile = Material(
+              animationDuration: _reduceMotion
+                  ? Duration.zero
+                  : const Duration(milliseconds: 200),
+              color:
+                  widget.selected ? colors.primary : colors.surfaceContainerLow,
+              borderRadius: radius,
+              clipBehavior: Clip.antiAlias,
+              child: child,
+            );
             return Padding(
               padding: EdgeInsets.only(bottom: widget.last ? 0 : 2),
-              child: Material(
-                animationDuration: _reduceMotion
-                    ? Duration.zero
-                    : const Duration(milliseconds: 200),
-                color: widget.selected
-                    ? colors.primary
-                    : colors.surfaceContainerLow,
-                borderRadius: BorderRadius.lerp(
-                    restShape, BorderRadius.circular(12), press),
-                clipBehavior: Clip.antiAlias,
-                child: child,
+              // The gamepad focus is the "pending" selection; outline it so
+              // it is distinct from the currently playing row's fill.
+              child: DecoratedBox(
+                position: DecorationPosition.foreground,
+                decoration: BoxDecoration(
+                  borderRadius: radius,
+                  border: _focused
+                      ? Border.all(color: colors.primary, width: 2)
+                      : null,
+                ),
+                child: tile,
               ),
             );
           },
           child: InkWell(
             onTap: widget.onTap,
             onHighlightChanged: _setPressed,
+            onFocusChange: (focused) {
+              if (_focused != focused) setState(() => _focused = focused);
+            },
             excludeFromSemantics: true,
             overlayColor: WidgetStateProperty.resolveWith((states) {
-              if (states.contains(WidgetState.pressed) ||
-                  states.contains(WidgetState.focused)) {
+              if (states.contains(WidgetState.pressed)) {
                 return foreground.withValues(alpha: 0.1);
+              }
+              if (states.contains(WidgetState.focused)) {
+                return colors.primary.withValues(alpha: 0.18);
               }
               if (states.contains(WidgetState.hovered)) {
                 return foreground.withValues(alpha: 0.08);

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -12,6 +12,7 @@ import 'package:kazumi/bean/appbar/drag_to_move_bar.dart' as dtb;
 import 'package:kazumi/bean/dialog/adaptive_bottom_sheet.dart';
 import 'package:kazumi/bean/dialog/dialog_helper.dart';
 import 'package:kazumi/bean/widget/embedded_native_control_area.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
 import 'package:kazumi/bean/widget/loading_indicator.dart';
 import 'package:kazumi/bean/widget/media_error_widget.dart';
 import 'package:kazumi/modules/download/download_module.dart';
@@ -65,6 +66,15 @@ class _VideoPageState extends State<VideoPage>
   StreamSubscription<String>? _logSubscription;
   final FocusNode keyboardFocus =
       FocusNode(debugLabel: 'Video player shortcut scope');
+  // Owns the player panel traversal scope shared with PlayerItem, plus the
+  // top bar scope. Joystick directional traversal never leaves the nearest
+  // focus scope, so the two scopes hand focus to each other explicitly.
+  final FocusScopeNode playerPanelScopeNode =
+      FocusScopeNode(debugLabel: 'Player controls');
+  final FocusScopeNode topBarScopeNode =
+      FocusScopeNode(debugLabel: 'Video top bar');
+  final FocusScopeNode sideTabScopeNode =
+      FocusScopeNode(debugLabel: 'Episode side tab');
 
   final _episodePanelKey = GlobalKey<EpisodeSelectionPanelState>();
   late AnimationController animation;
@@ -265,6 +275,9 @@ class _VideoPageState extends State<VideoPage>
     }
     DisplayModeService.unlockScreenRotation();
     keyboardFocus.dispose();
+    playerPanelScopeNode.dispose();
+    topBarScopeNode.dispose();
+    sideTabScopeNode.dispose();
     tabController.dispose();
     TimedShutdownService().cancel();
     super.dispose();
@@ -333,6 +346,63 @@ class _VideoPageState extends State<VideoPage>
     keyboardFocus.requestFocus();
   }
 
+  // Entered from the top bar via joystick down. Directional traversal never
+  // leaves a focus scope on its own, so the top bar hands focus over
+  // explicitly; the panel hold acquired by the focused control keeps the
+  // controls visible.
+  void _enterPlayerPanel() {
+    playerController.panel.showVideoController = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) focusFirstGamepadControl(playerPanelScopeNode);
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  // The episode side tab is a sibling focus scope. Directional traversal stays
+  // inside the nearest scope, so the player and the tab hand focus to each
+  // other explicitly instead of trying to cross scopes with the joystick.
+  bool get _sideTabVisible =>
+      _isSideTabLayout &&
+      videoPageController.showTabBody &&
+      !videoPageController.isPip;
+
+  bool _enterSideTabIfOpen() {
+    if (!_sideTabVisible) {
+      return false;
+    }
+    return focusFirstGamepadControl(sideTabScopeNode);
+  }
+
+  void _handleSideTabNavigate(TraversalDirection direction) {
+    if (!invokeGamepadControlDirection(direction)) {
+      FocusManager.instance.primaryFocus?.focusInDirection(direction);
+    }
+    // The sidebar is a self-contained second-level menu: the stick must never
+    // hand the pending selection to the player underneath. Only B returns to
+    // the parent level (and closes the tab). If traversal somehow leaves the
+    // scope, pull the selection back.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_sideTabVisible) return;
+      if (!sideTabScopeNode.hasFocus) {
+        focusFirstGamepadControl(sideTabScopeNode);
+      }
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  // Page-level fallback used while the player widget is not mounted yet (for
+  // example while the stream is still loading) and focus sits outside the
+  // top bar, panel, or side tab scopes.
+  void _handlePageNavigate(TraversalDirection direction) {
+    if (direction == TraversalDirection.right && _enterSideTabIfOpen()) {
+      return;
+    }
+    if (invokeGamepadControlDirection(direction)) {
+      return;
+    }
+    FocusManager.instance.primaryFocus?.focusInDirection(direction);
+  }
+
   void _toggleTabBodyAnimated() {
     if (_tabBodyTargetVisible) {
       _closeTabBodyAnimated();
@@ -350,12 +420,23 @@ class _VideoPageState extends State<VideoPage>
     _setTabBodyVisible(false, animated: false);
   }
 
+  // Opening the episode sidebar makes it the active second-level menu, so the
+  // selection moves straight into it instead of staying on the player.
+  void _focusSideTabOnOpen() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_sideTabVisible) return;
+      focusFirstGamepadControl(sideTabScopeNode);
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
   void _setTabBodyVisible(bool visible, {required bool animated}) {
     _tabBodyTargetVisible = visible;
     final int animationRun = ++_tabBodyAnimationRun;
 
     if (visible) {
-      if (!videoPageController.showTabBody) {
+      final wasHidden = !videoPageController.showTabBody;
+      if (wasHidden) {
         animation.value = 0.0;
         videoPageController.showTabBody = true;
       }
@@ -363,6 +444,9 @@ class _VideoPageState extends State<VideoPage>
         animation.forward(from: animation.value);
       } else {
         animation.value = 1.0;
+      }
+      if (wasHidden || !sideTabScopeNode.hasFocus) {
+        _focusSideTabOnOpen();
       }
       return;
     }
@@ -445,6 +529,14 @@ class _VideoPageState extends State<VideoPage>
     }
   }
 
+  void _selectRelativeTab(int offset) {
+    final target = (tabController.index + offset).clamp(
+      0,
+      tabController.length - 1,
+    );
+    tabController.animateTo(target);
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool isLandscape = _windowIsLandscape;
@@ -455,87 +547,173 @@ class _VideoPageState extends State<VideoPage>
       }
       _syncTabBodyAnimationAfterLayout();
     });
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (bool didPop, Object? result) {
-        if (didPop) {
-          return;
-        }
-        onBackPressed(context);
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        GamepadBackIntent: CallbackAction<GamepadBackIntent>(
+          onInvoke: (_) {
+            // Mirror the side tab display condition: while the episode tab
+            // covers the page, B dismisses it before leaving the page.
+            if (_sideTabVisible) {
+              _closeTabBodyAnimated();
+            } else {
+              onBackPressed(context);
+            }
+            return null;
+          },
+        ),
+        GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+          onInvoke: (intent) {
+            _handlePageNavigate(intent.direction);
+            return null;
+          },
+        ),
+        GamepadViewIntent: CallbackAction<GamepadViewIntent>(
+          onInvoke: (_) {
+            _toggleTabBodyAnimated();
+            return null;
+          },
+        ),
+        GamepadMenuIntent: CallbackAction<GamepadMenuIntent>(
+          onInvoke: (_) {
+            unawaited(playerController.playOrPause());
+            return null;
+          },
+        ),
+        GamepadPreviousSecondarySectionIntent:
+            CallbackAction<GamepadPreviousSecondarySectionIntent>(
+          onInvoke: (_) {
+            _selectRelativeTab(-1);
+            return null;
+          },
+        ),
+        GamepadNextSecondarySectionIntent:
+            CallbackAction<GamepadNextSecondarySectionIntent>(
+          onInvoke: (_) {
+            _selectRelativeTab(1);
+            return null;
+          },
+        ),
       },
-      child: Observer(builder: (context) {
-        final bool isPip = videoPageController.isPip;
-        final bool videoFillsWindow = isLandscape || isPip;
-        return Scaffold(
-          appBar: null,
-          body: SafeArea(
-              top: !videoPageController.isFullscreen && !isPip,
-              bottom: false,
-              left: !videoPageController.isFullscreen && !isPip,
-              right: !videoPageController.isFullscreen && !isPip,
-              child: Stack(
-                alignment: Alignment.centerRight,
-                children: [
-                  Column(
-                    children: [
-                      Flexible(
-                        flex: videoFillsWindow ? 1 : 0,
-                        child: Container(
-                          color: Colors.black,
-                          height: videoFillsWindow
-                              ? MediaQuery.sizeOf(context).height
-                              : MediaQuery.sizeOf(context).width * 9 / 16,
-                          width: MediaQuery.sizeOf(context).width,
-                          child: Focus(
-                            focusNode: keyboardFocus,
-                            autofocus: true,
+      child: PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (bool didPop, Object? result) {
+          if (didPop) {
+            return;
+          }
+          onBackPressed(context);
+        },
+        child: Observer(builder: (context) {
+          final bool isPip = videoPageController.isPip;
+          final bool videoFillsWindow = isLandscape || isPip;
+          return Scaffold(
+            appBar: null,
+            body: SafeArea(
+                top: !videoPageController.isFullscreen && !isPip,
+                bottom: false,
+                left: !videoPageController.isFullscreen && !isPip,
+                right: !videoPageController.isFullscreen && !isPip,
+                child: Stack(
+                  alignment: Alignment.centerRight,
+                  children: [
+                    Column(
+                      children: [
+                        Flexible(
+                          flex: videoFillsWindow ? 1 : 0,
+                          child: Container(
+                            color: Colors.black,
+                            height: videoFillsWindow
+                                ? MediaQuery.sizeOf(context).height
+                                : MediaQuery.sizeOf(context).width * 9 / 16,
+                            width: MediaQuery.sizeOf(context).width,
+                            // The player area owns the single keyboardFocus
+                            // attachment inside PlayerItem. Attaching the same
+                            // node here too reparents it to itself as soon as
+                            // joystick focus moves, crashing with
+                            // 'child != this'.
                             child: playerBody,
                           ),
                         ),
-                      ),
-                      if (!videoFillsWindow) Expanded(child: tabBody),
-                    ],
-                  ),
-                  if (isLandscape &&
-                      videoPageController.showTabBody &&
-                      !isPip) ...[
-                    if (disableAnimations) ...[
-                      sideTabMask,
-                      sideTabBody,
-                    ] else ...[
-                      FadeTransition(
-                        opacity: _maskOpacityAnimation,
-                        child: sideTabMask,
-                      ),
-                      SlideTransition(
-                        position: _rightOffsetAnimation,
-                        child: sideTabBody,
-                      ),
+                        if (!videoFillsWindow) Expanded(child: tabBody),
+                      ],
+                    ),
+                    if (isLandscape &&
+                        videoPageController.showTabBody &&
+                        !isPip) ...[
+                      if (disableAnimations) ...[
+                        sideTabMask,
+                        sideTabBody,
+                      ] else ...[
+                        FadeTransition(
+                          opacity: _maskOpacityAnimation,
+                          child: sideTabMask,
+                        ),
+                        SlideTransition(
+                          position: _rightOffsetAnimation,
+                          child: sideTabBody,
+                        ),
+                      ],
                     ],
                   ],
-                ],
-              )),
-        );
-      }),
+                )),
+          );
+        }),
+      ),
     );
   }
 
   Widget get sideTabBody {
-    return SizedBox(
-      height: MediaQuery.sizeOf(context).height,
-      width: (!isDesktop() && !isTablet())
-          ? MediaQuery.sizeOf(context).height
-          : (MediaQuery.sizeOf(context).width / 3 > 420
-              ? 420
-              : MediaQuery.sizeOf(context).width / 3),
-      child: Material(
-        color: Theme.of(context).colorScheme.surface,
-        borderRadius: const BorderRadiusDirectional.only(
-          topStart: Radius.circular(28),
-          bottomStart: Radius.circular(28),
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+          onInvoke: (intent) {
+            _handleSideTabNavigate(intent.direction);
+            return null;
+          },
         ),
-        clipBehavior: Clip.antiAlias,
-        child: (isDesktop() || isTablet()) ? tabBody : episodePanel,
+        // The episode sidebar is a second-level menu. While it owns focus its
+        // own mapping applies, and player or shell commands must not leak
+        // through to the video playing underneath. View is the sidebar's own
+        // toggle, so it closes the tab instead.
+        GamepadViewIntent: CallbackAction<GamepadViewIntent>(
+          onInvoke: (_) {
+            _closeTabBodyAnimated();
+            return null;
+          },
+        ),
+        GamepadMenuIntent:
+            CallbackAction<GamepadMenuIntent>(onInvoke: (_) => null),
+        GamepadContextActionIntent:
+            CallbackAction<GamepadContextActionIntent>(onInvoke: (_) => null),
+        GamepadSecondaryActionIntent:
+            CallbackAction<GamepadSecondaryActionIntent>(onInvoke: (_) => null),
+        GamepadPreviousSectionIntent:
+            CallbackAction<GamepadPreviousSectionIntent>(onInvoke: (_) => null),
+        GamepadNextSectionIntent:
+            CallbackAction<GamepadNextSectionIntent>(onInvoke: (_) => null),
+        GamepadLeftStickClickIntent:
+            CallbackAction<GamepadLeftStickClickIntent>(onInvoke: (_) => null),
+        GamepadRightStickClickIntent:
+            CallbackAction<GamepadRightStickClickIntent>(onInvoke: (_) => null),
+      },
+      child: FocusScope(
+        node: sideTabScopeNode,
+        child: SizedBox(
+          height: MediaQuery.sizeOf(context).height,
+          width: (!isDesktop() && !isTablet())
+              ? MediaQuery.sizeOf(context).height
+              : (MediaQuery.sizeOf(context).width / 3 > 420
+                  ? 420
+                  : MediaQuery.sizeOf(context).width / 3),
+          child: Material(
+            color: Theme.of(context).colorScheme.surface,
+            borderRadius: const BorderRadiusDirectional.only(
+              topStart: Radius.circular(28),
+              bottomStart: Radius.circular(28),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: (isDesktop() || isTablet()) ? tabBody : episodePanel,
+          ),
+        ),
       ),
     );
   }
@@ -632,52 +810,84 @@ class _VideoPageState extends State<VideoPage>
                     right: 0,
                     child: EmbeddedNativeControlArea(
                       requireOffset: !videoPageController.isFullscreen,
-                      child: Row(
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.arrow_back,
-                                color: Colors.white),
-                            onPressed: () => onBackPressed(context),
-                          ),
-                          const Expanded(
-                              child: dtb.DragToMoveArea(
-                                  child: SizedBox(height: 40))),
-                          IconButton(
-                            icon: const Icon(Icons.refresh_outlined,
-                                color: Colors.white),
-                            onPressed: () {
-                              changeEpisode(
-                                  videoPageController.selectedEpisode.episode,
-                                  currentRoad:
-                                      videoPageController.selectedEpisode.road);
+                      // The top bar owns its own traversal scope so panel
+                      // navigation cannot land here by accident; down hands
+                      // focus back to the player panel explicitly, while the
+                      // other directions keep the default in-scope traversal.
+                      child: Actions(
+                        actions: <Type, Action<Intent>>{
+                          GamepadNavigateIntent:
+                              CallbackAction<GamepadNavigateIntent>(
+                            onInvoke: (intent) {
+                              if (intent.direction == TraversalDirection.down) {
+                                _enterPlayerPanel();
+                                return null;
+                              }
+                              if (intent.direction ==
+                                      TraversalDirection.right &&
+                                  _enterSideTabIfOpen()) {
+                                // The side tab is a sibling scope. While the
+                                // player panel is not mounted (still loading)
+                                // this is the only way to reach it.
+                                return null;
+                              }
+                              FocusManager.instance.primaryFocus
+                                  ?.focusInDirection(intent.direction);
+                              return null;
                             },
                           ),
-                          Visibility(
-                            visible: MediaQuery.sizeOf(context).width >
-                                MediaQuery.sizeOf(context).height,
-                            child: IconButton(
-                              onPressed: () {
-                                _toggleTabBodyAnimated();
-                              },
-                              icon: Icon(
-                                _tabBodyTargetVisible
-                                    ? Icons.menu_open
-                                    : Icons.menu_open_outlined,
-                                color: Colors.white,
+                        },
+                        child: FocusScope(
+                          node: topBarScopeNode,
+                          child: Row(
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.arrow_back,
+                                    color: Colors.white),
+                                onPressed: () => onBackPressed(context),
                               ),
-                            ),
+                              const Expanded(
+                                  child: dtb.DragToMoveArea(
+                                      child: SizedBox(height: 40))),
+                              IconButton(
+                                icon: const Icon(Icons.refresh_outlined,
+                                    color: Colors.white),
+                                onPressed: () {
+                                  changeEpisode(
+                                      videoPageController
+                                          .selectedEpisode.episode,
+                                      currentRoad: videoPageController
+                                          .selectedEpisode.road);
+                                },
+                              ),
+                              Visibility(
+                                visible: MediaQuery.sizeOf(context).width >
+                                    MediaQuery.sizeOf(context).height,
+                                child: IconButton(
+                                  onPressed: () {
+                                    _toggleTabBodyAnimated();
+                                  },
+                                  icon: Icon(
+                                    _tabBodyTargetVisible
+                                        ? Icons.menu_open
+                                        : Icons.menu_open_outlined,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                icon: Icon(
+                                    showDebugLog
+                                        ? Icons.bug_report
+                                        : Icons.bug_report_outlined,
+                                    color: Colors.white),
+                                onPressed: () {
+                                  switchDebugConsole();
+                                },
+                              ),
+                            ],
                           ),
-                          IconButton(
-                            icon: Icon(
-                                showDebugLog
-                                    ? Icons.bug_report
-                                    : Icons.bug_report_outlined,
-                                color: Colors.white),
-                            onPressed: () {
-                              switchDebugConsole();
-                            },
-                          ),
-                        ],
+                        ),
                       ),
                     ),
                   ),
@@ -698,6 +908,14 @@ class _VideoPageState extends State<VideoPage>
                   changeEpisode: changeEpisode,
                   onBackPressed: onBackPressed,
                   keyboardFocus: keyboardFocus,
+                  playerPanelScopeNode: playerPanelScopeNode,
+                  topBarScopeNode: topBarScopeNode,
+                  sideTabScopeNode: sideTabScopeNode,
+                  isSideTabOpen: () =>
+                      _isSideTabLayout &&
+                      videoPageController.showTabBody &&
+                      !videoPageController.isPip,
+                  onCloseSideTab: _closeTabBodyAnimated,
                   disableAnimations: disableAnimations,
                   pauseForTimedShutdown: pauseForTimedShutdown,
                 ),

--- a/lib/services/platform/gamepad_input_service.dart
+++ b/lib/services/platform/gamepad_input_service.dart
@@ -1,0 +1,455 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+enum GamepadCommand {
+  navigateUp,
+  navigateDown,
+  navigateLeft,
+  navigateRight,
+  activate,
+  back,
+  secondaryAction,
+  contextAction,
+  previousSection,
+  nextSection,
+  previousSecondarySection,
+  nextSecondarySection,
+  menu,
+  view,
+  leftStickClick,
+  rightStickClick,
+  scrollUp,
+  scrollDown,
+  scrollLeft,
+  scrollRight,
+}
+
+class GamepadCommandEvent {
+  const GamepadCommandEvent({
+    required this.command,
+    required this.gamepadId,
+    this.isRepeat = false,
+  });
+
+  final GamepadCommand command;
+  final int gamepadId;
+  final bool isRepeat;
+}
+
+enum _InputControl { leftStick, rightStick, keyboard }
+
+typedef _CommandSource = ({int gamepadId, Object control});
+
+/// Normalizes controller buttons and axes into stable application commands.
+///
+/// Button labels are deliberately semantic: [GamepadButton.a] means the south
+/// face button, not a letter printed on a particular controller.
+///
+/// Input from every connected controller is merged into a single logical pad,
+/// the same model borealis/wiliwili use. This matters on handhelds where one
+/// physical stick is exposed through several kernel nodes at once (a native
+/// node, an xpad compatibility node, and virtual pads from Handheld Daemon or
+/// Steam Input). Treating those as separate controllers makes one flick emit
+/// several navigation steps. Merging by command means duplicated nodes collapse
+/// into one press.
+///
+/// A command is emitted only on the rising edge of that merged state, so
+/// holding a stick past the dead zone moves focus once. Repetition is owned by
+/// the app: [initialRepeatDelay] then [repeatInterval].
+class GamepadInputService {
+  GamepadInputService({
+    Stream<GamepadEvent>? events,
+    bool enabled = true,
+    double stickDeadZone = 0.5,
+    Duration initialRepeatDelay = const Duration(milliseconds: 250),
+    Duration repeatInterval = const Duration(milliseconds: 100),
+    Duration duplicateWindow = const Duration(milliseconds: 60),
+    Duration keyboardHoldTimeout = const Duration(seconds: 2),
+  })  : _events = events ?? Gamepad.instance.events,
+        _duplicateWindow = duplicateWindow,
+        _keyboardHoldTimeout = keyboardHoldTimeout,
+        _enabled = enabled,
+        _stickDeadZone = stickDeadZone,
+        _initialRepeatDelay = initialRepeatDelay,
+        _repeatInterval = repeatInterval;
+
+  final Stream<GamepadEvent> _events;
+  final StreamController<GamepadCommandEvent> _commands =
+      StreamController<GamepadCommandEvent>.broadcast(sync: true);
+
+  /// Latest axis values per controller. Kept per controller so a stick resting
+  /// at centre on one pad cannot cancel a real deflection on another.
+  final Map<int, Map<GamepadAxis, double>> _axes =
+      <int, Map<GamepadAxis, double>>{};
+
+  /// Which controls currently assert each command. Axis, D-pad, keyboard, and
+  /// every controller are ORed into one held state before edges are emitted,
+  /// matching Borealis' unified controller state.
+  final Map<GamepadCommand, Set<_CommandSource>> _activeSources =
+      <GamepadCommand, Set<_CommandSource>>{};
+  final Map<GamepadCommand, Timer> _repeatTimers = <GamepadCommand, Timer>{};
+
+  final ValueNotifier<bool> usingGamepad = ValueNotifier<bool>(false);
+
+  StreamSubscription<GamepadEvent>? _subscription;
+  bool _enabled;
+  bool _suspended = false;
+  int _generation = 0;
+  double _stickDeadZone;
+  Duration _initialRepeatDelay;
+  Duration _repeatInterval;
+  final Duration _duplicateWindow;
+
+  /// A lost KeyUp must not leave a virtual D-pad direction held forever.
+  /// Handheld middleware normally sends repeats while a key is held, so this
+  /// watchdog is refreshed by every repeat and only releases silent input.
+  final Duration _keyboardHoldTimeout;
+  final Map<GamepadCommand, Timer> _keyboardNavigationWatchdogs =
+      <GamepadCommand, Timer>{};
+
+  /// When each command last fired a fresh (non-repeat) press.
+  ///
+  /// One physical stick exposed through several kernel nodes does not report
+  /// those nodes in lockstep: node A can cross the threshold and fall back to
+  /// centre before node B crosses it at all. Command-level merging alone still
+  /// sees two complete press/release cycles there, which is what made a single
+  /// flick move focus twice. Collapsing presses that land within this window
+  /// treats them as the one physical action they are.
+  final Map<GamepadCommand, Stopwatch> _lastPress =
+      <GamepadCommand, Stopwatch>{};
+
+  Stream<GamepadCommandEvent> get commands => _commands.stream;
+  bool get enabled => _enabled;
+
+  /// Release threshold sits below the press threshold so a stick hovering near
+  /// the dead zone cannot chatter between pressed and released.
+  double get _stickReleaseThreshold => math.max(0.15, _stickDeadZone - 0.15);
+
+  static const Set<GamepadCommand> _repeatableCommands = <GamepadCommand>{
+    GamepadCommand.navigateUp,
+    GamepadCommand.navigateDown,
+    GamepadCommand.navigateLeft,
+    GamepadCommand.navigateRight,
+    GamepadCommand.previousSecondarySection,
+    GamepadCommand.nextSecondarySection,
+    GamepadCommand.scrollUp,
+    GamepadCommand.scrollDown,
+    GamepadCommand.scrollLeft,
+    GamepadCommand.scrollRight,
+  };
+
+  static const Set<GamepadCommand> _navigationCommands = <GamepadCommand>{
+    GamepadCommand.navigateUp,
+    GamepadCommand.navigateDown,
+    GamepadCommand.navigateLeft,
+    GamepadCommand.navigateRight,
+  };
+
+  void start() {
+    if (_subscription != null) {
+      return;
+    }
+    _subscription = _events.listen(
+      handleEvent,
+      onError: (Object _, StackTrace __) => reset(),
+      onDone: reset,
+    );
+  }
+
+  void configure({
+    bool? enabled,
+    double? stickDeadZone,
+    Duration? initialRepeatDelay,
+    Duration? repeatInterval,
+  }) {
+    final nextEnabled = enabled ?? _enabled;
+    final nextDeadZone =
+        (stickDeadZone ?? _stickDeadZone).clamp(0.15, 0.75).toDouble();
+    final nextInitialDelay = initialRepeatDelay ?? _initialRepeatDelay;
+    final nextRepeatInterval = repeatInterval ?? _repeatInterval;
+    final thresholdsChanged = nextDeadZone != _stickDeadZone;
+    final timingChanged = nextInitialDelay != _initialRepeatDelay ||
+        nextRepeatInterval != _repeatInterval;
+
+    _enabled = nextEnabled;
+    _stickDeadZone = nextDeadZone;
+    _initialRepeatDelay = nextInitialDelay;
+    _repeatInterval = nextRepeatInterval;
+    if (!_enabled || thresholdsChanged || timingChanged) {
+      reset();
+    }
+  }
+
+  void markPointerInput() {
+    // A touch/click is an explicit hand-off from the controller. Clearing
+    // held sources here prevents a stale virtual arrow from resuming after a
+    // pointer-driven page change.
+    reset();
+    usingGamepad.value = false;
+  }
+
+  /// Feeds desktop arrow keys into the same held state as controller input.
+  ///
+  /// Handheld middleware can expose one stick as both a gamepad axis and a
+  /// virtual keyboard arrow. Keeping Flutter's default arrow traversal separate
+  /// would move focus once for each path.
+  void handleKeyboardNavigation(GamepadCommand command, bool pressed) {
+    if (!_enabled || _suspended || !_navigationCommands.contains(command)) {
+      return;
+    }
+    const source = (gamepadId: -1, control: _InputControl.keyboard);
+    if (!pressed) {
+      _keyboardNavigationWatchdogs.remove(command)?.cancel();
+      _setSourceActive(source, command, false);
+      return;
+    }
+    final generation = _generation;
+    _setSourceActive(source, command, true);
+    if (generation != _generation) return;
+    _keyboardNavigationWatchdogs.remove(command)?.cancel();
+    _keyboardNavigationWatchdogs[command] = Timer(_keyboardHoldTimeout, () {
+      _keyboardNavigationWatchdogs.remove(command);
+      _setSourceActive(source, command, false);
+    });
+  }
+
+  @visibleForTesting
+  void handleEvent(GamepadEvent event) {
+    if (event is GamepadConnectionEvent) {
+      if (!event.connected) {
+        _handleDisconnect(event.gamepadId);
+      }
+      return;
+    }
+    if (!_enabled || _suspended) {
+      return;
+    }
+
+    if (event is GamepadButtonEvent) {
+      _handleButton(event.gamepadId, event.button, event.pressed);
+      return;
+    }
+    if (event is! GamepadAxisEvent) {
+      return;
+    }
+    final values = _axes.putIfAbsent(
+      event.gamepadId,
+      () => <GamepadAxis, double>{},
+    );
+    if (!event.value.isFinite) return;
+    values[event.axis] = event.value.clamp(-1.0, 1.0);
+    switch (event.axis) {
+      case GamepadAxis.leftStickX:
+      case GamepadAxis.leftStickY:
+        _updateStick(event.gamepadId, values, left: true);
+      case GamepadAxis.rightStickX:
+      case GamepadAxis.rightStickY:
+        _updateStick(event.gamepadId, values, left: false);
+    }
+  }
+
+  void _handleButton(int gamepadId, GamepadButton button, bool pressed) {
+    final command = switch (button) {
+      GamepadButton.a => GamepadCommand.activate,
+      GamepadButton.b => GamepadCommand.back,
+      GamepadButton.x => GamepadCommand.secondaryAction,
+      GamepadButton.y => GamepadCommand.contextAction,
+      GamepadButton.leftShoulder => GamepadCommand.previousSection,
+      GamepadButton.rightShoulder => GamepadCommand.nextSection,
+      GamepadButton.leftTrigger => GamepadCommand.previousSecondarySection,
+      GamepadButton.rightTrigger => GamepadCommand.nextSecondarySection,
+      GamepadButton.back => GamepadCommand.view,
+      GamepadButton.start => GamepadCommand.menu,
+      GamepadButton.leftStickButton => GamepadCommand.leftStickClick,
+      GamepadButton.rightStickButton => GamepadCommand.rightStickClick,
+      GamepadButton.dpadUp => GamepadCommand.navigateUp,
+      GamepadButton.dpadDown => GamepadCommand.navigateDown,
+      GamepadButton.dpadLeft => GamepadCommand.navigateLeft,
+      GamepadButton.dpadRight => GamepadCommand.navigateRight,
+      GamepadButton.guide => null,
+    };
+    if (command != null) {
+      _setSourceActive(
+        (gamepadId: gamepadId, control: button),
+        command,
+        pressed,
+      );
+    }
+  }
+
+  void _updateStick(
+    int gamepadId,
+    Map<GamepadAxis, double> values, {
+    required bool left,
+  }) {
+    final xAxis = left ? GamepadAxis.leftStickX : GamepadAxis.rightStickX;
+    final yAxis = left ? GamepadAxis.leftStickY : GamepadAxis.rightStickY;
+    final x = values[xAxis] ?? 0.0;
+    final y = values[yAxis] ?? 0.0;
+    final radius = math.sqrt(x * x + y * y);
+    // Left stick moves focus, right stick scrolls. Y is positive downwards.
+    final commands = left
+        ? const <GamepadCommand>[
+            GamepadCommand.navigateLeft,
+            GamepadCommand.navigateRight,
+            GamepadCommand.navigateUp,
+            GamepadCommand.navigateDown,
+          ]
+        : const <GamepadCommand>[
+            GamepadCommand.scrollLeft,
+            GamepadCommand.scrollRight,
+            GamepadCommand.scrollUp,
+            GamepadCommand.scrollDown,
+          ];
+    final source = (
+      gamepadId: gamepadId,
+      control: left ? _InputControl.leftStick : _InputControl.rightStick,
+    );
+
+    int? desired;
+    if (radius >= _stickDeadZone) {
+      // Only the dominant axis wins, so a diagonal push cannot fire two
+      // directions at once.
+      if (x.abs() >= y.abs()) {
+        desired = x < 0 ? 0 : 1;
+      } else {
+        desired = y < 0 ? 2 : 3;
+      }
+    } else if (radius > _stickReleaseThreshold) {
+      // Between the release and press thresholds, keep whatever this stick
+      // already holds instead of releasing it.
+      for (var i = 0; i < commands.length; i++) {
+        if (_activeSources[commands[i]]?.contains(source) ?? false) {
+          desired = i;
+          break;
+        }
+      }
+    }
+
+    // Release the previous direction before emitting a new one. A listener
+    // may reset or suspend input synchronously while handling that command.
+    for (var i = 0; i < commands.length; i++) {
+      if (desired != i) _setSourceActive(source, commands[i], false);
+    }
+    if (desired != null) _setSourceActive(source, commands[desired], true);
+  }
+
+  void _setSourceActive(
+    _CommandSource source,
+    GamepadCommand command,
+    bool active,
+  ) {
+    if (!active) {
+      final sources = _activeSources[command];
+      if (sources == null || !sources.remove(source) || sources.isNotEmpty) {
+        return;
+      }
+      _repeatTimers.remove(command)?.cancel();
+      _activeSources.remove(command);
+      return;
+    }
+    final sources =
+        _activeSources.putIfAbsent(command, () => <_CommandSource>{});
+    final wasEmpty = sources.isEmpty;
+    if (!sources.add(source) || !wasEmpty) return;
+
+    final since = _lastPress[command];
+    final duplicate = since != null && since.elapsed < _duplicateWindow;
+    final generation = _generation;
+    if (!duplicate) {
+      (_lastPress[command] ??= Stopwatch()..start()).reset();
+      _emit(command, source.gamepadId, isRepeat: false);
+    }
+    // Deduplication suppresses the extra edge, not a real sustained hold.
+    if (generation == _generation &&
+        identical(_activeSources[command], sources) &&
+        _repeatableCommands.contains(command)) {
+      _scheduleRepeat(command, sources, _initialRepeatDelay);
+    }
+  }
+
+  void _scheduleRepeat(
+      GamepadCommand command, Set<_CommandSource> sources, Duration delay) {
+    _repeatTimers.remove(command)?.cancel();
+    final generation = _generation;
+    _repeatTimers[command] = Timer(delay, () {
+      _repeatTimers.remove(command);
+      if (generation != _generation ||
+          !identical(_activeSources[command], sources) ||
+          sources.isEmpty) {
+        return;
+      }
+      _emit(command, sources.first.gamepadId, isRepeat: true);
+      // Actions can release, replace, or reset this hold during dispatch.
+      if (generation == _generation &&
+          identical(_activeSources[command], sources) &&
+          sources.isNotEmpty) {
+        _scheduleRepeat(command, sources, _repeatInterval);
+      }
+    });
+  }
+
+  void _emit(
+    GamepadCommand command,
+    int gamepadId, {
+    required bool isRepeat,
+  }) {
+    final generation = _generation;
+    usingGamepad.value = true;
+    if (generation == _generation && !_commands.isClosed) {
+      _commands.add(GamepadCommandEvent(
+        command: command,
+        gamepadId: gamepadId,
+        isRepeat: isRepeat,
+      ));
+    }
+  }
+
+  /// Ignore background events, including those from globally opened Linux pads.
+  void setSuspended(bool suspended) {
+    if (_suspended == suspended) return;
+    _suspended = suspended;
+    reset();
+  }
+
+  void reset() {
+    _generation++;
+    for (final timer in _repeatTimers.values) {
+      timer.cancel();
+    }
+    _repeatTimers.clear();
+    for (final timer in _keyboardNavigationWatchdogs.values) {
+      timer.cancel();
+    }
+    _keyboardNavigationWatchdogs.clear();
+    _activeSources.clear();
+    _axes.clear();
+    _lastPress.clear();
+  }
+
+  /// Releases everything a vanished controller held so a disconnect mid-hold
+  /// cannot leave a command repeating forever.
+  void _handleDisconnect(int gamepadId) {
+    _axes.remove(gamepadId);
+    for (final command in _activeSources.keys.toList()) {
+      final sources = _activeSources[command]
+              ?.where((source) => source.gamepadId == gamepadId)
+              .toList() ??
+          const <_CommandSource>[];
+      for (final source in sources) {
+        _setSourceActive(source, command, false);
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    reset();
+    await _subscription?.cancel();
+    _subscription = null;
+    await _commands.close();
+    usingGamepad.dispose();
+  }
+}

--- a/lib/services/storage/settings_keys.dart
+++ b/lib/services/storage/settings_keys.dart
@@ -2,6 +2,7 @@ import 'package:kazumi/services/player/syncplay_endpoint.dart';
 
 enum SettingGroup {
   player,
+  input,
   danmaku,
   theme,
   interface,
@@ -56,6 +57,21 @@ class SettingsKeys {
     _SettingBoxKey.searchEnhanceEnable,
     true,
     group: SettingGroup.misc,
+  );
+  static const gamepadEnabled = SettingKey<bool>(
+    'gamepadEnabled',
+    true,
+    group: SettingGroup.input,
+  );
+  static const gamepadStickDeadZone = SettingKey<double>(
+    'gamepadStickDeadZone',
+    0.5,
+    group: SettingGroup.input,
+  );
+  static const gamepadRepeatDelay = SettingKey<int>(
+    'gamepadRepeatDelay',
+    250,
+    group: SettingGroup.input,
   );
   static const autoUpdate = SettingKey<bool>(
     _SettingBoxKey.autoUpdate,
@@ -532,6 +548,9 @@ class SettingsKeys {
     hAenable,
     hardwareDecoder,
     searchEnhanceEnable,
+    gamepadEnabled,
+    gamepadStickDeadZone,
+    gamepadRepeatDelay,
     autoUpdate,
     checkPluginUpdateOnStartup,
     alwaysOntop,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -14,6 +14,7 @@
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <tray_manager/tray_manager_plugin.h>
+#include <universal_gamepad/gamepad_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -42,6 +43,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) tray_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "TrayManagerPlugin");
   tray_manager_plugin_register_with_registrar(tray_manager_registrar);
+  g_autoptr(FlPluginRegistrar) universal_gamepad_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GamepadPlugin");
+  gamepad_plugin_register_with_registrar(universal_gamepad_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -11,6 +11,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   screen_retriever_linux
   tray_manager
+  universal_gamepad
   url_launcher_linux
   window_manager
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -21,6 +21,7 @@ import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
 import tray_manager
+import universal_gamepad
 import url_launcher_macos
 import wakelock_plus
 import window_manager
@@ -42,6 +43,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
+  GamepadPlugin.register(with: registry.registrar(forPlugin: "GamepadPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1670,6 +1670,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  universal_gamepad:
+    dependency: "direct main"
+    description:
+      name: universal_gamepad
+      sha256: "8570c1c2d354c0959592839f45683599fd7d6a3b8b438b5b634388c6a5724798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.8"
   universal_io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   cookie_jar: ^4.0.9
   crypto: ^3.0.6
   connectivity_plus: ^6.0.5
+  universal_gamepad: 1.5.8
 
   path_provider: ^2.1.5
   hive_ce: ^2.16.0

--- a/test/exit_dialog_gamepad_test.dart
+++ b/test/exit_dialog_gamepad_test.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/dialog/dialog.dart';
+import 'package:kazumi/bean/dialog/exit_confirmation_dialog.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+import 'package:kazumi/navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+void main() {
+  GamepadButtonEvent button(GamepadButton button, bool pressed) {
+    return GamepadButtonEvent(
+      gamepadId: 1,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      button: button,
+      pressed: pressed,
+      value: pressed ? 1 : 0,
+    );
+  }
+
+  testWidgets('gamepad can navigate and dismiss the exit dialog',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    addTearDown(service.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: rootNavigatorKey,
+        navigatorObservers: [KazumiDialog.observer, topRouteObserver],
+        builder: (context, child) => GamepadNavigationScope(
+          service: service,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const Scaffold(body: Center(child: Text('home'))),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    unawaited(KazumiDialog.show<ExitDialogResult>(
+      builder: (_) => const ExitConfirmationDialog(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('关闭 Kazumi？'), findsOneWidget);
+
+    Future<void> press(GamepadButton b) async {
+      service.handleEvent(button(b, true));
+      service.handleEvent(button(b, false));
+      await tester.pumpAndSettle();
+    }
+
+    // The first gamepad press must land focus somewhere usable in the dialog.
+    await press(GamepadButton.dpadDown);
+    expect(tester.takeException(), isNull);
+    final dialogFocus = FocusManager.instance.primaryFocus;
+    expect(dialogFocus, isNotNull);
+    expect(dialogFocus!.context, isNotNull);
+    expect(
+      ModalRoute.of(dialogFocus.context!)?.settings.name,
+      'KazumiDialog',
+      reason: 'focus should be inside the exit dialog',
+    );
+
+    // Walk down and activate until the "exit" option is selected. Before the
+    // fix, A did nothing on the radio tiles and the confirm label never
+    // changed.
+    for (var i = 0; i < 4 && find.text('退出').evaluate().isEmpty; i++) {
+      await press(GamepadButton.dpadDown);
+      await press(GamepadButton.a);
+      expect(tester.takeException(), isNull);
+    }
+    expect(find.text('退出'), findsOneWidget,
+        reason: 'A should activate the focused exit option');
+
+    // B dismisses the dialog and returns to the page.
+    await press(GamepadButton.b);
+    expect(tester.takeException(), isNull);
+    expect(find.text('关闭 Kazumi？'), findsNothing);
+    expect(find.text('home'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}

--- a/test/gamepad_focus_recovery_test.dart
+++ b/test/gamepad_focus_recovery_test.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+import 'dart:ui' show ViewFocusEvent, ViewFocusState, ViewFocusDirection;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+void main() {
+  testWidgets(
+      'key release is observed even when the new focused child consumes it',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focus = FocusNode();
+    final events = <GamepadCommandEvent>[];
+    final sub = service.commands.listen(events.add);
+    var swallow = false;
+    await tester.pumpWidget(MaterialApp(
+        home: GamepadNavigationScope(
+      service: service,
+      child: Focus(
+          focusNode: focus,
+          autofocus: true,
+          onKeyEvent: (_, event) =>
+              swallow ? KeyEventResult.handled : KeyEventResult.ignored,
+          child: const SizedBox.expand()),
+    )));
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    swallow = true;
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+    final released = events.length;
+    await tester.pump(const Duration(seconds: 1));
+    expect(events.length, released);
+    await tester.pumpWidget(const SizedBox.shrink());
+    focus.dispose();
+    unawaited(sub.cancel());
+    unawaited(service.dispose());
+  });
+
+  testWidgets(
+      'desktop view focus loss blocks native input even while app is resumed',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focus = FocusNode();
+    final events = <GamepadCommandEvent>[];
+    final sub = service.commands.listen(events.add);
+    await tester.pumpWidget(MaterialApp(
+        home: GamepadNavigationScope(
+      service: service,
+      child: Focus(
+          focusNode: focus, autofocus: true, child: const SizedBox.expand()),
+    )));
+    await tester.pump();
+    void press(bool pressed) => service.handleEvent(GamepadButtonEvent(
+        gamepadId: 1,
+        timestamp: 0,
+        button: GamepadButton.dpadDown,
+        pressed: pressed,
+        value: pressed ? 1 : 0));
+    press(true);
+    tester.binding.handleViewFocusChanged(ViewFocusEvent(
+        viewId: tester.view.viewId,
+        state: ViewFocusState.unfocused,
+        direction: ViewFocusDirection.undefined));
+    press(false);
+    press(true);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump(const Duration(seconds: 1));
+    expect(events, hasLength(1));
+    tester.binding.handleViewFocusChanged(ViewFocusEvent(
+        viewId: tester.view.viewId,
+        state: ViewFocusState.focused,
+        direction: ViewFocusDirection.undefined));
+    press(false);
+    press(true);
+    expect(events, hasLength(2));
+    press(false);
+    await tester.pumpWidget(const SizedBox.shrink());
+    focus.dispose();
+    unawaited(sub.cancel());
+    unawaited(service.dispose());
+  });
+
+  testWidgets(
+      'gamepad uses slider actions and vertical movement leaves the slider',
+      (tester) async {
+    final service = GamepadInputService(
+        events: const Stream.empty(), duplicateWindow: Duration.zero);
+    final slider = FocusNode();
+    final next = FocusNode();
+    var value = 0.5;
+    await tester.pumpWidget(MaterialApp(
+        home: GamepadNavigationScope(
+      service: service,
+      child: StatefulBuilder(
+          builder: (context, setState) => Scaffold(
+                  body: Column(children: [
+                Slider(
+                    focusNode: slider,
+                    value: value,
+                    onChanged: (v) => setState(() => value = v)),
+                TextButton(
+                    focusNode: next,
+                    onPressed: () {},
+                    child: const Text('next')),
+              ]))),
+    )));
+    slider.requestFocus();
+    await tester.pump();
+    Future<void> press(GamepadButton button) async {
+      service.handleEvent(GamepadButtonEvent(
+          gamepadId: 1, timestamp: 0, button: button, pressed: true, value: 1));
+      service.handleEvent(GamepadButtonEvent(
+          gamepadId: 1,
+          timestamp: 0,
+          button: button,
+          pressed: false,
+          value: 0));
+      await tester.pumpAndSettle();
+    }
+
+    await press(GamepadButton.dpadRight);
+    expect(value, greaterThan(0.5));
+    expect(slider.hasFocus, isTrue);
+    await press(GamepadButton.dpadDown);
+    expect(next.hasFocus, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+    slider.dispose();
+    next.dispose();
+    unawaited(service.dispose());
+  });
+}

--- a/test/gamepad_input_lifecycle_test.dart
+++ b/test/gamepad_input_lifecycle_test.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+GamepadAxisEvent axis(double value, {int id = 1}) => GamepadAxisEvent(
+    gamepadId: id, timestamp: 0, axis: GamepadAxis.leftStickX, value: value);
+
+void main() {
+  testWidgets('deduplicated delayed node still repeats a sustained hold',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final sub = service.commands.listen(events.add);
+    service.handleEvent(axis(1));
+    service.handleEvent(axis(0));
+    service.handleEvent(axis(1, id: 2));
+    expect(events, hasLength(1));
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(events, hasLength(2));
+    expect(events.last.isRepeat, isTrue);
+    service.handleEvent(axis(0, id: 2));
+    await tester.pump(const Duration(seconds: 1));
+    expect(events, hasLength(2));
+    service.reset();
+    unawaited(sub.cancel());
+    unawaited(service.dispose());
+  });
+
+  for (final resetOnRepeat in [false, true]) {
+    testWidgets(
+        'reset inside ${resetOnRepeat ? 'repeat' : 'press'} leaves no repeat timer',
+        (tester) async {
+      final service = GamepadInputService(events: const Stream.empty());
+      var count = 0;
+      final sub = service.commands.listen((event) {
+        count++;
+        if (event.isRepeat == resetOnRepeat) service.reset();
+      });
+      service.handleEvent(axis(1));
+      await tester.pump(const Duration(milliseconds: 250));
+      final expected = resetOnRepeat ? 2 : 1;
+      expect(count, expected);
+      await tester.pump(const Duration(seconds: 1));
+      expect(count, expected);
+      // Do not reset here: pending timers must fail the widget test.
+      unawaited(sub.cancel());
+    });
+  }
+
+  testWidgets(
+      'background events cannot re-arm input and resume accepts a new press',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final sub = service.commands.listen(events.add);
+    service.handleEvent(axis(1));
+    service.setSuspended(true);
+    service.handleEvent(axis(-1));
+    service.handleKeyboardNavigation(GamepadCommand.navigateDown, true);
+    await tester.pump(const Duration(seconds: 3));
+    expect(events, hasLength(1));
+    service.setSuspended(false);
+    service.handleEvent(axis(-1));
+    expect(events.last.command, GamepadCommand.navigateLeft);
+    service.handleEvent(axis(0));
+    await tester.pump(const Duration(seconds: 3));
+    expect(events, hasLength(2));
+    service.reset();
+    unawaited(sub.cancel());
+    unawaited(service.dispose());
+  });
+
+  testWidgets(
+      'silent keyboard source expires but an unchanged native hold continues',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final sub = service.commands.listen(events.add);
+    service.handleKeyboardNavigation(GamepadCommand.navigateDown, true);
+    await tester.pump(const Duration(seconds: 3));
+    final afterTimeout = events.length;
+    await tester.pump(const Duration(seconds: 1));
+    expect(events.length, afterTimeout);
+    service.handleEvent(axis(1));
+    await tester.pump(const Duration(seconds: 3));
+    expect(events.last.command, GamepadCommand.navigateRight);
+    expect(events.last.isRepeat, isTrue);
+    service.handleEvent(axis(0));
+    final released = events.length;
+    await tester.pump(const Duration(seconds: 1));
+    expect(events.length, released);
+    service.reset();
+    unawaited(sub.cancel());
+    unawaited(service.dispose());
+  });
+}

--- a/test/gamepad_input_service_test.dart
+++ b/test/gamepad_input_service_test.dart
@@ -1,0 +1,345 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+void main() {
+  GamepadButtonEvent button(
+    GamepadButton button,
+    bool pressed, {
+    int id = 1,
+    double? value,
+  }) {
+    return GamepadButtonEvent(
+      gamepadId: id,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      button: button,
+      pressed: pressed,
+      value: value ?? (pressed ? 1 : 0),
+    );
+  }
+
+  GamepadAxisEvent axis(
+    GamepadAxis axis,
+    double value, {
+    int id = 1,
+  }) {
+    return GamepadAxisEvent(
+      gamepadId: id,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      axis: axis,
+      value: value,
+    );
+  }
+
+  GamepadConnectionEvent disconnect({int id = 1}) {
+    return GamepadConnectionEvent(
+      gamepadId: id,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      connected: false,
+      info: GamepadInfo(id: id, name: 'Test gamepad'),
+    );
+  }
+
+  test('face buttons emit semantic commands once per press', () async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(button(GamepadButton.a, true));
+    service.handleEvent(button(GamepadButton.a, true));
+    service.handleEvent(button(GamepadButton.a, false));
+    service.handleEvent(button(GamepadButton.b, true));
+
+    expect(
+      events.map((event) => event.command),
+      <GamepadCommand>[GamepadCommand.activate, GamepadCommand.back],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('left stick applies dead zone, dominance, and release hysteresis',
+      () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, -0.4));
+    expect(events, isEmpty);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, -0.8));
+    service.handleEvent(axis(GamepadAxis.leftStickY, -0.55));
+    expect(events.map((event) => event.command), [GamepadCommand.navigateUp]);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, -0.1));
+    service.handleEvent(axis(GamepadAxis.leftStickX, -0.9));
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateUp, GamepadCommand.navigateLeft],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('holding a stick past the dead zone moves focus exactly once', () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    // A real stick streams a ramp of values while held.
+    for (final value in <double>[0.6, 0.7, 0.85, 0.95, 1.0, 0.9]) {
+      service.handleEvent(axis(GamepadAxis.leftStickX, value));
+    }
+
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateRight],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('duplicate device nodes for one physical stick emit a single step',
+      () async {
+    // Handhelds expose one physical pad through several nodes at once: a native
+    // node, an xpad compatibility node, and virtual pads from Handheld Daemon
+    // or Steam Input. Each reports the same flick.
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 1));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 2));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 3));
+
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateDown],
+    );
+
+    // Releasing only some nodes keeps the command held, so no extra step fires
+    // when the remaining nodes release.
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0, id: 1));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0, id: 2));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0, id: 3));
+    expect(events.length, 1);
+
+    // A fresh flick after full release moves once more, once it is clearly a
+    // separate physical action rather than a duplicate report.
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 1));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 2));
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateDown, GamepadCommand.navigateDown],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('axis and dpad on one device share one held navigation state', () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+      duplicateWindow: Duration.zero,
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9));
+    service.handleEvent(button(GamepadButton.dpadDown, true));
+    service.handleEvent(button(GamepadButton.dpadDown, false));
+
+    // Releasing the synthetic D-pad must not release the still-held axis.
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.95));
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateDown],
+    );
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0));
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('keyboard arrow and gamepad axis share one held navigation state',
+      () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+      duplicateWindow: Duration.zero,
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleKeyboardNavigation(GamepadCommand.navigateRight, true);
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.9));
+    service.handleKeyboardNavigation(GamepadCommand.navigateRight, false);
+
+    // HHD's virtual arrow can release before the gamepad axis. The axis stays
+    // held and must not create a second rising edge on its next report.
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.95));
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateRight],
+    );
+
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.0));
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('lost keyboard KeyUp is released by the navigation watchdog', () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      duplicateWindow: Duration.zero,
+      keyboardHoldTimeout: const Duration(milliseconds: 20),
+      initialRepeatDelay: const Duration(hours: 1),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleKeyboardNavigation(GamepadCommand.navigateLeft, true);
+    await Future<void>.delayed(const Duration(milliseconds: 35));
+    // No KeyUp arrived. A fresh press must still produce a new edge after the
+    // watchdog has released the stale virtual-keyboard source.
+    service.handleKeyboardNavigation(GamepadCommand.navigateLeft, true);
+
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateLeft, GamepadCommand.navigateLeft],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('duplicate nodes reporting the same flick out of step emit one step',
+      () async {
+    // Nodes for one physical stick do not report in lockstep: one can cross the
+    // threshold and fall back to centre before another crosses it at all.
+    // Command-level merging alone still sees two press/release cycles here.
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 1));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0, id: 1));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9, id: 2));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0, id: 2));
+
+    expect(
+      events.map((event) => event.command),
+      [GamepadCommand.navigateDown],
+    );
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('a deliberate second flick after the merge window still moves focus',
+      () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      stickDeadZone: 0.5,
+      initialRepeatDelay: const Duration(hours: 1),
+      duplicateWindow: const Duration(milliseconds: 30),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.9));
+    service.handleEvent(axis(GamepadAxis.leftStickY, 0.0));
+
+    expect(events.length, 2);
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('duplicate device nodes for one button press emit a single command',
+      () async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(button(GamepadButton.a, true, id: 1));
+    service.handleEvent(button(GamepadButton.a, true, id: 2));
+    expect(events.length, 1);
+
+    service.handleEvent(button(GamepadButton.a, false, id: 1));
+    service.handleEvent(button(GamepadButton.a, false, id: 2));
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    service.handleEvent(button(GamepadButton.a, true, id: 1));
+    expect(events.length, 2);
+
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('repeat is app-timed and stops immediately on release', () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      initialRepeatDelay: const Duration(milliseconds: 10),
+      repeatInterval: const Duration(milliseconds: 10),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(button(GamepadButton.dpadRight, true));
+    await Future<void>.delayed(const Duration(milliseconds: 38));
+    expect(events.length, greaterThanOrEqualTo(2));
+    expect(events.first.isRepeat, isFalse);
+    expect(events.skip(1).every((event) => event.isRepeat), isTrue);
+
+    service.handleEvent(button(GamepadButton.dpadRight, false));
+    final countAfterRelease = events.length;
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    expect(events.length, countAfterRelease);
+    await subscription.cancel();
+    await service.dispose();
+  });
+
+  test('disconnect releases everything that controller held', () async {
+    final service = GamepadInputService(
+      events: const Stream.empty(),
+      initialRepeatDelay: const Duration(milliseconds: 10),
+      repeatInterval: const Duration(milliseconds: 10),
+    );
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+
+    service.handleEvent(button(GamepadButton.dpadDown, true));
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    service.handleEvent(disconnect());
+    final countAfterDisconnect = events.length;
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    expect(events.length, countAfterDisconnect);
+
+    // The command is free again, so another pad can drive it.
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    service.handleEvent(button(GamepadButton.dpadDown, true, id: 2));
+    expect(events.length, countAfterDisconnect + 1);
+    await subscription.cancel();
+    await service.dispose();
+  });
+}

--- a/test/gamepad_navigation_test.dart
+++ b/test/gamepad_navigation_test.dart
@@ -1,0 +1,482 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+import 'package:kazumi/navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+void main() {
+  testWidgets('B closes a modal and restores the underlying page focus',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final pageFocus = FocusNode();
+    late BuildContext pageContext;
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: rootNavigatorKey,
+      navigatorObservers: [topRouteObserver],
+      builder: (context, child) => GamepadNavigationScope(
+        service: service,
+        child: child!,
+      ),
+      home: Builder(builder: (context) {
+        pageContext = context;
+        return Scaffold(
+            body: TextButton(
+          focusNode: pageFocus,
+          onPressed: () {},
+          child: const Text('page action'),
+        ));
+      }),
+    ));
+    pageFocus.requestFocus();
+    await tester.pumpAndSettle();
+    unawaited(showDialog<void>(
+      context: pageContext,
+      builder: (context) => AlertDialog(
+        title: const Text('modal'),
+        actions: [
+          TextButton(
+            autofocus: true,
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('close'),
+          )
+        ],
+      ),
+    ));
+    await tester.pumpAndSettle();
+    service.handleEvent(GamepadButtonEvent(
+      gamepadId: 1,
+      timestamp: 1,
+      button: GamepadButton.b,
+      pressed: true,
+      value: 1,
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('modal'), findsNothing);
+    expect(find.text('page action'), findsOneWidget);
+    expect(pageFocus.hasFocus, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+    service.reset();
+    pageFocus.dispose();
+  });
+
+  testWidgets('backgrounding releases held controller navigation',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final events = <GamepadCommandEvent>[];
+    final subscription = service.commands.listen(events.add);
+    await tester.pumpWidget(MaterialApp(
+        home: GamepadNavigationScope(
+      service: service,
+      child: const Scaffold(body: Text('page')),
+    )));
+    service.handleEvent(GamepadButtonEvent(
+      gamepadId: 1,
+      timestamp: 1,
+      button: GamepadButton.dpadDown,
+      pressed: true,
+      value: 1,
+    ));
+    await tester.pump();
+    expect(events.length, 1);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump(const Duration(seconds: 1));
+    expect(events.length, 1);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpWidget(const SizedBox.shrink());
+    unawaited(subscription.cancel());
+    service.reset();
+  });
+
+  GamepadButtonEvent button(GamepadButton button, bool pressed) {
+    return GamepadButtonEvent(
+      gamepadId: 1,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      button: button,
+      pressed: pressed,
+      value: pressed ? 1 : 0,
+    );
+  }
+
+  GamepadAxisEvent axis(GamepadAxis axis, double value) {
+    return GamepadAxisEvent(
+      gamepadId: 1,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      axis: axis,
+      value: value,
+    );
+  }
+
+  testWidgets('virtual arrow and gamepad axis move focus only once',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final first = FocusNode();
+    final second = FocusNode();
+    final third = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: Row(
+              children: [
+                TextButton(
+                  focusNode: first,
+                  onPressed: () {},
+                  child: const Text('first'),
+                ),
+                TextButton(
+                  focusNode: second,
+                  onPressed: () {},
+                  child: const Text('second'),
+                ),
+                TextButton(
+                  focusNode: third,
+                  onPressed: () {},
+                  child: const Text('third'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    first.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(second.hasFocus, isTrue);
+
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.9));
+    await tester.pump();
+    expect(second.hasFocus, isTrue);
+    expect(third.hasFocus, isFalse);
+
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.95));
+    await tester.pump();
+    expect(second.hasFocus, isTrue);
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.0));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    service.reset();
+    first.dispose();
+    second.dispose();
+    third.dispose();
+  });
+
+  testWidgets('native B suppresses a virtual keyboard activation',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focusNode = FocusNode();
+    var activations = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: TextButton(
+              focusNode: focusNode,
+              onPressed: () => activations++,
+              child: const Text('action'),
+            ),
+          ),
+        ),
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pump();
+
+    service.handleEvent(button(GamepadButton.b, true));
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(activations, 0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    service.reset();
+    focusNode.dispose();
+  });
+
+  testWidgets('native B also cancels an activation that arrived first',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focusNode = FocusNode();
+    var activations = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: TextButton(
+              focusNode: focusNode,
+              onPressed: () => activations++,
+              child: const Text('action'),
+            ),
+          ),
+        ),
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    service.handleEvent(button(GamepadButton.b, true));
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(activations, 0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    service.reset();
+    focusNode.dispose();
+  });
+
+  testWidgets('a native A and its virtual keyboard copy activate once',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focusNode = FocusNode();
+    var activations = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: TextButton(
+              focusNode: focusNode,
+              onPressed: () => activations++,
+              child: const Text('action'),
+            ),
+          ),
+        ),
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pump();
+
+    service.handleEvent(button(GamepadButton.a, true));
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(activations, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    service.reset();
+    focusNode.dispose();
+  });
+
+  testWidgets('keyboard activation is preserved when no native button arrives',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final focusNode = FocusNode();
+    var activations = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: TextButton(
+              focusNode: focusNode,
+              onPressed: () => activations++,
+              child: const Text('action'),
+            ),
+          ),
+        ),
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(activations, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    service.reset();
+    focusNode.dispose();
+  });
+
+  testWidgets('Y keeps text focus and delegates to the page context action',
+      (tester) async {
+    final controller = TextEditingController();
+    final focus = FocusNode();
+    final service = GamepadInputService(events: const Stream.empty());
+    var contextActions = 0;
+    String? submitted;
+    await tester.pumpWidget(MaterialApp(
+      home: GamepadNavigationScope(
+        service: service,
+        child: Actions(
+          actions: {
+            GamepadContextActionIntent:
+                CallbackAction<GamepadContextActionIntent>(onInvoke: (_) {
+              contextActions++;
+              return null;
+            }),
+          },
+          child: Scaffold(
+            body: TextField(
+              focusNode: focus,
+              controller: controller,
+              textInputAction: TextInputAction.search,
+              onSubmitted: (value) => submitted = value,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.showKeyboard(find.byType(TextField));
+    tester.testTextInput.updateEditingValue(const TextEditingValue(
+      text: '动画',
+      selection: TextSelection.collapsed(offset: 2),
+      composing: TextRange(start: 0, end: 2),
+    ));
+    await tester.pump();
+    service.handleEvent(button(GamepadButton.y, true));
+    service.handleEvent(button(GamepadButton.y, false));
+    await tester.pump();
+    expect(contextActions, 1);
+    expect(focus.hasFocus, isTrue);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byType(TextButton), findsNothing);
+    expect(controller.value.composing, const TextRange(start: 0, end: 2));
+    expect(tester.testTextInput.isVisible, isTrue);
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    expect(submitted, '动画');
+    await tester.pumpWidget(const SizedBox.shrink());
+    service.reset();
+    controller.dispose();
+    focus.dispose();
+  });
+
+  testWidgets('text arrow keys do not become gamepad navigation',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final controller = TextEditingController(text: 'abc');
+    final focus = FocusNode();
+    final commands = <GamepadCommand>[];
+    final subscription = service.commands.listen((event) {
+      commands.add(event.command);
+    });
+    await tester.pumpWidget(MaterialApp(
+      home: GamepadNavigationScope(
+        service: service,
+        child: Scaffold(
+            body: TextField(
+          controller: controller,
+          focusNode: focus,
+        )),
+      ),
+    ));
+    await tester.showKeyboard(find.byType(TextField));
+    controller.selection = const TextSelection.collapsed(offset: 2);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(controller.selection.baseOffset, 1);
+    expect(commands, isEmpty);
+    expect(focus.hasFocus, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+    unawaited(subscription.cancel());
+    service.reset();
+    controller.dispose();
+    focus.dispose();
+  });
+
+  testWidgets('pointer input hides hints and controller restores navigation',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final first = FocusNode();
+    final second = FocusNode();
+    await tester.pumpWidget(MaterialApp(
+      home: GamepadNavigationScope(
+        service: service,
+        child: Scaffold(
+            body: Row(children: [
+          TextButton(
+              focusNode: first, onPressed: () {}, child: const Text('one')),
+          TextButton(
+              focusNode: second, onPressed: () {}, child: const Text('two')),
+        ])),
+      ),
+    ));
+    first.requestFocus();
+    await tester.pump();
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0.9));
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0));
+    await tester.pump();
+    expect(second.hasFocus, isTrue);
+    expect(service.usingGamepad.value, isTrue);
+    await tester.tap(find.text('one'));
+    await tester.pump();
+    expect(service.usingGamepad.value, isFalse);
+    first.requestFocus();
+    await tester.pump();
+    service.handleEvent(axis(GamepadAxis.leftStickX, -0.9));
+    service.handleEvent(axis(GamepadAxis.leftStickX, 0));
+    await tester.pump();
+    expect(service.usingGamepad.value, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+    service.reset();
+    first.dispose();
+    second.dispose();
+  });
+
+  testWidgets('joystick leaves a focused text field instead of trapping',
+      (tester) async {
+    // A focused text field must not swallow directional input as cursor
+    // movement; the stick has to be able to move on to the next control.
+    final service = GamepadInputService(events: const Stream.empty());
+    final textFocus = FocusNode(debugLabel: 'danmaku input');
+    final buttonFocus = FocusNode(debugLabel: 'next button');
+    await tester.pumpWidget(MaterialApp(
+      home: GamepadNavigationScope(
+        service: service,
+        child: Scaffold(
+          body: Row(children: [
+            SizedBox(
+              width: 220,
+              child: TextField(
+                focusNode: textFocus,
+                autofocus: true,
+                decoration: const InputDecoration(hintText: 'danmaku'),
+              ),
+            ),
+            TextButton(
+              focusNode: buttonFocus,
+              onPressed: () {},
+              child: const Text('next'),
+            ),
+          ]),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(textFocus.hasPrimaryFocus, isTrue);
+
+    service.handleEvent(button(GamepadButton.dpadRight, true));
+    service.handleEvent(button(GamepadButton.dpadRight, false));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(buttonFocus.hasPrimaryFocus, isTrue,
+        reason: 'right must move focus out of the text field');
+    await tester.pumpWidget(const SizedBox.shrink());
+    service.reset();
+    textFocus.dispose();
+    buttonFocus.dispose();
+  });
+}

--- a/test/interactive_seek_lifecycle_test.dart
+++ b/test/interactive_seek_lifecycle_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/pages/player/controller/interactive_seek_lifecycle.dart';
+
+void main() {
+  late Duration position;
+  late bool playing;
+  late List<String> actions;
+  late InteractiveSeekLifecycle lifecycle;
+
+  InteractiveSeekLifecycle createLifecycle() {
+    return InteractiveSeekLifecycle(
+      readPosition: () => position,
+      isPlaying: () => playing,
+      writePreview: (value) => position = value,
+      normalize: (value) {
+        final milliseconds = value.inMilliseconds.clamp(0, 60000).toInt();
+        return Duration(milliseconds: milliseconds);
+      },
+      pause: () async {
+        actions.add('pause');
+        playing = false;
+      },
+      seek: (target) async {
+        actions.add('seek:${target.inSeconds}');
+        position = target;
+      },
+      play: () async {
+        actions.add('play');
+        playing = true;
+      },
+    );
+  }
+
+  setUp(() {
+    position = const Duration(seconds: 10);
+    playing = true;
+    actions = <String>[];
+    lifecycle = createLifecycle();
+  });
+
+  test('playing session pauses, seeks once, then resumes on commit', () async {
+    lifecycle.begin();
+    expect(lifecycle.update(const Duration(seconds: 35)), isTrue);
+    expect(position, const Duration(seconds: 35));
+
+    expect(await lifecycle.commit(), isTrue);
+
+    expect(actions, <String>['pause', 'seek:35', 'play']);
+    expect(position, const Duration(seconds: 35));
+    expect(playing, isTrue);
+    expect(lifecycle.hasActiveSession, isFalse);
+  });
+
+  test('paused session stays paused after commit', () async {
+    playing = false;
+    lifecycle.begin();
+    lifecycle.update(const Duration(seconds: 20));
+
+    expect(await lifecycle.commit(), isTrue);
+
+    expect(actions, <String>['seek:20']);
+    expect(playing, isFalse);
+  });
+
+  test('cancel restores position and the original playing state', () async {
+    lifecycle.begin();
+    lifecycle.update(const Duration(seconds: 40));
+
+    expect(await lifecycle.cancel(), isTrue);
+
+    expect(actions, <String>['pause', 'play']);
+    expect(position, const Duration(seconds: 10));
+    expect(playing, isTrue);
+    expect(lifecycle.hasActiveSession, isFalse);
+  });
+
+  test('cancelled paused session neither seeks nor starts playback', () async {
+    playing = false;
+    lifecycle.begin();
+    lifecycle.update(const Duration(seconds: 50));
+
+    expect(await lifecycle.cancel(), isTrue);
+
+    expect(actions, isEmpty);
+    expect(position, const Duration(seconds: 10));
+    expect(playing, isFalse);
+  });
+
+  test(
+    'commit is idempotent while an asynchronous seek is in flight',
+    () async {
+      final seekGate = Completer<void>();
+      var seekCount = 0;
+      lifecycle = InteractiveSeekLifecycle(
+        readPosition: () => position,
+        isPlaying: () => false,
+        writePreview: (value) => position = value,
+        normalize: (value) => value,
+        pause: () async {},
+        seek: (_) async {
+          seekCount += 1;
+          await seekGate.future;
+        },
+        play: () async {},
+      );
+      lifecycle.begin();
+      lifecycle.update(const Duration(seconds: 30));
+
+      final first = lifecycle.commit();
+      final second = lifecycle.commit();
+      await Future<void>.delayed(Duration.zero);
+      expect(seekCount, 1);
+
+      seekGate.complete();
+      expect(await first, isTrue);
+      expect(await second, isTrue);
+    },
+  );
+
+  test('a stalled media operation releases the interactive session', () async {
+    final stalled = Completer<void>();
+    lifecycle = InteractiveSeekLifecycle(
+      readPosition: () => position,
+      isPlaying: () => false,
+      writePreview: (value) => position = value,
+      normalize: (value) => value,
+      pause: () async {},
+      seek: (_) => stalled.future,
+      play: () async {},
+      operationTimeout: const Duration(milliseconds: 1),
+    );
+    lifecycle.begin();
+    lifecycle.update(const Duration(seconds: 30));
+
+    await expectLater(lifecycle.commit(), throwsA(isA<TimeoutException>()));
+    expect(lifecycle.hasActiveSession, isFalse);
+  });
+
+  test('invalidating a pending pause prevents stale seek and play', () async {
+    final pauseGate = Completer<void>();
+    lifecycle = InteractiveSeekLifecycle(
+      readPosition: () => position,
+      isPlaying: () => true,
+      writePreview: (value) => position = value,
+      normalize: (value) => value,
+      pause: () => pauseGate.future,
+      seek: (_) async => actions.add('seek'),
+      play: () async => actions.add('play'),
+    );
+    lifecycle.begin();
+    lifecycle.update(const Duration(seconds: 30));
+    final completion = lifecycle.commit();
+    lifecycle.invalidate();
+    pauseGate.complete();
+    expect(await completion, isFalse);
+    expect(actions, isEmpty);
+    expect(lifecycle.hasActiveSession, isFalse);
+  });
+
+  test('failed seek releases the session and permits a new gesture', () async {
+    lifecycle = InteractiveSeekLifecycle(
+      readPosition: () => position,
+      isPlaying: () => false,
+      writePreview: (value) => position = value,
+      normalize: (value) => value,
+      pause: () async {},
+      seek: (_) async => throw StateError('backend failure'),
+      play: () async {},
+    );
+    lifecycle.begin();
+    await expectLater(lifecycle.commit(), throwsStateError);
+    expect(lifecycle.hasActiveSession, isFalse);
+    lifecycle.begin();
+    expect(lifecycle.update(const Duration(seconds: 25)), isTrue);
+    expect(await lifecycle.cancel(), isTrue);
+  });
+}

--- a/test/player_focus_reparent_test.dart
+++ b/test/player_focus_reparent_test.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+// Regression for the playback crash:
+// 'child != this': Tried to make a child into a parent of itself.
+// VideoPage and PlayerItem briefly attached the same FocusNode in nested
+// Focus widgets. As soon as joystick focus moved, Flutter tried to reparent
+// the node to itself. The fix keeps a single attachment inside the player
+// area; this test locks that pattern and documents the constraint.
+void main() {
+  GamepadButtonEvent button(GamepadButton button, bool pressed) {
+    return GamepadButtonEvent(
+      gamepadId: 1,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+      button: button,
+      pressed: pressed,
+      value: pressed ? 1 : 0,
+    );
+  }
+
+  testWidgets('single player focus survives joystick traversal to sibling',
+      (tester) async {
+    final service = GamepadInputService(events: const Stream.empty());
+    final playerFocus = FocusNode(debugLabel: 'Video player shortcut scope');
+    final panelScope = FocusScopeNode(debugLabel: 'Player controls');
+    addTearDown(() {
+      playerFocus.dispose();
+      panelScope.dispose();
+      service.reset();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: Column(
+              children: [
+                // Top bar sibling, outside the player Actions subtree, just
+                // like VideoPage's back/refresh buttons.
+                TextButton(
+                  autofocus: true,
+                  onPressed: () {},
+                  child: const Text('top action'),
+                ),
+                Actions(
+                  actions: <Type, Action<Intent>>{},
+                  child: Focus(
+                    focusNode: playerFocus,
+                    autofocus: true,
+                    child: FocusScope(
+                      node: panelScope,
+                      child: Column(
+                        children: [
+                          TextButton(
+                            onPressed: () {},
+                            child: const Text('panel first'),
+                          ),
+                          TextButton(
+                            onPressed: () {},
+                            child: const Text('panel second'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Drive joystick navigation the same way the player does: move within the
+    // panel, then out toward the sibling top action. None of these steps may
+    // throw 'child != this'.
+    for (var i = 0; i < 4; i++) {
+      service.handleEvent(button(GamepadButton.dpadDown, true));
+      service.handleEvent(button(GamepadButton.dpadDown, false));
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+    for (var i = 0; i < 4; i++) {
+      service.handleEvent(button(GamepadButton.dpadUp, true));
+      service.handleEvent(button(GamepadButton.dpadUp, false));
+      await tester.pump(const Duration(milliseconds: 150));
+    }
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(FocusManager.instance.primaryFocus, isNotNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('joystick moves between top bar and panel across scopes',
+      (tester) async {
+    // Mirrors the VideoPage/PlayerItem wiring: the panel lives in its own
+    // traversal scope (directional traversal never leaves the nearest
+    // scope), so up at the panel top edge hands focus to the top bar
+    // explicitly, and down from the top bar hands it back.
+    final service = GamepadInputService(events: const Stream.empty());
+    final playerFocus = FocusNode(debugLabel: 'Video player shortcut scope');
+    final panelScope = FocusScopeNode(debugLabel: 'Player controls');
+    final topScope = FocusScopeNode(debugLabel: 'Video top bar');
+    final topFirst = FocusNode(debugLabel: 'top first');
+    final topSecond = FocusNode(debugLabel: 'top second');
+    final panelFirst = FocusNode(debugLabel: 'panel first');
+    final panelSecond = FocusNode(debugLabel: 'panel second');
+    addTearDown(() {
+      playerFocus.dispose();
+      panelScope.dispose();
+      topScope.dispose();
+      topFirst.dispose();
+      topSecond.dispose();
+      panelFirst.dispose();
+      panelSecond.dispose();
+      service.reset();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: Column(
+              children: [
+                Actions(
+                  actions: <Type, Action<Intent>>{
+                    GamepadNavigateIntent:
+                        CallbackAction<GamepadNavigateIntent>(
+                      onInvoke: (intent) {
+                        if (intent.direction == TraversalDirection.down) {
+                          focusFirstGamepadControl(panelScope);
+                          return null;
+                        }
+                        FocusManager.instance.primaryFocus
+                            ?.focusInDirection(intent.direction);
+                        return null;
+                      },
+                    ),
+                  },
+                  child: FocusScope(
+                    node: topScope,
+                    child: Row(
+                      children: [
+                        TextButton(
+                          focusNode: topFirst,
+                          onPressed: () {},
+                          child: const Text('top first'),
+                        ),
+                        TextButton(
+                          focusNode: topSecond,
+                          onPressed: () {},
+                          child: const Text('top second'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Actions(
+                  actions: <Type, Action<Intent>>{
+                    GamepadNavigateIntent:
+                        CallbackAction<GamepadNavigateIntent>(
+                      onInvoke: (intent) {
+                        final focused = FocusManager.instance.primaryFocus;
+                        final moved = focused?.focusInDirection(
+                              intent.direction,
+                            ) ??
+                            false;
+                        if (!moved &&
+                            intent.direction == TraversalDirection.up) {
+                          focusFirstGamepadControl(topScope);
+                        }
+                        return null;
+                      },
+                    ),
+                  },
+                  child: Focus(
+                    focusNode: playerFocus,
+                    child: FocusScope(
+                      node: panelScope,
+                      child: Column(
+                        children: [
+                          TextButton(
+                            focusNode: panelFirst,
+                            autofocus: true,
+                            onPressed: () {},
+                            child: const Text('panel first'),
+                          ),
+                          TextButton(
+                            focusNode: panelSecond,
+                            onPressed: () {},
+                            child: const Text('panel second'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(panelFirst.hasPrimaryFocus, isTrue);
+
+    // Up from the top edge of the panel must reach the top bar.
+    service.handleEvent(button(GamepadButton.dpadUp, true));
+    service.handleEvent(button(GamepadButton.dpadUp, false));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(topFirst.hasPrimaryFocus, isTrue);
+
+    // Down from the top bar must return into the panel.
+    service.handleEvent(button(GamepadButton.dpadDown, true));
+    service.handleEvent(button(GamepadButton.dpadDown, false));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(panelFirst.hasPrimaryFocus, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('joystick right enters the episode side tab and left returns',
+      (tester) async {
+    // Mirrors the VideoPage/PlayerItem wiring: the episode side tab is a
+    // sibling focus scope on the right, so the player hands focus over on
+    // right and the tab hands it back on left at its own edge.
+    final service = GamepadInputService(events: const Stream.empty());
+    final panelScope = FocusScopeNode(debugLabel: 'Player controls');
+    final sideTabScope = FocusScopeNode(debugLabel: 'Episode side tab');
+    final panelFirst = FocusNode(debugLabel: 'panel first');
+    final tabFirst = FocusNode(debugLabel: 'tab first');
+    final tabSecond = FocusNode(debugLabel: 'tab second');
+    addTearDown(() {
+      panelScope.dispose();
+      sideTabScope.dispose();
+      panelFirst.dispose();
+      tabFirst.dispose();
+      tabSecond.dispose();
+      service.reset();
+    });
+
+    Widget navScope({
+      required FocusScopeNode node,
+      required Widget child,
+      required TraversalDirection exitDirection,
+      required FocusScopeNode exitTarget,
+    }) {
+      return Actions(
+        actions: <Type, Action<Intent>>{
+          GamepadNavigateIntent: CallbackAction<GamepadNavigateIntent>(
+            onInvoke: (intent) {
+              final focused = FocusManager.instance.primaryFocus;
+              final moved =
+                  focused?.focusInDirection(intent.direction) ?? false;
+              if (!moved && intent.direction == exitDirection) {
+                focusFirstGamepadControl(exitTarget);
+              }
+              return null;
+            },
+          ),
+        },
+        child: FocusScope(node: node, child: child),
+      );
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GamepadNavigationScope(
+          service: service,
+          child: Scaffold(
+            body: Row(
+              children: [
+                Expanded(
+                  child: navScope(
+                    node: panelScope,
+                    exitDirection: TraversalDirection.right,
+                    exitTarget: sideTabScope,
+                    child: TextButton(
+                      focusNode: panelFirst,
+                      autofocus: true,
+                      onPressed: () {},
+                      child: const Text('panel first'),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: navScope(
+                    node: sideTabScope,
+                    exitDirection: TraversalDirection.left,
+                    exitTarget: panelScope,
+                    child: Column(
+                      children: [
+                        TextButton(
+                          focusNode: tabFirst,
+                          onPressed: () {},
+                          child: const Text('episode one'),
+                        ),
+                        TextButton(
+                          focusNode: tabSecond,
+                          onPressed: () {},
+                          child: const Text('episode two'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(panelFirst.hasPrimaryFocus, isTrue);
+
+    // Right from the player reaches the episode list.
+    service.handleEvent(button(GamepadButton.dpadRight, true));
+    service.handleEvent(button(GamepadButton.dpadRight, false));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(tabFirst.hasPrimaryFocus, isTrue);
+
+    // Left at the tab's edge returns to the player.
+    service.handleEvent(button(GamepadButton.dpadLeft, true));
+    service.handleEvent(button(GamepadButton.dpadLeft, false));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(panelFirst.hasPrimaryFocus, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}

--- a/test/player_pointer_interaction_test.dart
+++ b/test/player_pointer_interaction_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kazumi/pages/player/player_pointer_interaction.dart';
+
+void main() {
+  group('player surface pointer filtering', () {
+    test('Linux accepts touch and stylus but not mouse', () {
+      final devices = playerSurfaceDragDevices(isLinux: true)!;
+
+      expect(devices, contains(PointerDeviceKind.touch));
+      expect(devices, contains(PointerDeviceKind.stylus));
+      expect(devices, contains(PointerDeviceKind.invertedStylus));
+      expect(devices, isNot(contains(PointerDeviceKind.mouse)));
+      expect(devices, isNot(contains(PointerDeviceKind.trackpad)));
+    });
+
+    test('non-Linux keeps the existing unrestricted device behavior', () {
+      expect(playerSurfaceDragDevices(isLinux: false), isNull);
+    });
+
+    test('Linux desktop seek requires unlocked panel and valid duration', () {
+      expect(
+        shouldEnablePlayerSurfaceSeek(
+          isDesktop: true,
+          isLinux: true,
+          panelLocked: false,
+          videoDuration: const Duration(minutes: 1),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldEnablePlayerSurfaceSeek(
+          isDesktop: true,
+          isLinux: true,
+          panelLocked: true,
+          videoDuration: const Duration(minutes: 1),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldEnablePlayerSurfaceSeek(
+          isDesktop: true,
+          isLinux: true,
+          panelLocked: false,
+          videoDuration: Duration.zero,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldEnablePlayerSurfaceSeek(
+          isDesktop: true,
+          isLinux: false,
+          panelLocked: false,
+          videoDuration: const Duration(minutes: 1),
+        ),
+        isFalse,
+      );
+    });
+
+    test('vertical surface adjustment remains disabled on desktop', () {
+      expect(shouldEnablePlayerSurfaceVerticalDrag(isDesktop: true), isFalse);
+      expect(shouldEnablePlayerSurfaceVerticalDrag(isDesktop: false), isTrue);
+    });
+  });
+
+  group('horizontal drag seek mapping', () {
+    test('one full width maps to at most 120 seconds', () {
+      expect(
+        horizontalDragSeekTarget(
+          initialPosition: const Duration(minutes: 5),
+          videoDuration: const Duration(minutes: 20),
+          cumulativeDeltaX: 1280,
+          surfaceWidth: 1280,
+        ),
+        const Duration(minutes: 7),
+      );
+    });
+
+    test('short videos use their duration as the full-width span', () {
+      expect(
+        horizontalDragSeekTarget(
+          initialPosition: const Duration(seconds: 45),
+          videoDuration: const Duration(seconds: 90),
+          cumulativeDeltaX: -640,
+          surfaceWidth: 1280,
+        ),
+        Duration.zero,
+      );
+    });
+
+    test('target clamps to media bounds and reports net direction', () {
+      final target = horizontalDragSeekTarget(
+        initialPosition: const Duration(seconds: 50),
+        videoDuration: const Duration(seconds: 60),
+        cumulativeDeltaX: 2000,
+        surfaceWidth: 1000,
+      );
+
+      expect(target, const Duration(seconds: 60));
+      expect(
+        interactiveSeekDirection(
+          initialPosition: const Duration(seconds: 50),
+          target: target,
+        ),
+        1,
+      );
+    });
+
+    test('invalid dimensions do not change the preview position', () {
+      expect(
+        horizontalDragSeekTarget(
+          initialPosition: const Duration(seconds: 12),
+          videoDuration: Duration.zero,
+          cumulativeDeltaX: 100,
+          surfaceWidth: 0,
+        ),
+        const Duration(seconds: 12),
+      );
+    });
+  });
+}

--- a/test/settings_gamepad_navigation_test.dart
+++ b/test/settings_gamepad_navigation_test.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:kazumi/bean/widget/gamepad_navigation.dart';
+import 'package:kazumi/navigation.dart';
+import 'package:kazumi/pages/settings/settings_page.dart';
+import 'package:kazumi/services/platform/gamepad_input_service.dart';
+import 'package:kazumi/services/storage/storage.dart';
+import 'package:logger/logger.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:universal_gamepad/universal_gamepad.dart';
+
+const categories = [
+  'player',
+  'danmaku',
+  'keyboard',
+  'plugin',
+  'download-settings',
+  'theme',
+  'interface',
+  'sync',
+  'proxy',
+  'update',
+  'storage',
+  'about'
+];
+
+class _Paths extends PathProviderPlatform {
+  _Paths(this.path);
+  final String path;
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+}
+
+void main() {
+  late Directory temp;
+  late PathProviderPlatform original;
+  late GamepadInputService service;
+  setUpAll(() async {
+    Logger.level = Level.off;
+    temp = await Directory.systemTemp.createTemp('kazumi_settings_gamepad_');
+    original = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _Paths(temp.path);
+    Hive.init(temp.path);
+    await GStorage.init();
+  });
+  tearDownAll(() async {
+    await Hive.close();
+    PathProviderPlatform.instance = original;
+    await temp.delete(recursive: true);
+  });
+  setUp(() {
+    service = GamepadInputService(
+        events: const Stream.empty(), duplicateWindow: Duration.zero);
+  });
+
+  Future<void> openSettings(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1100, 620);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final module = createModule(register: (c) {
+      c.route('/settings',
+          child: (context, state) => SettingsPage(location: state.uri.path),
+          children: (sub) {
+            for (final category in categories) {
+              sub.route('/$category',
+                  child: (context, state) => Scaffold(
+                          body: Column(children: [
+                        Text('detail:$category'),
+                        TextButton(
+                            onPressed: () =>
+                                context.pushNamed('/settings/$category/child'),
+                            child: Text('open:$category')),
+                        TextButton(
+                            onPressed: () {}, child: Text('action:$category')),
+                      ])));
+              sub.route('/$category/child',
+                  child: (context, state) => Scaffold(
+                      body: TextButton(
+                          onPressed: () => context.maybePop(),
+                          child: Text('child:$category'))));
+            }
+          });
+    });
+    await tester.pumpWidget(ModularApp(
+      module: module,
+      initialRoute: '/settings/player',
+      navigatorKey: rootNavigatorKey,
+      navigatorObservers: [topRouteObserver],
+      child: Builder(
+          builder: (context) => MaterialApp.router(
+                routerConfig: ModularApp.routerConfigOf(context),
+                builder: (context, child) =>
+                    GamepadNavigationScope(service: service, child: child!),
+              )),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> press(WidgetTester tester, GamepadButton button) async {
+    service.handleEvent(GamepadButtonEvent(
+        gamepadId: 1, timestamp: 0, button: button, pressed: true, value: 1));
+    service.handleEvent(GamepadButtonEvent(
+        gamepadId: 1, timestamp: 0, button: button, pressed: false, value: 0));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> close(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    service.reset();
+    unawaited(service.dispose());
+    await tester.pump();
+  }
+
+  testWidgets(
+      'all sidebar categories preview on focus and remain reachable after scrolling',
+      (tester) async {
+    await openSettings(tester);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/player');
+    for (final category in categories.skip(1)) {
+      await press(tester, GamepadButton.dpadDown);
+      expect(FocusManager.instance.primaryFocus?.debugLabel,
+          '/settings/$category');
+      expect(find.text('detail:$category'), findsOneWidget);
+      final rect = FocusManager.instance.primaryFocus!.rect;
+      expect(rect.top, greaterThanOrEqualTo(0));
+      expect(rect.bottom, lessThanOrEqualTo(620));
+    }
+    await press(tester, GamepadButton.dpadDown);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/about');
+    await press(tester, GamepadButton.dpadRight);
+    expect(FocusManager.instance.primaryFocus?.debugLabel,
+        isNot('/settings/about'));
+    await press(tester, GamepadButton.dpadLeft);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/about');
+    await press(tester, GamepadButton.a);
+    await press(tester, GamepadButton.b);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/about');
+    await close(tester);
+  });
+
+  testWidgets(
+      'held stick traverses replaced category routes and neutral stops immediately',
+      (tester) async {
+    await openSettings(tester);
+    void axis(double value) => service.handleEvent(GamepadAxisEvent(
+        gamepadId: 1,
+        timestamp: 0,
+        axis: GamepadAxis.leftStickY,
+        value: value));
+    axis(1);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    for (var i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    axis(0);
+    await tester.pumpAndSettle();
+    final stopped = FocusManager.instance.primaryFocus?.debugLabel;
+    expect(stopped, isNot('/settings/player'));
+    expect(stopped, isNot('/settings/danmaku'));
+    expect(stopped, startsWith('/settings/'));
+    await tester.pump(const Duration(seconds: 2));
+    expect(FocusManager.instance.primaryFocus?.debugLabel, stopped);
+    await close(tester);
+  });
+
+  testWidgets('B pops a nested detail before returning to the sidebar',
+      (tester) async {
+    await openSettings(tester);
+    await press(tester, GamepadButton.dpadRight);
+    await press(tester, GamepadButton.a);
+    expect(find.text('child:player'), findsOneWidget);
+    await press(tester, GamepadButton.b);
+    expect(find.text('child:player'), findsNothing);
+    expect(find.text('detail:player'), findsOneWidget);
+    await press(tester, GamepadButton.b);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/player');
+    await close(tester);
+  });
+
+  testWidgets('hidden sidebar cannot retain focus after narrowing the window',
+      (tester) async {
+    await openSettings(tester);
+    await press(tester, GamepadButton.dpadDown);
+    tester.view.physicalSize = const Size(500, 800);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel,
+        isNot('/settings/danmaku'));
+    expect(isGamepadFocusUsable(FocusManager.instance.primaryFocus!), isTrue);
+    tester.view.physicalSize = const Size(1100, 620);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel, '/settings/danmaku');
+    await close(tester);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -15,6 +15,7 @@
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <tray_manager/tray_manager_plugin.h>
+#include <universal_gamepad/gamepad_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <webview_windows/webview_windows_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -38,6 +39,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   TrayManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("TrayManagerPlugin"));
+  GamepadPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GamepadPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WebviewWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -12,6 +12,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   screen_retriever_windows
   tray_manager
+  universal_gamepad
   url_launcher_windows
   webview_windows
   window_manager


### PR DESCRIPTION
Settings keeps rail focus while previewing categories, enters detail with A/Right, returns with Left at the nav edge, and uses layered B handling without stacking category routes. Root and settings routes restore visible focus after navigation, dialogs, and pointer handoff.

Centralize held-input dedup and app-timed repeat, fixing lost repeat after dedup and stale timers after callback resets. Clear held state on blur, background, disconnect, service replacement, and touch takeover; keyboard release no longer depends on the original focus.

In the player the stick only moves focus between on-screen controls: it no longer seeks or changes the volume, and hidden controls are revealed on the first press. A only confirms the focused control instead of toggling fullscreen or playback, while B layers back from the episode side tab, to the controls, then out of the page. The panel, top bar, and side tab bridge focus across their scopes, and a focused text field no longer swallows directional input. Opening the episode sidebar moves focus straight into it, and while it owns focus it consumes player and shell commands and the stick cannot move the pending selection out of it; only B returns to the player. The bottom gamepad hint bar is removed along with its setting.

Focused buttons and the pending episode row get a solid outline so the selection is obvious. The exit dialog maps ActivateIntent onto its radio and checkbox tiles so A selects them. Hide the debug-mode banner, add the universal_gamepad dependency, and cover the behavior with widget, input, dialog, and seek regression tests.

<!--
提交 PR 前，请确认您已经阅读 [贡献指引](static/doc/CONTRIBUTING.md)。不符合的 PR 可能会被延迟处理或直接关闭。
请勿随意删除此模板的任何部分。

我已认真阅读。
-->

## 描述

<!-- 该PR为kazumi在linux上添加了类似于wiliwili的手柄输入和初步的触屏适配，以便为搭载了BazziteOS、steamos等os系统的win掌机或者steamdeck能够有较为一体和方便的看番体验 -->

## 关联的 Issues

<!-- 无 -->

## PR 类型

<!-- 这个 PR 属于什么类型的改动？ -->

- [ ] Bug 修复
- [ * ] 添加新功能
- [ ] 重构实现
- [ ] 文档或格式
- [ ] 其它

## AI 辅助开发

<!-- 这个 PR 的工作是否用到了 AI 辅助？ -->

- [ ] 没有使用 AI 辅助
- [ * ] AI 辅助开发了部分功能，但是我已检查并理解 AI 所写的代码
- [ ] 基本上都由 AI 实现，但是我非常了解 AI 的代码与写完的产物

AI 辅助模型: gpt-6-astra、grok-4.6

<!-- 请按照要求，填写完整的 AI 模型名称，如 “Claude Fable 5”，“Kimi-K3” -->

## 提交前检查

- [ * ] 我已经填写了 PR 模板中的所有内容
- [ * ] 我已经阅读了 [贡献指引](static/doc/CONTRIBUTING.md) ，并遵守指引进行开发
- [ * ] 这个 PR 的功能已经经过我的测试，并且我完全理解我（或 AI）做出的改动

## 附注

<!-- 希望该功能能被收录QWQ -->